### PR TITLE
Fix: fix issue with Snyk CLI not found on Windows OS.

### DIFF
--- a/src/main/scala/io/snyk/plugin/client/CliClient.scala
+++ b/src/main/scala/io/snyk/plugin/client/CliClient.scala
@@ -21,6 +21,7 @@ import java.nio.file.{Files, Paths}
 import java.util.regex.Pattern
 
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.SystemInfo
 import io.snyk.plugin.depsource.ProjectType
 import monix.execution.atomic.Atomic
 
@@ -109,7 +110,7 @@ private final class StandardCliClient(tryConfig: => Try[SnykConfig], aConsoleCom
     prepareProjectBeforeCliCall(project, projectDependency)
 
     val commands: util.ArrayList[String] = new util.ArrayList[String]
-    commands.add("snyk")
+    commands.add(snykCliCommandName)
     commands.add("--json")
 
     projectDependency.projectType match {
@@ -158,7 +159,7 @@ private final class StandardCliClient(tryConfig: => Try[SnykConfig], aConsoleCom
   private def requestCliForError(projectPath: String): String = {
     val commands: util.ArrayList[String] = new util.ArrayList[String]
 
-    commands.add("snyk")
+    commands.add(snykCliCommandName)
     commands.add("--json")
     commands.add("test")
 
@@ -179,7 +180,7 @@ private final class StandardCliClient(tryConfig: => Try[SnykConfig], aConsoleCom
     log.debug("Check whether Snyk CLI is installed")
 
     val commands: util.ArrayList[String] = new util.ArrayList[String]
-    commands.add("snyk")
+    commands.add(snykCliCommandName)
     commands.add("--version")
 
     try {
@@ -237,6 +238,7 @@ private final class StandardCliClient(tryConfig: => Try[SnykConfig], aConsoleCom
     json <- decode[SnykUserResponse](jsonStr).toTry
   } yield json.user
 
+  private def snykCliCommandName: String = if (SystemInfo.isWindows) "snyk.cmd" else "snyk"
 }
 
 private final class MockCliClient(

--- a/src/test/scala/io/snyk/plugin/SnykGradleMultiModuleTest.scala
+++ b/src/test/scala/io/snyk/plugin/SnykGradleMultiModuleTest.scala
@@ -77,20 +77,32 @@ class SnykGradleMultiModuleTest extends AbstractGradleTestCase() {
     assertEquals("SNYK-JAVA-COMGOOGLEGUAVA-32236",
       snykVulnResponseSeq(1).vulnerabilities.get(0).asInstanceOf[SecurityVuln].id)
 
-    assertEquals("SNYK-JAVA-ORGCODEHAUSJACKSON-534878",
+    assertEquals("SNYK-JAVA-ORGAPACHELOGGINGLOG4J-567761",
       snykVulnResponseSeq(1).vulnerabilities.get(1).asInstanceOf[SecurityVuln].id)
+
+    assertEquals("SNYK-JAVA-ORGAPACHELOGGINGLOG4J-567761",
+      snykVulnResponseSeq(1).vulnerabilities.get(2).asInstanceOf[SecurityVuln].id)
+
+    assertEquals("SNYK-JAVA-ORGCODEHAUSJACKSON-534878",
+      snykVulnResponseSeq(1).vulnerabilities.get(3).asInstanceOf[SecurityVuln].id)
 
     assertEquals("SNYK-JAVA-COMGOOGLEGUAVA-32236",
       snykVulnResponseSeq(2).vulnerabilities.get(0).asInstanceOf[SecurityVuln].id)
 
-    assertEquals("SNYK-JAVA-ORGJOLOKIA-32136",
+    assertEquals("SNYK-JAVA-ORGAPACHELOGGINGLOG4J-567761",
       snykVulnResponseSeq(2).vulnerabilities.get(1).asInstanceOf[SecurityVuln].id)
 
-    assertEquals("SNYK-JAVA-ORGJOLOKIA-32137",
+    assertEquals("SNYK-JAVA-ORGAPACHELOGGINGLOG4J-567761",
       snykVulnResponseSeq(2).vulnerabilities.get(2).asInstanceOf[SecurityVuln].id)
 
-    assertEquals("SNYK-JAVA-ORGJOLOKIA-540501",
+    assertEquals("SNYK-JAVA-ORGJOLOKIA-32136",
       snykVulnResponseSeq(2).vulnerabilities.get(3).asInstanceOf[SecurityVuln].id)
+
+    assertEquals("SNYK-JAVA-ORGJOLOKIA-32137",
+      snykVulnResponseSeq(2).vulnerabilities.get(4).asInstanceOf[SecurityVuln].id)
+
+    assertEquals("SNYK-JAVA-ORGJOLOKIA-540501",
+      snykVulnResponseSeq(2).vulnerabilities.get(5).asInstanceOf[SecurityVuln].id)
   }
 
   @Test
@@ -114,22 +126,34 @@ class SnykGradleMultiModuleTest extends AbstractGradleTestCase() {
     assertEquals(3, snykVulnResponseSeq.size)
 
     assertEquals("SNYK-JAVA-COMGOOGLEGUAVA-32236",
-      snykVulnResponseSeq(1).vulnerabilities.get(0).asInstanceOf[SecurityVuln].id)
+                 snykVulnResponseSeq(1).vulnerabilities.get(0).asInstanceOf[SecurityVuln].id)
+
+    assertEquals("SNYK-JAVA-ORGAPACHELOGGINGLOG4J-567761",
+                 snykVulnResponseSeq(1).vulnerabilities.get(1).asInstanceOf[SecurityVuln].id)
+
+    assertEquals("SNYK-JAVA-ORGAPACHELOGGINGLOG4J-567761",
+                 snykVulnResponseSeq(1).vulnerabilities.get(2).asInstanceOf[SecurityVuln].id)
 
     assertEquals("SNYK-JAVA-ORGCODEHAUSJACKSON-534878",
-      snykVulnResponseSeq(1).vulnerabilities.get(1).asInstanceOf[SecurityVuln].id)
+                 snykVulnResponseSeq(1).vulnerabilities.get(3).asInstanceOf[SecurityVuln].id)
 
     assertEquals("SNYK-JAVA-COMGOOGLEGUAVA-32236",
-      snykVulnResponseSeq(2).vulnerabilities.get(0).asInstanceOf[SecurityVuln].id)
+                 snykVulnResponseSeq(2).vulnerabilities.get(0).asInstanceOf[SecurityVuln].id)
+
+    assertEquals("SNYK-JAVA-ORGAPACHELOGGINGLOG4J-567761",
+                 snykVulnResponseSeq(2).vulnerabilities.get(1).asInstanceOf[SecurityVuln].id)
+
+    assertEquals("SNYK-JAVA-ORGAPACHELOGGINGLOG4J-567761",
+                 snykVulnResponseSeq(2).vulnerabilities.get(2).asInstanceOf[SecurityVuln].id)
 
     assertEquals("SNYK-JAVA-ORGJOLOKIA-32136",
-      snykVulnResponseSeq(2).vulnerabilities.get(1).asInstanceOf[SecurityVuln].id)
+                 snykVulnResponseSeq(2).vulnerabilities.get(3).asInstanceOf[SecurityVuln].id)
 
     assertEquals("SNYK-JAVA-ORGJOLOKIA-32137",
-      snykVulnResponseSeq(2).vulnerabilities.get(2).asInstanceOf[SecurityVuln].id)
+                 snykVulnResponseSeq(2).vulnerabilities.get(4).asInstanceOf[SecurityVuln].id)
 
     assertEquals("SNYK-JAVA-ORGJOLOKIA-540501",
-      snykVulnResponseSeq(2).vulnerabilities.get(3).asInstanceOf[SecurityVuln].id)
+                 snykVulnResponseSeq(2).vulnerabilities.get(5).asInstanceOf[SecurityVuln].id)
   }
 
   private def createModule(moduleName: String, buildGradleStr: String): Unit = {


### PR DESCRIPTION
Fix issue with Snyk CLI not found on Windows OS. Now the plugin checks the type of operating system and returns the corresponding command name. If it's Windows OS it will return "snyk.cmd". If it's Unix/Linux Os it will return "snyk".