### PR TITLE
chore: allow to install the plugin on IntelliJ 2020.3.*

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginVersion=2.0.3
 pluginSinceBuild=202
-pluginUntilBuild=202.*
+pluginUntilBuild=203.*
 #
 platformVersion=2020.2
 #


### PR DESCRIPTION
IntelliJ 2020.3 is out: https://blog.jetbrains.com/idea/2020/12/intellij-idea-2020-3/
This PR bumps `pluginUntilBuild` property to 203.*, so users can install it on new versions.