### PR TITLE
Fix: replace deprecated icon with new version.

### DIFF
--- a/src/main/scala/io/snyk/plugin/ui/actions/SnykToggleGroupDisplayAction.scala
+++ b/src/main/scala/io/snyk/plugin/ui/actions/SnykToggleGroupDisplayAction.scala
@@ -6,7 +6,7 @@ import io.snyk.plugin.SnykPluginProjectComponent
 import io.snyk.plugin.ui.state.Flag
 
 class SnykToggleGroupDisplayAction()
-extends ToggleAction("Toggle display of Maven Groups", null, AllIcons.General.HideDownPart) {
+extends ToggleAction("Toggle display of Maven Groups", null, AllIcons.General.HideToolWindow) {
   override def update(e: AnActionEvent): Unit = {
     super.update(e)
     val p = e.getPresentation


### PR DESCRIPTION
Replaced AllIcons.General.HideDownPart with AllIcons.General.HideToolWindow because HideDownPart icon are going to be removed in the upcoming IntelliJ Platform 2020.1 release.