### PR TITLE
fix: move 'test' parameter as first argument

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,6 @@ jobs:
     name: Test
     needs: gradleValidation
     runs-on: ubuntu-latest
-    container: gradle:jdk8
     steps:
       - name: Fetch Sources
         uses: actions/checkout@v2
@@ -39,4 +38,4 @@ jobs:
         run: ./gradlew verifyPlugin
 
       - name: Run Tests
-        run: ./gradlew test
+        run: ./gradlew clean test

--- a/src/main/kotlin/io/snyk/plugin/services/SnykCliService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykCliService.kt
@@ -92,6 +92,7 @@ class SnykCliService(val project: Project) {
 
         val commands: MutableList<String> = mutableListOf()
         commands.add(getCliCommandPath())
+        commands.add("test")
         commands.add("--json")
 
         val customEndpoint = settings.customEndpointUrl
@@ -115,8 +116,6 @@ class SnykCliService(val project: Project) {
         if (additionalParameters != null && additionalParameters.trim().isNotEmpty()) {
             commands.addAll(additionalParameters.trim().split(" "))
         }
-
-        commands.add("test")
 
         logger.info("Cli parameters: $commands")
 

--- a/src/test/kotlin/io/snyk/plugin/services/SnykCliServiceTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/services/SnykCliServiceTest.kt
@@ -67,7 +67,7 @@ class SnykCliServiceTest : LightPlatformTestCase() {
         val mockRunner = Mockito.mock(ConsoleCommandRunner::class.java)
 
         Mockito
-            .`when`(mockRunner.execute(listOf(getCliFile().absolutePath, "--json", "test"), project.basePath!!))
+            .`when`(mockRunner.execute(listOf(getCliFile().absolutePath, "test", "--json"), project.basePath!!))
             .thenReturn("""
                     {
                       "ok": false,
@@ -94,7 +94,7 @@ class SnykCliServiceTest : LightPlatformTestCase() {
         val mockRunner = Mockito.mock(ConsoleCommandRunner::class.java)
 
         Mockito
-            .`when`(mockRunner.execute(listOf(getCliFile().absolutePath, "--json", "test"), project.basePath!!))
+            .`when`(mockRunner.execute(listOf(getCliFile().absolutePath, "test", "--json"), project.basePath!!))
             .thenReturn(getResourceAsString("group-vulnerabilities-test.json"))
 
         getCli(project).setConsoleCommandRunner(mockRunner)
@@ -119,7 +119,7 @@ class SnykCliServiceTest : LightPlatformTestCase() {
         val mockRunner = Mockito.mock(ConsoleCommandRunner::class.java)
 
         Mockito
-            .`when`(mockRunner.execute(listOf(getCliFile().absolutePath, "--json", "test"), project.basePath!!))
+            .`when`(mockRunner.execute(listOf(getCliFile().absolutePath, "test", "--json"), project.basePath!!))
             .thenReturn(getResourceAsString("licence-vulnerabilities.json"))
 
         getCli(project).setConsoleCommandRunner(mockRunner)
@@ -191,8 +191,8 @@ class SnykCliServiceTest : LightPlatformTestCase() {
         val defaultCommands =  getCli(project).buildCliCommandsList(getApplicationSettingsStateService())
 
         assertEquals(getCliFile().absolutePath, defaultCommands[0])
-        assertEquals("--json", defaultCommands[1])
-        assertEquals("test", defaultCommands[2])
+        assertEquals("test", defaultCommands[1])
+        assertEquals("--json", defaultCommands[2])
     }
 
     @Test
@@ -206,9 +206,9 @@ class SnykCliServiceTest : LightPlatformTestCase() {
         val defaultCommands = getCli(project).buildCliCommandsList(settingsStateService)
 
         assertEquals(getCliFile().absolutePath, defaultCommands[0])
-        assertEquals("--json", defaultCommands[1])
-        assertEquals("--api=https://app.snyk.io/api", defaultCommands[2])
-        assertEquals("test", defaultCommands[3])
+        assertEquals("test", defaultCommands[1])
+        assertEquals("--json", defaultCommands[2])
+        assertEquals("--api=https://app.snyk.io/api", defaultCommands[3])
     }
 
     @Test
@@ -222,9 +222,9 @@ class SnykCliServiceTest : LightPlatformTestCase() {
         val defaultCommands = getCli(project).buildCliCommandsList(settings)
 
         assertEquals(getCliFile().absolutePath, defaultCommands[0])
-        assertEquals("--json", defaultCommands[1])
-        assertEquals("--insecure", defaultCommands[2])
-        assertEquals("test", defaultCommands[3])
+        assertEquals("test", defaultCommands[1])
+        assertEquals("--json", defaultCommands[2])
+        assertEquals("--insecure", defaultCommands[3])
     }
 
     @Test
@@ -237,9 +237,9 @@ class SnykCliServiceTest : LightPlatformTestCase() {
         val defaultCommands = getCli(project).buildCliCommandsList(settingsStateService)
 
         assertEquals(getCliFile().absolutePath, defaultCommands[0])
-        assertEquals("--json", defaultCommands[1])
-        assertEquals("--org=test-org", defaultCommands[2])
-        assertEquals("test", defaultCommands[3])
+        assertEquals("test", defaultCommands[1])
+        assertEquals("--json", defaultCommands[2])
+        assertEquals("--org=test-org", defaultCommands[3])
     }
 
     @Test
@@ -251,9 +251,9 @@ class SnykCliServiceTest : LightPlatformTestCase() {
         val defaultCommands = getCli(project).buildCliCommandsList(getApplicationSettingsStateService())
 
         assertEquals(getCliFile().absolutePath, defaultCommands[0])
-        assertEquals("--json", defaultCommands[1])
-        assertEquals("--file=package.json", defaultCommands[2])
-        assertEquals("test", defaultCommands[3])
+        assertEquals("test", defaultCommands[1])
+        assertEquals("--json", defaultCommands[2])
+        assertEquals("--file=package.json", defaultCommands[3])
     }
 
     @Test
@@ -272,12 +272,12 @@ class SnykCliServiceTest : LightPlatformTestCase() {
         val defaultCommands = getCli(project).buildCliCommandsList(settingsStateService)
 
         assertEquals(getCliFile().absolutePath, defaultCommands[0])
-        assertEquals("--json", defaultCommands[1])
-        assertEquals("--api=https://app.snyk.io/api", defaultCommands[2])
-        assertEquals("--insecure", defaultCommands[3])
-        assertEquals("--org=test-org", defaultCommands[4])
-        assertEquals("--file=package.json", defaultCommands[5])
-        assertEquals("test", defaultCommands[6])
+        assertEquals("test", defaultCommands[1])
+        assertEquals("--json", defaultCommands[2])
+        assertEquals("--api=https://app.snyk.io/api", defaultCommands[3])
+        assertEquals("--insecure", defaultCommands[4])
+        assertEquals("--org=test-org", defaultCommands[5])
+        assertEquals("--file=package.json", defaultCommands[6])
     }
 
     @Test

--- a/src/test/kotlin/io/snyk/plugin/services/SnykCliServiceTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/services/SnykCliServiceTest.kt
@@ -7,6 +7,7 @@ import io.snyk.plugin.getApplicationSettingsStateService
 import io.snyk.plugin.getCli
 import io.snyk.plugin.getCliFile
 import io.snyk.plugin.setupDummyCliFile
+import junit.framework.TestCase
 import org.junit.Test
 import org.mockito.Mockito
 import java.io.File
@@ -297,14 +298,14 @@ class SnykCliServiceTest : LightPlatformTestCase() {
         val defaultCommands = getCli(project).buildCliCommandsList(settingsStateService)
 
         assertEquals(getCliFile().absolutePath, defaultCommands[0])
-        assertEquals("--json", defaultCommands[1])
-        assertEquals("--api=https://app.snyk.io/api", defaultCommands[2])
-        assertEquals("--insecure", defaultCommands[3])
-        assertEquals("--org=test-org", defaultCommands[4])
-        assertEquals("--file=package.json", defaultCommands[5])
-        assertEquals("--configuration-matching='iamaRegex'", defaultCommands[6])
-        assertEquals("--sub-project=snyk", defaultCommands[7])
-        assertEquals("test", defaultCommands[8])
+        assertEquals("test", defaultCommands[1])
+        assertEquals("--json", defaultCommands[2])
+        assertEquals("--api=https://app.snyk.io/api", defaultCommands[3])
+        assertEquals("--insecure", defaultCommands[4])
+        assertEquals("--org=test-org", defaultCommands[5])
+        assertEquals("--file=package.json", defaultCommands[6])
+        assertEquals("--configuration-matching='iamaRegex'", defaultCommands[7])
+        assertEquals("--sub-project=snyk", defaultCommands[8])
     }
 
     @Test

--- a/src/test/kotlin/io/snyk/plugin/services/SnykTaskQueueServiceTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/services/SnykTaskQueueServiceTest.kt
@@ -18,7 +18,7 @@ class SnykTaskQueueServiceTest : LightPlatformTestCase() {
         val mockRunner = Mockito.mock(ConsoleCommandRunner::class.java)
 
         Mockito
-            .`when`(mockRunner.execute(listOf(getCliFile().absolutePath, "--json", "test"), project.basePath!!))
+            .`when`(mockRunner.execute(listOf(getCliFile().absolutePath, "test", "--json"), project.basePath!!))
             .thenReturn(javaClass.classLoader.getResource("group-vulnerabilities-test.json")!!.readText(Charsets.UTF_8))
 
         getCli(project).setConsoleCommandRunner(mockRunner)


### PR DESCRIPTION
This PR fixes the issue when scanning directory is specified via additional parameters.