### PR TITLE
Fix: removed "Toggle display of Maven Groups" button.

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -61,7 +61,6 @@
         <group id="io.snyk.plugin.ActionBar">
             <action id="io.snyk.plugin.RescanAction" class="io.snyk.plugin.ui.actions.SnykRescanAction" text="Re-Scan project with Snyk" />
             <action id="io.snyk.plugin.ToggleGroupDisplayAction" class="io.snyk.plugin.ui.actions.SnykToggleGroupDisplayAction" text="Toggle display of Maven Groups" />
-            <action id="io.snyk.plugin.SelectProjectAction" class="io.snyk.plugin.ui.actions.SnykSelectProjectAction" text="Toggle display of Maven Groups" />
         </group>
         <!--group id="MyPlugin.SampleMenu" text="_Sample Menu" description="Sample menu">
             <add-to-group group-id="MainMenu" anchor="last"  />


### PR DESCRIPTION
Removed "Toggle display of Maven Groups" button.

<img width="1343" alt="Снимок экрана 2020-03-12 в 1 46 43 PM" src="https://user-images.githubusercontent.com/7049329/76544393-a5537600-6490-11ea-85d1-31ac9a811053.png">
