### PR TITLE
feat: add until-build attribute to plugin.xml

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -58,7 +58,7 @@
     ]]></change-notes>
 
     <!--see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html-->
-    <idea-version since-build="191"/>
+    <idea-version since-build="191" until-build="202"/>
 
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html
          on how to target different products -->


### PR DESCRIPTION
We add `until-build` attribute to set maximum build of IDE compatible with our plugin.
Build number ranges: https://jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html