### PR TITLE
Fix: Gradle CLI parameters

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 ideaVersion=2019.1
 
-patchVersion=6
+patchVersion=7
 buildNumber=SNAPSHOT
 
 publishChannel=develop

--- a/src/main/scala/io/snyk/plugin/client/CliClient.scala
+++ b/src/main/scala/io/snyk/plugin/client/CliClient.scala
@@ -364,7 +364,6 @@ private final class StandardCliClient(
       }
     }
 
-
     commands.add("test")
 
     log.info(s"Snyk commands: $commands")

--- a/src/main/scala/io/snyk/plugin/client/CliClient.scala
+++ b/src/main/scala/io/snyk/plugin/client/CliClient.scala
@@ -366,7 +366,7 @@ private final class StandardCliClient(
 
     commands.add("test")
 
-    log.info(s"Snyk commands: $commands")
+    log.info(s"Cli parameters: $commands")
 
     commands
   }

--- a/src/test/scala/io/snyk/plugin/SnykCliClientTest.scala
+++ b/src/test/scala/io/snyk/plugin/SnykCliClientTest.scala
@@ -333,8 +333,7 @@ class SnykCliClientTest extends AbstractMavenTestCase() {
     assertEquals("snyk", defaultCommands.get(0))
     assertEquals("--json", defaultCommands.get(1))
     assertEquals("--file=build.gradle", defaultCommands.get(2))
-    assertEquals("--all-sub-projects", defaultCommands.get(3))
-    assertEquals("test", defaultCommands.get(4))
+    assertEquals("test", defaultCommands.get(3))
   }
 
   @Test
@@ -392,8 +391,7 @@ class SnykCliClientTest extends AbstractMavenTestCase() {
     assertEquals("--insecure", defaultCommands.get(3))
     assertEquals("--org=test-org", defaultCommands.get(4))
     assertEquals("--file=build.gradle", defaultCommands.get(5))
-    assertEquals("--all-sub-projects", defaultCommands.get(6))
-    assertEquals("test", defaultCommands.get(7))
+    assertEquals("test", defaultCommands.get(6))
   }
 
   @Test


### PR DESCRIPTION
Fixed CLI parameters in the case of the Gradle package manager. 
If --file parameter exists it will not use --all-sub-projects parameter, otherwise it will use --all-sub-projects. 