### PR TITLE
chore: bump plugin version to 2.1.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion=2.1.0
+pluginVersion=2.1.1
 pluginSinceBuild=202
 pluginUntilBuild=203.*
 #


### PR DESCRIPTION
This PR bump `pluginVersion` to 2.1.1 (next release tag).