### PR TITLE
Feat: add red underline annotator for maven vulnerabilities

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -47,6 +47,8 @@
 
     <extensions defaultExtensionNs="com.intellij">
         <toolWindow id="Snyk" secondary="true" icon="/icons/plus.png" anchor="right" factoryClass="io.snyk.plugin.ui.SnykToolWindowFactory"/>
+
+        <annotator language="XML" implementationClass="io.snyk.plugin.ui.annotators.SnykMavenRedUnderlineAnnotator"/>
     </extensions>
 
     <application-components>

--- a/src/main/scala/io/snyk/plugin/ui/annotators/SnykMavenRedUnderlineAnnotator.scala
+++ b/src/main/scala/io/snyk/plugin/ui/annotators/SnykMavenRedUnderlineAnnotator.scala
@@ -1,0 +1,41 @@
+package io.snyk.plugin.ui.annotators
+
+import com.intellij.lang.annotation.{AnnotationHolder, Annotator}
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.psi.PsiElement
+import io.snyk.plugin.IntellijLogging.ScalaLogger
+import io.snyk.plugin.datamodel.SecurityVuln
+import io.snyk.plugin.ui.state.SnykPluginState
+
+/**
+  * Red underline annotator for Maven vulnerabilities.
+  */
+class SnykMavenRedUnderlineAnnotator extends Annotator {
+  protected lazy val log: ScalaLogger = new ScalaLogger(Logger.getInstance(this.getClass))
+
+  override def annotate(element: PsiElement, holder: AnnotationHolder): Unit = {
+    val pluginState = SnykPluginState.forIntelliJ(element.getProject)
+
+    val latestScanForSelectedProject = pluginState.latestScanForSelectedProject
+
+    if (latestScanForSelectedProject.isEmpty) {
+      return
+    }
+
+    latestScanForSelectedProject.get.vulnerabilities.seq.foreach(vulnerability => {
+      val securityVulnerability = vulnerability.asInstanceOf[SecurityVuln]
+
+      val vulnerabilityName = securityVulnerability.name
+      val vulnerabilityNameParts = vulnerabilityName.split(":")
+
+      vulnerabilityNameParts.foreach(name => {
+        if (element.getText == name) {
+          import com.intellij.openapi.util.TextRange
+
+          val range = new TextRange(element.getTextRange.getStartOffset, element.getTextRange.getEndOffset)
+          holder.createErrorAnnotation(range, "Vulnerability issue")
+        }
+      })
+    })
+  }
+}

--- a/src/main/scala/io/snyk/plugin/ui/annotators/SnykMavenRedUnderlineAnnotator.scala
+++ b/src/main/scala/io/snyk/plugin/ui/annotators/SnykMavenRedUnderlineAnnotator.scala
@@ -33,7 +33,7 @@ class SnykMavenRedUnderlineAnnotator extends Annotator {
           import com.intellij.openapi.util.TextRange
 
           val range = new TextRange(element.getTextRange.getStartOffset, element.getTextRange.getEndOffset)
-          holder.createErrorAnnotation(range, "Vulnerability issue")
+          holder.createErrorAnnotation(range, "Vulnerable package")
         }
       })
     })

