### PR TITLE
fix: handle custom endpoint option correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Snyk Vulnerability Scanner Changelog
 
+## [2.0.4]
+### Fixed
+- Fix handling custom endpoint option
+
 ## [2.0.3]
 ### Added
 - Allow specifying CLI working directory for project submodules

--- a/src/main/kotlin/io/snyk/plugin/services/SnykCliService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykCliService.kt
@@ -98,7 +98,7 @@ class SnykCliService(val project: Project) {
         val customEndpoint = settings.customEndpointUrl
 
         if (customEndpoint != null && customEndpoint.isNotEmpty()) {
-            commands.add("--api=$customEndpoint")
+            commands.add("--API=$customEndpoint")
         }
 
         if (settings.ignoreUnknownCA) {

--- a/src/test/kotlin/io/snyk/plugin/services/SnykCliServiceTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/services/SnykCliServiceTest.kt
@@ -209,7 +209,7 @@ class SnykCliServiceTest : LightPlatformTestCase() {
         assertEquals(getCliFile().absolutePath, defaultCommands[0])
         assertEquals("test", defaultCommands[1])
         assertEquals("--json", defaultCommands[2])
-        assertEquals("--api=https://app.snyk.io/api", defaultCommands[3])
+        assertEquals("--API=https://app.snyk.io/api", defaultCommands[3])
     }
 
     @Test
@@ -275,7 +275,7 @@ class SnykCliServiceTest : LightPlatformTestCase() {
         assertEquals(getCliFile().absolutePath, defaultCommands[0])
         assertEquals("test", defaultCommands[1])
         assertEquals("--json", defaultCommands[2])
-        assertEquals("--api=https://app.snyk.io/api", defaultCommands[3])
+        assertEquals("--API=https://app.snyk.io/api", defaultCommands[3])
         assertEquals("--insecure", defaultCommands[4])
         assertEquals("--org=test-org", defaultCommands[5])
         assertEquals("--file=package.json", defaultCommands[6])
@@ -300,7 +300,7 @@ class SnykCliServiceTest : LightPlatformTestCase() {
         assertEquals(getCliFile().absolutePath, defaultCommands[0])
         assertEquals("test", defaultCommands[1])
         assertEquals("--json", defaultCommands[2])
-        assertEquals("--api=https://app.snyk.io/api", defaultCommands[3])
+        assertEquals("--API=https://app.snyk.io/api", defaultCommands[3])
         assertEquals("--insecure", defaultCommands[4])
         assertEquals("--org=test-org", defaultCommands[5])
         assertEquals("--file=package.json", defaultCommands[6])


### PR DESCRIPTION
This PR fixes handling custom endpoint (`--api`) option. The behavior was changed in CLI (https://github.com/snyk/snyk/blob/master/src/lib/config.ts#L10), it should be capitalized or use envvar.