### PR TITLE
docs: replace supported package managers list with a link in readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Snyk Vulnerability Scanner Changelog
 
+## [2.0.3]
+### Added
+- Allow specifying CLI working directory for project submodules
+- Improve integration names between different JetBrains IDEs
+### Changed
+- Change since/until build to `202-203.*`
+### Fixed
+- Split CLI additional arguments correctly
+
 ## [2.0.2]
 ### Added
 - Add icons for supported package managers

--- a/README.md
+++ b/README.md
@@ -22,13 +22,9 @@ you fix issues as fast as possible.
 - Remediation advice
 - License compliance
 
-## Supported package managers
+## Useful links
 
-- NPM, Yarn, Yarn Workspaces
-- Maven, Gradle
-- NuGet, Paket
-- Pip, PyPI, Pipenv
-- Cocoapods
-- Composer
+- This plugin works with projects written in Java, JavaScript, .NET and many more languages. See the [full list of languages and package managers Snyk supports](https://snyk.co/ucWSd)
+- [Bug tracker](https://github.com/snyk/snyk-intellij-plugin/issues)
 
 <!-- Plugin description end -->


### PR DESCRIPTION
This PR updates readme with links to all CLI supported managers.