--- a/src/test/resources/sample-response-for-annotator-test.json
+++ b/src/test/resources/sample-response-for-annotator-test.json
@@ -1,0 +1,78 @@
+{
+  "ok": false,
+  "vulnerabilities": [
+    {
+      "CVSSv3": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:H/A:N",
+      "alternativeIds": [],
+      "creationTime": "2019-11-19T11:44:30.225935Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 5.9,
+      "description": "## Overview\n\n[org.codehaus.jackson:jackson-mapper-asl](https://mvnrepository.com/artifact/org.codehaus.jackson/jackson-mapper-asl) is a high-performance data binding package built on Jackson JSON processor.\n\n\nAffected versions of this package are vulnerable to XML External Entity (XXE) Injection.\nMultiple classes including  `XmlMapper` was found to be vulnerabiltiy to XXE, which might allow attackers to have unspecified impact via unknown vectors.\n\n## Details\nXXE Injection is a type of attack against an application that parses XML input.\r\nXML is a markup language that defines a set of rules for encoding documents in a format that is both human-readable and machine-readable. By default, many XML processors allow specification of an external entity, a URI that is dereferenced and evaluated during XML processing. When an XML document is being parsed, the parser can make a request and include the content at the specified URI inside of the XML document.\r\n\r\nAttacks can include disclosing local files, which may contain sensitive data such as passwords or private user data, using file: schemes or relative paths in the system identifier.\r\n\r\nFor example, below is a sample XML document, containing an XML element- username.\r\n\r\n```xml\r\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\r\n   <username>John</username>\r\n</xml>\r\n```\r\n\r\nAn external XML entity - `xxe`, is defined using a system identifier and present within a DOCTYPE header. These entities can access local or remote content. For example the below code contains an external XML entity that would fetch the content of  `/etc/passwd` and display it to the user rendered by `username`.\r\n\r\n```xml\r\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\r\n<!DOCTYPE foo [\r\n   <!ENTITY xxe SYSTEM \"file:///etc/passwd\" >]>\r\n   <username>&xxe;</username>\r\n</xml>\r\n```\r\n\r\nOther XXE Injection attacks can access local resources that may not stop returning data, possibly impacting application availability and leading to Denial of Service.\n\n\n## Remediation\n\nThere is no fixed version for `org.codehaus.jackson:jackson-mapper-asl`.\n\n\n## References\n\n- [Bugzilla Ticket](https://bugzilla.redhat.com/show_bug.cgi?id=1715075)\n",
+      "disclosureTime": "2019-11-18T00:00:00Z",
+      "exploit": "Not Defined",
+      "fixedIn": [],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGCODEHAUSJACKSON-534878",
+      "identifiers": {
+        "CVE": [
+          "CVE-2019-10172"
+        ],
+        "CWE": [
+          "CWE-611"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "jackson-mapper-asl",
+        "groupId": "org.codehaus.jackson"
+      },
+      "modificationTime": "2019-12-02T14:45:32.742563Z",
+      "moduleName": "org.codehaus.jackson:jackson-mapper-asl",
+      "packageManager": "maven",
+      "packageName": "org.codehaus.jackson:jackson-mapper-asl",
+      "patches": [],
+      "publicationTime": "2019-11-19T11:56:32Z",
+      "references": [
+        {
+          "title": "Bugzilla Ticket",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1715075"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[0,]"
+        ]
+      },
+      "severity": "medium",
+      "title": "XML External Entity (XXE) Injection",
+      "from": [
+        "emailbroadcaster:emailbroadcaster@1.0-SNAPSHOT",
+        "org.codehaus.jackson:jackson-mapper-asl@1.8.5"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "isPinnable": false,
+      "name": "org.codehaus.jackson:jackson-mapper-asl",
+      "version": "1.8.5"
+    }
+  ],
+  "dependencyCount": 26,
+  "org": "aldanchenko",
+  "licensesPolicy": null,
+  "isPrivate": true,
+  "packageManager": "maven",
+  "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.14.0\nignore: {}\npatch: {}\n",
+  "ignoreSettings": null,
+  "summary": "1 vulnerable dependency path",
+  "alerts": [
+    {
+      "msg": "Snyk CLI supports Node.js v8.0.0 and higher. Support for Node.js v6.5.0+ is temporarily available, but will be discontinued after January 2020. Please upgrade your runtime version in order to get Snyk CLI updates.The latest CLI version that supports Node.js 4 is `snyk@1.88.2`.",
+      "name": "env-deprecation",
+      "type": "info"
+    }
+  ]
+}

--- a/src/test/scala/io/snyk/plugin/SnykMavenRedUnderlineAnnotatorTest.scala
+++ b/src/test/scala/io/snyk/plugin/SnykMavenRedUnderlineAnnotatorTest.scala
@@ -1,0 +1,42 @@
+package io.snyk.plugin
+
+import com.intellij.testFramework.fixtures.LightCodeInsightFixtureTestCase
+import io.snyk.plugin.datamodel.SnykMavenArtifact
+import io.snyk.plugin.ui.state.SnykPluginState
+
+import scala.io.{Codec, Source}
+import scala.util.Try
+
+class SnykMavenRedUnderlineAnnotatorTest extends LightCodeInsightFixtureTestCase() {
+
+  def testHighlighting(): Unit = {
+    SnykPluginState.mockForProject(myModule.getProject, mockResponder = myMockResponder)
+
+    myFixture.configureByText("pom.xml",
+      """<?xml version="1.0" encoding="UTF-8"?>
+                  <project xmlns="http://maven.apache.org/POM/4.0.0"
+                           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                           xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+
+                    <groupId>simpleMaven</groupId>
+                    <artifactId>simpleMaven</artifactId>
+                    <version>1.0</version>
+
+                    <dependencies>
+                      <dependency>
+                        <groupId><error>org.codehaus.jackson</error></groupId>
+                        <artifactId><error>jackson-mapper-asl</error></artifactId>
+                        <version>1.8.5</version>
+                      </dependency>
+                    </dependencies>
+                  </project>
+    """)
+
+    myFixture.checkHighlighting(true, false, true)
+  }
+
+  private[this] def myMockResponder(treeRoot: SnykMavenArtifact): Try[String] = Try {
+    Source.fromResource("sample-response-for-annotator-test.json", getClass.getClassLoader)(Codec.UTF8).mkString
+  }
+}


### PR DESCRIPTION
This will add a red underline for Maven vulnerabilities.

<img width="1400" alt="Screen Shot 2020-01-27 at 6 51 09 PM" src="https://user-images.githubusercontent.com/7049329/73202472-c9a6fd80-4143-11ea-93cf-de2b45486161.png">
