### PR TITLE
feat: Naively split the additionalParameters value so the CommandLineRunner sends them correctly as separate arguments

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 pluginVersion=2.0.3
-pluginSinceBuild=202
+pluginSinceBuild=201
 pluginUntilBuild=202.*
 #
 platformVersion=2020.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 pluginVersion=2.0.3
-pluginSinceBuild=201
+pluginSinceBuild=202
 pluginUntilBuild=202.*
 #
 platformVersion=2020.2

--- a/src/main/kotlin/io/snyk/plugin/services/SnykCliService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykCliService.kt
@@ -112,11 +112,8 @@ class SnykCliService(val project: Project) {
 
         val additionalParameters = settings.getAdditionalParameters(project)
 
-        if (additionalParameters != null && additionalParameters.isNotEmpty()) {
-
-            val additionalParamsArray = splitParameters(additionalParameters)
-            commands.addAll(additionalParamsArray)
-
+        if (additionalParameters != null && additionalParameters.trim().isNotEmpty()) {
+            commands.addAll(additionalParameters.trim().split(" "))
         }
 
         commands.add("test")
@@ -148,10 +145,4 @@ class SnykCliService(val project: Project) {
     }
 
     fun isPackageJsonExists(): Boolean = File(project.basePath!!, "package.json").exists()
-
-    fun splitParameters(params: String) : List<String> {
-
-        return params.split(" ")
-
-    }
 }

--- a/src/main/kotlin/io/snyk/plugin/services/SnykCliService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykCliService.kt
@@ -113,7 +113,10 @@ class SnykCliService(val project: Project) {
         val additionalParameters = settings.getAdditionalParameters(project)
 
         if (additionalParameters != null && additionalParameters.isNotEmpty()) {
-            commands.add(additionalParameters)
+
+            val additionalParamsArray = splitParameters(additionalParameters)
+            commands.addAll(additionalParamsArray)
+
         }
 
         commands.add("test")
@@ -145,4 +148,10 @@ class SnykCliService(val project: Project) {
     }
 
     fun isPackageJsonExists(): Boolean = File(project.basePath!!, "package.json").exists()
+
+    fun splitParameters(params: String) : List<String> {
+
+        return params.split(" ")
+
+    }
 }

--- a/src/test/kotlin/io/snyk/plugin/services/SnykCliServiceTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/services/SnykCliServiceTest.kt
@@ -281,6 +281,33 @@ class SnykCliServiceTest : LightPlatformTestCase() {
     }
 
     @Test
+    fun testBuildCliCommandsListWithMultiAdditionalParameters() {
+        setupDummyCliFile()
+
+        val settingsStateService = getApplicationSettingsStateService()
+
+        settingsStateService.token = "0000-1111-2222-3333"
+        settingsStateService.customEndpointUrl = "https://app.snyk.io/api"
+        settingsStateService.organization = "test-org"
+        settingsStateService.ignoreUnknownCA = true
+
+        project.service<SnykProjectSettingsStateService>().additionalParameters =
+            "--file=package.json --configuration-matching='iamaRegex' --sub-project=snyk"
+
+        val defaultCommands = getCli(project).buildCliCommandsList(settingsStateService)
+
+        assertEquals(getCliFile().absolutePath, defaultCommands[0])
+        assertEquals("--json", defaultCommands[1])
+        assertEquals("--api=https://app.snyk.io/api", defaultCommands[2])
+        assertEquals("--insecure", defaultCommands[3])
+        assertEquals("--org=test-org", defaultCommands[4])
+        assertEquals("--file=package.json", defaultCommands[5])
+        assertEquals("--configuration-matching='iamaRegex'", defaultCommands[6])
+        assertEquals("--sub-project=snyk", defaultCommands[7])
+        assertEquals("test", defaultCommands[8])
+    }
+
+    @Test
     fun testCheckIsCliInstalledAutomaticallyByPluginSuccessful() {
         val cliFile = getCliFile()
 


### PR DESCRIPTION
Had a bunch of issues with Snyk plugin for Android Studio since our setup requires the usage of several flags (--configuration-matches, --severity-threshold and --sub-project)

Discussed this with Trevor McCord over several emails since we're evaluating getting on board with Snyk. Discovered that SnykCLIService bundles them up in a single argument and apparently only the first arg is correctly parsed and the rest gets ignored or throws an error.

Android-studio log
`2020-11-12 10:27:02,635 [60825005]   INFO - plugin.services.SnykCliService - Cli parameters: [/Users/vmacias/Library/Application Support/Google/AndroidStudio4.1/plugins/snyk-intellij-plugin/snyk-macos, --json, --org=billpocket, --severity-threshold=low --sub-project=billpocket --configuration-matching=".*BillpocketProdSyncImages.*$", test]`

This PR naively splits the additionalParameters string at every whitespace. Didn't want to introduce dependencies for arg parsing.