### PR TITLE
fix: remove patch changelog task dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Snyk Vulnerability Scanner Changelog
 
+## [2.0.2]
+### Fixed
+- Hide API token in configuration settings
+
 ## [2.0.1]
 ### Added
 - Propagate integration name for JetBrain IDEs

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,7 +72,6 @@ tasks {
   }
 
   publishPlugin {
-    dependsOn("patchChangelog")
     token(System.getenv("PUBLISH_TOKEN"))
     channels(pluginVersion.split('-').getOrElse(1) { "default" }.split('.').first())
   }


### PR DESCRIPTION
This PR removes patchChanglog gradle task during publishing phase.