### PR TITLE
chore: update until version to 211

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Snyk Vulnerability Scanner Changelog
 
+## [2.1.2]
+### Changed
+- Make plugin compatible with 2021.1 version
+
 ## [2.1.1]
 ### Changed
 - Update plugin description marketplace page

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginVersion=2.1.2
 pluginSinceBuild=202
-pluginUntilBuild=203.*
+pluginUntilBuild=211.*
 #
 platformVersion=2020.2
 #


### PR DESCRIPTION
This PR updates untilVersion to 211 to make plugin compatible with 2021.1.