### PR TITLE
chore: patch plugin.xml with latest changelog item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Snyk Vulnerability Scanner Changelog
 
-## [Unreleased]
+## [2.0.1]
+### Added
+- Propagate integration name for JetBrain IDEs
 
 ## [2.0.0]
 ### Added

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,9 +63,16 @@ tasks {
         subList(indexOf(start) + 1, indexOf(end))
       }.joinToString("\n").run { markdownToHTML(this) }
     })
+
+    changeNotes(
+      closure {
+        changelog.getLatest().toHTML()
+      }
+    )
   }
 
   publishPlugin {
+    dependsOn("patchChangelog")
     token(System.getenv("PUBLISH_TOKEN"))
     channels(pluginVersion.split('-').getOrElse(1) { "default" }.split('.').first())
   }


### PR DESCRIPTION
This PR adds latest changelog item in `plugin.xml` during `patchChangeLog` task.

Example screenshot:
<img width="543" alt="Screen Shot 2020-09-14 at 12 01 32" src="https://user-images.githubusercontent.com/60606414/93072865-50342f00-f682-11ea-8434-00c89ab0f692.png">
