### PR TITLE
fix: .dcignore and .gitignore parsing and usage (ROADRUNNER-55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [2.1.3]
 ### Changed
+- Fix and improve .dcignore and .gitignore parsing and usage
 - Bugfix for `missing file parameter` exception
 
 ## [2.1.2]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
   implementation("com.atlassian.commonmark:commonmark:0.15.2")
   implementation("com.google.code.gson:gson:2.8.6")
   implementation("com.segment.analytics.java:analytics:+")
-  implementation("io.snyk.code.sdk:snyk-code-client:2.1.8")
+  implementation("io.snyk.code.sdk:snyk-code-client:2.1.9")
 
   testImplementation("junit:junit:4.13") {
     exclude(group = "org.hamcrest")

--- a/src/main/kotlin/io/snyk/plugin/SnykBulkFileListener.kt
+++ b/src/main/kotlin/io/snyk/plugin/SnykBulkFileListener.kt
@@ -91,14 +91,7 @@ class SnykBulkFileListener() : BulkFileListener {
                 }
 
             // clean .dcignore caches if needed
-            val ignoreFilesChanged = virtualFilesAffected
-                .filter { it.name == ".dcignore" || it.name == ".gitignore" }
-                .distinct()
-            for (virtualFile in ignoreFilesChanged) {
-                val ignoreFile = PsiManager.getInstance(project).findFile(virtualFile) ?: continue
-                SnykCodeIgnoreInfoHolder.instance.remove_ignoreFileContent(ignoreFile)
-                AnalysisData.instance.removeProjectFromCaches(project)
-            }
+            SnykCodeIgnoreInfoHolder.instance.cleanIgnoreFileCachesIfAffected(project, virtualFilesAffected)
         }
     }
 
@@ -113,17 +106,7 @@ class SnykBulkFileListener() : BulkFileListener {
             )
 
             // update .dcignore caches if needed
-            val ignoreFilesChanged = virtualFilesAffected
-                .filter { it.name == ".dcignore" || it.name == ".gitignore" }
-                .distinct()
-            for (virtualFile in ignoreFilesChanged) {
-                val ignoreFile = PsiManager.getInstance(project).findFile(virtualFile) ?: continue
-                project.service<SnykTaskQueueService>().scheduleRunnable(
-                    "updating caches for: ${PDU.instance.getFilePath(ignoreFile)}"
-                ) { progress ->
-                    SnykCodeIgnoreInfoHolder.instance.update_ignoreFileContent(ignoreFile, progress)
-                }
-            }
+            SnykCodeIgnoreInfoHolder.instance.updateIgnoreFileCachesIfAffected(project, virtualFilesAffected)
         }
     }
 

--- a/src/main/kotlin/io/snyk/plugin/SnykPostStartupActivity.kt
+++ b/src/main/kotlin/io/snyk/plugin/SnykPostStartupActivity.kt
@@ -28,22 +28,11 @@ class SnykPostStartupActivity : StartupActivity.DumbAware {
             listenersActivated = true
         }
 
-        createDcIgnoreIfNeeded(project)
+        SnykCodeIgnoreInfoHolder.instance.createDcIgnoreIfNeeded(project)
 
         if (!ApplicationManager.getApplication().isUnitTestMode) {
             project.service<SnykTaskQueueService>().downloadLatestRelease()
         }
     }
 
-    private fun createDcIgnoreIfNeeded(project: Project) {
-        val prjBasePath = project.basePath
-        val gitignore = File("$prjBasePath/.gitignore")
-        val dcignore = File("$prjBasePath/.dcignore")
-        if (!gitignore.exists() && dcignore.createNewFile()) {
-            val fullDcIgnoreText = this.javaClass.classLoader.getResource("full.dcignore")?.readText()
-                ?: throw RuntimeException("full.dcignore can not be found in plugin's resources")
-            dcignore.writeText(fullDcIgnoreText)
-            SnykBalloonNotifications.showInfo("We added generic .dcignore file to upload only project's source code.", project)
-        }
-    }
 }

--- a/src/main/kotlin/io/snyk/plugin/SnykPostStartupActivity.kt
+++ b/src/main/kotlin/io/snyk/plugin/SnykPostStartupActivity.kt
@@ -40,9 +40,9 @@ class SnykPostStartupActivity : StartupActivity.DumbAware {
         val gitignore = File("$prjBasePath/.gitignore")
         val dcignore = File("$prjBasePath/.dcignore")
         if (!gitignore.exists() && dcignore.createNewFile()) {
-            val fullDcIgnoreInputStream = this.javaClass.classLoader.getResourceAsStream("full.dcignore")
+            val fullDcIgnoreText = this.javaClass.classLoader.getResource("full.dcignore")?.readText()
                 ?: throw RuntimeException("full.dcignore can not be found in plugin's resources")
-            dcignore.writeBytes(fullDcIgnoreInputStream.readAllBytes())
+            dcignore.writeText(fullDcIgnoreText)
             SnykBalloonNotifications.showInfo("We added generic .dcignore file to upload only project's source code.", project)
         }
     }

--- a/src/main/kotlin/io/snyk/plugin/SnykProjectManagerListener.kt
+++ b/src/main/kotlin/io/snyk/plugin/SnykProjectManagerListener.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManagerListener
 import io.snyk.plugin.snykcode.core.AnalysisData
 import io.snyk.plugin.snykcode.core.RunUtils
+import io.snyk.plugin.snykcode.core.SnykCodeIgnoreInfoHolder
 
 class SnykProjectManagerListener : ProjectManagerListener {
 
@@ -15,6 +16,7 @@ class SnykProjectManagerListener : ProjectManagerListener {
             // lets all running ProgressIndicators release MUTEX first
             RunUtils.instance.cancelRunningIndicators(project)
             AnalysisData.instance.removeProjectFromCaches(project)
+            SnykCodeIgnoreInfoHolder.instance.removeProject(project)
         }
     }
 }

--- a/src/main/kotlin/io/snyk/plugin/services/SnykCodeService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykCodeService.kt
@@ -2,7 +2,6 @@ package io.snyk.plugin.services
 
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.project.Project
-import io.snyk.plugin.events.SnykScanListener
 import io.snyk.plugin.snykcode.core.RunUtils
 import io.snyk.plugin.snykcode.core.SCLogger
 
@@ -15,6 +14,5 @@ class SnykCodeService(val project: Project) {
     fun scan() {
         SCLogger.instance.logInfo("Re-Analyse Project requested for: $project")
         RunUtils.instance.rescanInBackgroundCancellableDelayed(project, 0, false, false)
-        project.messageBus.syncPublisher(SnykScanListener.SNYK_SCAN_TOPIC).scanningStarted()
     }
 }

--- a/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
@@ -67,6 +67,7 @@ class SnykTaskQueueService(val project: Project) {
                 }
                 if (settings.snykCodeSecurityIssuesScanEnable || settings.snykCodeQualityIssuesScanEnable) {
                     getSnykCode(project).scan()
+                    scanPublisher.scanningStarted()
                 }
 
             }

--- a/src/main/kotlin/io/snyk/plugin/snykcode/core/HashContentUtils.kt
+++ b/src/main/kotlin/io/snyk/plugin/snykcode/core/HashContentUtils.kt
@@ -1,6 +1,7 @@
 package io.snyk.plugin.snykcode.core
 
 import ai.deepcode.javaclient.core.HashContentUtilsBase
+import com.intellij.openapi.fileEditor.impl.LoadTextUtil
 import com.intellij.openapi.util.Computable
 import com.intellij.psi.PsiFile
 
@@ -21,8 +22,13 @@ class HashContentUtils private constructor() : HashContentUtilsBase(
             SCLogger.instance.logWarn("Invalid PsiFile: $psiFile")
             return ""
         }
-        // psiFile.getText() is NOT expensive as it's goes to VirtualFileContent.getText()
-        return psiFile.text
+        // psiFile.getText() NOT works as it not synchronized to the source on disk
+        return try {
+            LoadTextUtil.loadText(psiFile.virtualFile).toString()
+        } catch (e: IllegalArgumentException) {
+            SCLogger.instance.logWarn(e.toString())
+            ""
+        }
     }
 
     companion object {

--- a/src/main/kotlin/io/snyk/plugin/snykcode/core/PDU.kt
+++ b/src/main/kotlin/io/snyk/plugin/snykcode/core/PDU.kt
@@ -27,6 +27,10 @@ class PDU private constructor() : PlatformDependentUtilsBase() {
 
     override fun getFileName(file: Any): String = toPsiFile(file).virtualFile.name
 
+    override fun getFilePath(file: Any): String = toPsiFile(file).virtualFile.path
+
+    override fun getDirPath(file: Any): String = toPsiFile(file).virtualFile.parent.path
+
     override fun getProjectBasedFilePath(file: Any): String {
         val psiFile = toPsiFile(file)
         // looks like we don't need ReadAction for this (?)
@@ -115,6 +119,8 @@ class PDU private constructor() : PlatformDependentUtilsBase() {
             progress.checkCanceled()
         }
     }
+
+    override fun progressCanceled(progress: Any?): Boolean = progress is ProgressIndicator && progress.isCanceled
 
     override fun progressSetFraction(progress: Any?, fraction: Double) {
         if (progress is ProgressIndicator) {

--- a/src/main/kotlin/io/snyk/plugin/snykcode/core/SnykCodeIgnoreInfoHolder.kt
+++ b/src/main/kotlin/io/snyk/plugin/snykcode/core/SnykCodeIgnoreInfoHolder.kt
@@ -3,16 +3,10 @@ package io.snyk.plugin.snykcode.core
 import ai.deepcode.javaclient.core.DeepCodeIgnoreInfoHolderBase
 
 class SnykCodeIgnoreInfoHolder private constructor() : DeepCodeIgnoreInfoHolderBase(
-    HashContentUtils.instance
+    HashContentUtils.instance,
+    PDU.instance,
+    SCLogger.instance
 ) {
-
-    override fun getFilePath(file: Any): String = PDU.toPsiFile(file).virtualFile.path
-
-    override fun getFileName(file: Any): String = PDU.toPsiFile(file).virtualFile.name
-
-    override fun getProjectOfFile(file: Any): Any = PDU.toPsiFile(file).project
-
-    override fun getDirPath(file: Any): String = PDU.toPsiFile(file).virtualFile.parent.path
 
     companion object{
         val instance = SnykCodeIgnoreInfoHolder()

--- a/src/main/kotlin/io/snyk/plugin/snykcode/core/SnykCodeIgnoreInfoHolder.kt
+++ b/src/main/kotlin/io/snyk/plugin/snykcode/core/SnykCodeIgnoreInfoHolder.kt
@@ -1,12 +1,56 @@
 package io.snyk.plugin.snykcode.core
 
 import ai.deepcode.javaclient.core.DeepCodeIgnoreInfoHolderBase
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiManager
+import io.snyk.plugin.services.SnykTaskQueueService
+import io.snyk.plugin.ui.SnykBalloonNotifications
+import java.io.File
 
 class SnykCodeIgnoreInfoHolder private constructor() : DeepCodeIgnoreInfoHolderBase(
     HashContentUtils.instance,
     PDU.instance,
     SCLogger.instance
 ) {
+
+    fun cleanIgnoreFileCachesIfAffected(project: Project, virtualFilesToCheck: Collection<VirtualFile>) {
+        val ignoreFilesChanged = getIgnoreFiles(project, virtualFilesToCheck)
+        for (ignoreFile in ignoreFilesChanged) {
+            remove_ignoreFileContent(ignoreFile)
+            AnalysisData.instance.removeProjectFromCaches(project)
+        }
+    }
+
+    fun updateIgnoreFileCachesIfAffected(project: Project, virtualFilesToCheck: Collection<VirtualFile>) {
+        val ignoreFilesChanged = getIgnoreFiles(project, virtualFilesToCheck)
+        for (ignoreFile in ignoreFilesChanged) {
+            project.service<SnykTaskQueueService>().scheduleRunnable(
+                "updating caches for: ${PDU.instance.getFilePath(ignoreFile)}"
+            ) { progress ->
+                update_ignoreFileContent(ignoreFile, progress)
+            }
+        }
+    }
+
+    fun createDcIgnoreIfNeeded(project: Project) {
+        val prjBasePath = project.basePath
+        val gitignore = File("$prjBasePath/.gitignore")
+        val dcignore = File("$prjBasePath/.dcignore")
+        if (!gitignore.exists() && dcignore.createNewFile()) {
+            val fullDcIgnoreText = this.javaClass.classLoader.getResource("full.dcignore")?.readText()
+                ?: throw RuntimeException("full.dcignore can not be found in plugin's resources")
+            dcignore.writeText(fullDcIgnoreText)
+            SnykBalloonNotifications.showInfo("We added generic .dcignore file to upload only project's source code.", project)
+        }
+    }
+
+    private fun getIgnoreFiles(project: Project, virtualFilesToCheck: Collection<VirtualFile>) =
+        virtualFilesToCheck
+            .filter { it.name == ".dcignore" || it.name == ".gitignore" }
+            .distinct()
+            .mapNotNull { PsiManager.getInstance(project).findFile(it) }
 
     companion object{
         val instance = SnykCodeIgnoreInfoHolder()

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/OnboardPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/OnboardPanel.kt
@@ -1,9 +1,8 @@
 package io.snyk.plugin.ui.toolwindow
 
-import com.intellij.icons.AllIcons
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
-import com.intellij.ui.layout.*
+import com.intellij.ui.layout.panel
 import icons.SnykIcons
 import io.snyk.plugin.analytics.EventPropertiesProvider
 import io.snyk.plugin.analytics.Segment
@@ -13,23 +12,20 @@ import io.snyk.plugin.services.SnykAnalyticsService
 import io.snyk.plugin.services.SnykTaskQueueService
 import io.snyk.plugin.snykcode.core.SnykCodeUtils
 import io.snyk.plugin.ui.settings.ScanTypesPanel
-import java.io.File
 import javax.swing.SwingConstants
 
 class OnboardPanel(project: Project) {
     private val scanTypesPanel by lazy {
-        val allSupportedFilesCount = SnykCodeUtils.instance.getAllSupportedFilesInProject(project).size
+        val allSupportedFilesInProject =
+            SnykCodeUtils.instance.getAllSupportedFilesInProject(project, false, null)
+        val allSupportedFilesCount = allSupportedFilesInProject.size
         val allFilesCount = SnykCodeUtils.instance.allProjectFilesCount(project)
         return@lazy ScanTypesPanel(
-            snykCodeScanComments = "We will upload and analyze $allSupportedFilesCount files " +
+            snykCodeScanComments = "We will upload and analyze up to $allSupportedFilesCount files " +
                 "(${(100.0 * allSupportedFilesCount / allFilesCount).toInt()}%)" +
                 " out of $allFilesCount files",
             snykCodeQualityIssueCheckboxVisible = false
         ).panel
-    }
-
-    init {
-        File(project.basePath + "/.dcignore").createNewFile()
     }
 
     val panel = panel {
@@ -41,12 +37,6 @@ class OnboardPanel(project: Project) {
         }
         row {
             label("Let's start analyzing your code", bold = true).constraints(growX).apply {
-                component.horizontalAlignment = SwingConstants.CENTER
-            }
-        }
-        row {
-            label("We added a .dcignore file to upload only application's source code.").constraints(growX).apply {
-                component.icon = AllIcons.General.NotificationInfo
                 component.horizontalAlignment = SwingConstants.CENTER
             }
         }

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
@@ -36,6 +36,7 @@ import io.snyk.plugin.services.SnykTaskQueueService
 import io.snyk.plugin.snykcode.SnykCodeResults
 import io.snyk.plugin.snykcode.core.AnalysisData
 import io.snyk.plugin.snykcode.core.PDU
+import io.snyk.plugin.snykcode.core.SnykCodeIgnoreInfoHolder
 import io.snyk.plugin.snykcode.severityAsString
 import io.snyk.plugin.ui.SnykBalloonNotifications
 import java.awt.BorderLayout
@@ -296,6 +297,7 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
         currentCliError = null
         currentSnykCodeError = null
         AnalysisData.instance.resetCachesAndTasks(project)
+        SnykCodeIgnoreInfoHolder.instance.removeProject(project)
 
         ApplicationManager.getApplication().invokeLater {
             doCleanUi()

--- a/src/main/resources/full.dcignore
+++ b/src/main/resources/full.dcignore
@@ -1,0 +1,1547 @@
+# Write glob rules for ignored files.
+# Check syntax on https://deepcode.freshdesk.com/support/solutions/articles/60000531055-how-can-i-ignore-files-or-directories-
+# Check examples on https://github.com/github/gitignore
+
+# Hidden directories
+.*/
+
+# FuelPHP
+/fuel/vendor
+/docs/
+/fuel/app/logs/*/*/*
+/fuel/app/cache/*/*
+
+# Godot
+data_*/
+
+# Lilypond
+*~
+
+# Nim
+nimcache/
+nimblecache/
+htmldocs/
+
+# Android
+bin/
+gen/
+out/
+build/
+proguard/
+captures/
+freeline/
+fastlane/screenshots
+fastlane/test_output
+lint/intermediates/
+lint/generated/
+lint/outputs/
+lint/tmp/
+
+# UnrealEngine
+Binaries/*
+Plugins/*/Binaries/*
+Build/*
+!Build/*/
+Build/*/**
+Saved/*
+Intermediate/*
+Plugins/*/Intermediate/*
+DerivedDataCache/*
+
+# Zephir
+ext/build/
+ext/modules/
+ext/Makefile*
+ext/config*
+ext/autom4te*
+ext/install-sh
+ext/missing
+ext/mkinstalldirs
+ext/libtool
+
+# Typo3
+/fileadmin/user_upload/
+/fileadmin/_temp_/
+/fileadmin/_processed_/
+/uploads/
+/typo3conf/temp_CACHED*
+/typo3conf/ENABLE_INSTALL_TOOL
+/FIRST_INSTALL
+/typo3
+/Packages
+/typo3temp/
+
+# Actionscript
+bin-debug/
+bin-release/
+[Oo]bj/
+[Bb]in/
+
+# WordPress
+!wp-content/
+wp-content/*
+!wp-content/mu-plugins/
+!wp-content/plugins/
+!wp-content/themes/
+wp-content/themes/twenty*/
+node_modules/
+
+# Lithium
+libraries/*
+resources/tmp/*
+
+# Python
+__pycache__/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+MANIFEST
+htmlcov/
+cover/
+instance/
+docs/_build/
+target/
+profile_default/
+__pypackages__/
+celerybeat-schedule
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+/site
+cython_debug/
+
+# VVVV
+bin/
+
+# CodeIgniter
+*/config/development
+*/cache/*
+application/logs/*
+/vendor/
+
+# AppEngine
+appengine-generated/
+
+# Objective-C
+xcuserdata/
+build/
+DerivedData/
+Carthage/Build/
+fastlane/test_output
+iOSInjectionProject/
+
+# GWT
+war/gwt_bree/
+gwt-unitCache/
+war/WEB-INF/deploy/
+war/WEB-INF/classes/
+www-test/
+
+# Delphi
+__history/
+__recovery/
+modules/
+
+# ROS
+devel/
+logs/
+build/
+bin/
+lib/
+msg_gen/
+srv_gen/
+build_isolated/
+devel_isolated/
+/cfg/cpp/
+qtcreator-*
+/planning/cfg
+/planning/docs
+*~
+CATKIN_IGNORE
+
+# Stella
+obj/
+
+# Jekyll
+_site/
+
+# MetaProgrammingSystem
+classes_gen
+source_gen
+test_gen
+
+# JENKINS_HOME
+!/jobs
+jobs/**
+!jobs/**/
+builds
+indexing
+jobs/**/*workspace
+
+# Leiningen
+/lib/
+/classes/
+/target/
+/checkouts/
+
+# Laravel
+/vendor/
+node_modules/
+app/storage/
+public/storage
+public/hot
+public_html/storage
+public_html/hot
+
+# R
+/*.Rcheck/
+*_cache/
+/cache/
+docs/
+po/*~
+
+# Processing
+applet
+out
+
+# GitBook
+node_modules
+_book
+
+# LemonStand
+/config/*
+/controllers/*
+/init/*
+/logs/*
+/phproad/*
+/temp/*
+/uploaded/*
+/installer_files/*
+/modules/backend/*
+/modules/blog/*
+/modules/cms/*
+/modules/core/*
+/modules/session/*
+/modules/shop/*
+/modules/system/*
+/modules/users/*
+
+# ArchLinuxPackages
+pkg/
+
+# Swift
+xcuserdata/
+build/
+DerivedData/
+Carthage/Build/
+Dependencies/
+fastlane/test_output
+iOSInjectionProject/
+
+# Packer
+packer_cache/
+
+# Elixir
+/_build
+/cover
+/deps
+/doc
+
+# Phalcon
+/cache/
+/config/development/
+
+# Unity
+/[Ll]ibrary/
+/[Tt]emp/
+/[Oo]bj/
+/[Bb]uild/
+/[Bb]uilds/
+/[Ll]ogs/
+/[Uu]ser[Ss]ettings/
+/[Mm]emoryCaptures/
+/[Aa]ssets/Plugins/Editor/JetBrains*
+ExportedObj/
+/[Aa]ssets/[Ss]treamingAssets/aa/*
+
+# Scrivener
+*/QuickLook/
+
+# Kohana
+application/cache/*
+application/logs/*
+
+# Prestashop
+/cache/*
+!/cache/push/activity
+!/cache/push/trends
+/download/*
+/img/*
+!/img/jquery-ui
+!/img/scenes
+/upload/*
+/vendor/*
+/docs/phpdoc-sf/
+/admin-dev/autoupgrade/*
+/admin-dev/backups/*
+/admin-dev/import/*
+/admin-dev/export/*
+themes/*/cache/*
+config/xml/*
+config/themes/*
+modules/*
+override/*
+themes/*/
+!themes/classic
+!themes/_core
+!themes/_libraries
+bower_components/
+node_modules/
+php-cs-fixer
+translations/*
+mails/*
+!mails/themes/
+!mails/_partials/
+themes/default-bootstrap/lang/*
+themes/default-bootstrap/mails/*
+!themes/default-bootstrap/mails/en/
+themes/default-bootstrap/modules/*/mails/*
+!themes/default-bootstrap/modules/*/mails/en
+/bin/
+/app/Resources/translations/*
+!/app/Resources/translations/default
+/build/
+/var/*
+!/var/cache
+/var/cache/*
+!/var/logs
+/var/logs/*
+!/var/sessions
+/var/sessions/*
+/vendor/
+/web/bundles/
+
+# ExtJs
+build/
+ext/
+
+# CMake
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+_deps
+
+# Umbraco
+**/App_Data/Logs/
+**/App_Data/[Pp]review/
+**/App_Data/TEMP/
+**/App_Data/NuGetBackup/
+!**/App_Data/[Pp]ackages/*
+!**/[Uu]mbraco/[Dd]eveloper/[Pp]ackages/*
+!**/[Uu]mbraco/[Vv]iews/[Pp]ackages/*
+**/App_Data/cache/
+
+# CakePHP
+/vendor/*
+/tmp/cache/models/*
+!/tmp/cache/models/empty
+/tmp/cache/persistent/*
+!/tmp/cache/persistent/empty
+/tmp/cache/views/*
+!/tmp/cache/views/empty
+/tmp/sessions/*
+!/tmp/sessions/empty
+/tmp/tests/*
+!/tmp/tests/empty
+/logs/*
+!/logs/empty
+/app/tmp/*
+/vendors/*
+
+# Java
+hs_err_pid*
+
+# Symfony
+/app/cache/*
+/app/logs/*
+/app/spool/*
+/var/cache/*
+/var/logs/*
+/var/sessions/*
+/var/log/*
+/bin/*
+!bin/console
+!bin/symfony_requirements
+/vendor/
+/web/bundles/
+/web/uploads/
+/build/
+**/Entity/*~
+
+# Composer
+/vendor/
+
+# SymphonyCMS
+manifest/cache/
+manifest/logs/
+manifest/tmp/
+symphony/
+workspace/uploads/
+
+# JBoss6
+/server/all/data
+/server/all/log
+/server/all/tmp
+/server/all/work
+/server/default/data
+/server/default/log
+/server/default/tmp
+/server/default/work
+/server/minimal/data
+/server/minimal/log
+/server/minimal/tmp
+/server/minimal/work
+/server/jbossweb-standalone/data
+/server/jbossweb-standalone/log
+/server/jbossweb-standalone/tmp
+/server/jbossweb-standalone/work
+/server/standard/data
+/server/standard/log
+/server/standard/tmp
+/server/standard/work
+
+# JBoss4
+/server/all/data
+/server/all/log
+/server/all/tmp
+/server/all/work
+/server/default/data
+/server/default/log
+/server/default/tmp
+/server/default/work
+/server/minimal/data
+/server/minimal/log
+/server/minimal/tmp
+/server/minimal/work
+
+# Red
+quick-test/runnable/
+system/tests/source/units/auto-tests/
+tests/source/units/auto-tests/
+
+# Snap
+parts/
+prime/
+stage/
+
+# Splunk
+local
+
+# Hugo
+/public/
+/resources/_gen/
+
+# Bazel
+/bazel-*
+
+# Nikola
+cache/
+output/
+
+# JupyterNotebooks
+profile_default/
+
+# Puppet
+pkg/*
+spec/fixtures/*
+coverage/*
+vendor/*
+
+# Racket
+compiled/
+
+# Phoenix
+/tmp
+/node_modules
+/assets/node_modules
+/priv/static/
+/installer/_build
+/installer/tmp
+/installer/doc
+/installer/deps
+
+# Logtalk
+lgt_tmp/
+logtalk_tester_logs/
+logtalk_doclet_logs/
+
+# NWjs
+locales/
+pnacl/
+
+# Cordova
+/platforms
+
+# Vue
+docs/_book
+test/
+
+# Kentico
+!CMS/CMSAdminControls/*/
+!CMS/CMSModules/System/*/
+!CMS/App_Data/CIRepository/**
+CMS/App_Data/AzureCache
+CMS/App_Data/AzureTemp
+CMS/App_Data/CMSTemp
+CMS/App_Data/Persistent
+CMS/CMSSiteUtils/Export
+CMS/CMSSiteUtils/Import
+CMS/App_Data/CMSModules/SmartSearch/**
+!CMS/App_Data/CMSModules/SmartSearch/*/
+!CMS/App_Data/CMSModules/SmartSearch/_StopWords/**
+!CMS/App_Data/CMSModules/SmartSearch/_Synonyms/**
+CMS/App_Data/DancingGoat
+CMS/App_Data/Templates/CommunitySite
+CMS/App_Data/Templates/CorporateSite
+CMS/App_Data/Templates/DancingGoat
+CMS/App_Data/Templates/EcommerceSite
+CMS/App_Data/Templates/IntranetPortal
+CMS/App_Data/Templates/PersonalSite
+CMS/App_Themes/CommunitySite
+CMS/App_Themes/CorporateSite
+CMS/App_Themes/EcommerceSite
+CMS/App_Themes/IntranetPortal*
+CMS/App_Themes/PersonalSite
+CMS/CMSTemplates/CorporateSite
+CMS/CommunitySite
+CMS/CorporateSite
+CMS/DancingGoat
+CMS/EcommerceSite
+CMS/IntranetPortal
+CMS/PersonalSite
+
+# InforCMS
+[Mm]odel/[Dd]eployment
+!Model/Portal/*/SupportFiles/[Bb]in/
+!Model/Portal/PortalTemplates/*/SupportFiles/[Bb]in
+
+# Xilinx
+*_synth_*
+*/*/bd/*/hdl
+*/*/*/bd/*/hdl
+*/*/bd/*/ip/*/*/
+*/*/*/bd/*/ip/*/*/
+hw_handoff
+ipshared
+
+# Pimcore
+/pimcore
+/website/var/assets/*
+/website/var/backup/*
+/website/var/cache/*
+/website/var/classes/Object*
+!/website/var/classes/objectbricks
+/website/var/config/Geo*
+/website/var/config/object/*
+/website/var/config/portal/*
+/website/var/config/sqlreport/*
+/website/var/email/*
+/website/var/recyclebin/*
+/website/var/search/*
+/website/var/system/*
+/website/var/tmp/*
+/website/var/versions/asset/*
+/website/var/versions/document/*
+/website/var/versions/object/*
+/website/var/user-image/*
+
+# Magento2
+/sitemap
+/pub/sitemap
+/app/config_sandbox
+/app/code/Magento/TestModule*
+/pub/media/attribute/*
+/pub/media/analytics/*
+/pub/media/catalog/*
+/pub/media/customer/*
+/pub/media/downloadable/*
+/pub/media/favicon/*
+/pub/media/import/*
+/pub/media/logo/*
+/pub/media/theme/*
+/pub/media/theme_customization/*
+/pub/media/wysiwyg/*
+/pub/media/tmp/*
+/pub/media/captcha/*
+/pub/static/*
+/var/*
+/vendor/*
+/generated/*
+
+# Bitrix
+/bitrix/*
+!/bitrix/templates
+!/bitrix/components
+/bitrix/components/bitrix
+!/bitrix/gadgets
+/bitrix/gadgets/bitrix
+!/bitrix/php_interface/
+/upload/
+
+# Drupal7
+files/
+sites/*/files
+sites/*/private
+sites/*/translations
+/includes
+/misc
+/modules
+/profiles
+/scripts
+/themes
+
+# CodeSniffer
+/wpcs/*
+
+# Jigsaw
+build_*
+
+# Magento1
+/media/*
+!/media/customer
+/media/customer/*
+!/media/dhl
+/media/dhl/*
+!/media/downloadable
+/media/downloadable/*
+!/media/xmlconnect
+/media/xmlconnect/*
+!/media/xmlconnect/custom
+/media/xmlconnect/custom/*
+!/media/xmlconnect/original
+/media/xmlconnect/original/*
+!/media/xmlconnect/system
+/media/xmlconnect/system/*
+/var/*
+!/var/package
+/var/package/*
+
+# ThinkPHP
+/Application/Runtime/
+
+# AtmelStudio
+[Dd]ebug/
+[Rr]elease/
+
+# IAR_EWARM
+EWARM/**/Obj
+EWARM/**/List
+EWARM/**/Exe
+EWARM/settings
+
+# esp-idf
+build/
+sdkconfig
+
+# Concrete5
+error_log
+files/cache/*
+files/tmp/*
+/application/files/*
+/updates/*
+
+# Drupal
+/sites/*/files
+/sites/*/public
+/sites/*/private
+/sites/*/files-public
+/sites/*/files-private
+/sites/*/translations
+/sites/*/tmp
+/sites/*/cache
+/sites/simpletest
+/core
+/vendor
+
+# Mercury
+Mercury/
+
+# Joomla
+/administrator/cache/*
+/administrator/components/com_actionlogs/*
+/administrator/components/com_admin/*
+/administrator/components/com_ajax/*
+/administrator/components/com_associations/*
+/administrator/components/com_banners/*
+/administrator/components/com_cache/*
+/administrator/components/com_categories/*
+/administrator/components/com_checkin/*
+/administrator/components/com_config/*
+/administrator/components/com_contact/*
+/administrator/components/com_content/*
+/administrator/components/com_contenthistory/*
+/administrator/components/com_cpanel/*
+/administrator/components/com_fields/*
+/administrator/components/com_finder/*
+/administrator/components/com_installer/*
+/administrator/components/com_joomlaupdate/*
+/administrator/components/com_languages/*
+/administrator/components/com_login/*
+/administrator/components/com_media/*
+/administrator/components/com_menus/*
+/administrator/components/com_messages/*
+/administrator/components/com_modules/*
+/administrator/components/com_newsfeeds/*
+/administrator/components/com_plugins/*
+/administrator/components/com_postinstall/*
+/administrator/components/com_privacy/*
+/administrator/components/com_redirect/*
+/administrator/components/com_search/*
+/administrator/components/com_tags/*
+/administrator/components/com_templates/*
+/administrator/components/com_users/*
+/administrator/help/*
+/administrator/includes/*
+/administrator/language/overrides/*
+/administrator/logs/*
+/administrator/modules/mod_custom/*
+/administrator/modules/mod_feed/*
+/administrator/modules/mod_latest/*
+/administrator/modules/mod_latestactions/*
+/administrator/modules/mod_logged/*
+/administrator/modules/mod_login/*
+/administrator/modules/mod_menu/*
+/administrator/modules/mod_multilangstatus/*
+/administrator/modules/mod_online/*
+/administrator/modules/mod_popular/*
+/administrator/modules/mod_privacy_dashboard/*
+/administrator/modules/mod_quickicon/*
+/administrator/modules/mod_sampledata/*
+/administrator/modules/mod_stats_admin/*
+/administrator/modules/mod_status/*
+/administrator/modules/mod_submenu/*
+/administrator/modules/mod_title/*
+/administrator/modules/mod_toolbar/*
+/administrator/modules/mod_unread/*
+/administrator/modules/mod_version/*
+/administrator/templates/hathor/*
+/administrator/templates/isis/*
+/administrator/templates/system/*
+/bin/*
+/cache/*
+/cli/*
+/components/com_ajax/*
+/components/com_banners/*
+/components/com_config/*
+/components/com_contact/*
+/components/com_content/*
+/components/com_contenthistory/*
+/components/com_fields/*
+/components/com_finder/*
+/components/com_mailto/*
+/components/com_media/*
+/components/com_menus/*
+/components/com_modules/*
+/components/com_newsfeeds/*
+/components/com_privacy/*
+/components/com_search/*
+/components/com_tags/*
+/components/com_users/*
+/components/com_wrapper/*
+/images/banners/*
+/images/headers/*
+/images/sampledata/*
+/images/joomla*
+/includes/*
+/installation/*
+/language/overrides/*
+/layouts/joomla/*
+/layouts/libraries/*
+/layouts/plugins/*
+/libraries/cms/*
+/libraries/fof/*
+/libraries/idna_convert/*
+/libraries/joomla/*
+/libraries/legacy/*
+/libraries/php-encryption/*
+/libraries/phpass/*
+/libraries/phpmailer/*
+/libraries/phputf8/*
+/libraries/simplepie/*
+/libraries/vendor/*
+/media/cms/*
+/media/com_associations/*
+/media/com_contact/*
+/media/com_content/*
+/media/com_contenthistory/*
+/media/com_fields/*
+/media/com_finder/*
+/media/com_joomlaupdate/*
+/media/com_menus/*
+/media/com_modules/*
+/media/com_wrapper/*
+/media/contacts/*
+/media/editors/*
+/media/jui/*
+/media/mailto/*
+/media/media/*
+/media/mod_languages/*
+/media/mod_sampledata/*
+/media/overrider/*
+/media/plg_captcha_recaptcha/*
+/media/plg_captcha_recaptcha_invisible/*
+/media/plg_quickicon_extensionupdate/*
+/media/plg_quickicon_joomlaupdate/*
+/media/plg_quickicon_privacycheck/*
+/media/plg_system_highlight/*
+/media/plg_system_stats/*
+/media/plg_twofactorauth_totp/*
+/media/system/*
+/modules/mod_articles_archive/*
+/modules/mod_articles_categories/*
+/modules/mod_articles_category/*
+/modules/mod_articles_latest/*
+/modules/mod_articles_news/*
+/modules/mod_articles_popular/*
+/modules/mod_banners/*
+/modules/mod_breadcrumbs/*
+/modules/mod_custom/*
+/modules/mod_feed/*
+/modules/mod_finder/*
+/modules/mod_footer/*
+/modules/mod_languages/*
+/modules/mod_login/*
+/modules/mod_menu/*
+/modules/mod_random_image/*
+/modules/mod_related_items/*
+/modules/mod_search/*
+/modules/mod_stats/*
+/modules/mod_syndicate/*
+/modules/mod_tags_popular/*
+/modules/mod_tags_similar/*
+/modules/mod_users_latest/*
+/modules/mod_whosonline/*
+/modules/mod_wrapper/*
+/plugins/actionlog/joomla/*
+/plugins/authentication/cookie/*
+/plugins/authentication/example/*
+/plugins/authentication/gmail/*
+/plugins/authentication/joomla/*
+/plugins/authentication/ldap/*
+/plugins/captcha/recaptcha/*
+/plugins/captcha/recaptcha_invisible/*
+/plugins/content/confirmconsent/*
+/plugins/content/contact/*
+/plugins/content/emailcloak/*
+/plugins/content/example/*
+/plugins/content/fields/*
+/plugins/content/finder/*
+/plugins/content/geshi/*
+/plugins/content/joomla/*
+/plugins/content/loadmodule/*
+/plugins/content/pagebreak/*
+/plugins/content/pagenavigation/*
+/plugins/content/vote/*
+/plugins/editors/codemirror/*
+/plugins/editors/none/*
+/plugins/editors/tinymce/*
+/plugins/editors-xtd/article/*
+/plugins/editors-xtd/contact/*
+/plugins/editors-xtd/fields/*
+/plugins/editors-xtd/image/*
+/plugins/editors-xtd/menu/*
+/plugins/editors-xtd/module/*
+/plugins/editors-xtd/pagebreak/*
+/plugins/editors-xtd/readmore/*
+/plugins/extension/example/*
+/plugins/extension/joomla/*
+/plugins/fields/calendar/*
+/plugins/fields/checkboxes/*
+/plugins/fields/color/*
+/plugins/fields/editor/*
+/plugins/fields/imagelist/*
+/plugins/fields/integer/*
+/plugins/fields/list/*
+/plugins/fields/media/*
+/plugins/fields/radio/*
+/plugins/fields/repeatable/*
+/plugins/fields/sql/*
+/plugins/fields/text/*
+/plugins/fields/textarea/*
+/plugins/fields/url/*
+/plugins/fields/user/*
+/plugins/fields/usergrouplist/*
+/plugins/finder/categories/*
+/plugins/finder/contacts/*
+/plugins/finder/content/*
+/plugins/finder/newsfeeds/*
+/plugins/finder/tags/*
+/plugins/installer/folderinstaller/*
+/plugins/installer/packageinstaller/*
+/plugins/installer/urlinstaller/*
+/plugins/privacy/actionlogs/*
+/plugins/privacy/consents/*
+/plugins/privacy/contact/*
+/plugins/privacy/content/*
+/plugins/privacy/message/*
+/plugins/privacy/user/*
+/plugins/quickicon/extensionupdate/*
+/plugins/quickicon/joomlaupdate/*
+/plugins/quickicon/phpversioncheck/*
+/plugins/quickicon/privacycheck/*
+/plugins/sampledata/blog/*
+/plugins/search/categories/*
+/plugins/search/contacts/*
+/plugins/search/content/*
+/plugins/search/newsfeeds/*
+/plugins/search/tags/*
+/plugins/search/weblinks/*
+/plugins/system/actionlogs/*
+/plugins/system/cache/*
+/plugins/system/debug/*
+/plugins/system/fields/*
+/plugins/system/highlight/*
+/plugins/system/languagecode/*
+/plugins/system/languagefilter/*
+/plugins/system/log/*
+/plugins/system/logout/*
+/plugins/system/logrotation/*
+/plugins/system/p3p/*
+/plugins/system/privacyconsent/*
+/plugins/system/redirect/*
+/plugins/system/remember/*
+/plugins/system/sef/*
+/plugins/system/sessiongc/*
+/plugins/system/stats/*
+/plugins/system/updatenotification/*
+/plugins/twofactorauth/totp/*
+/plugins/twofactorauth/yubikey/*
+/plugins/user/contactcreator/*
+/plugins/user/example/*
+/plugins/user/joomla/*
+/plugins/user/profile/*
+/plugins/user/terms/*
+/templates/beez3/*
+/templates/protostar/*
+/templates/system/*
+/tmp/*
+
+# Yii
+assets/*
+protected/runtime/*
+themes/classic/views/
+
+# Rust
+debug/
+target/
+
+# Node
+logs
+pids
+lib-cov
+coverage
+bower_components
+build/Release
+node_modules/
+jspm_packages/
+web_modules/
+out
+dist
+
+# PureScript
+bower_components
+node_modules
+output
+
+# JBoss
+jboss/server/all/tmp/**/*
+jboss/server/all/data/**/*
+jboss/server/all/work/**/*
+jboss/server/default/tmp/**/*
+jboss/server/default/data/**/*
+jboss/server/default/work/**/*
+jboss/server/minimal/tmp/**/*
+jboss/server/minimal/data/**/*
+jboss/server/minimal/work/**/*
+
+# Grails
+/web-app/WEB-INF/classes
+/test/reports
+/logs
+/plugins
+/web-app/plugins
+/target
+
+# C
+*.dSYM/
+
+# ZendFramework
+vendor/
+data/logs/
+data/cache/
+data/sessions/
+data/tmp/
+temp/
+data/DoctrineORMModule/Proxy/
+data/DoctrineORMModule/cache/
+demos/
+extras/documentation
+
+# PlayFramework
+bin/
+/db
+/lib/
+/logs/
+/modules
+/project/project
+/project/target
+/target
+tmp/
+test-result
+/dist/
+
+# SugarCRM
+/cache/*
+/custom/history/
+/custom/modulebuilder/
+/custom/working/
+/custom/modules/*/Ext/
+/custom/application/Ext/
+/upload/*
+/upload_backup/
+
+# ExpressionEngine
+images/avatars/
+images/captchas/
+images/smileys/
+images/member_photos/
+images/signature_attachments/
+images/pm_attachments/
+sized/
+thumbs/
+_thumbs/
+*/expressionengine/cache/*
+
+# KiCad
+*~
+_autosave-*
+fp-info-cache
+
+# Plone
+bin/
+build/
+develop-eggs/
+downloads/
+eggs/
+fake-eggs/
+parts/
+dist/
+var/
+
+# D
+docs/
+
+# CFWheels
+plugins/**/*
+files
+db/sql
+javascripts/bundles
+stylesheets/bundles
+
+# Yeoman
+node_modules/
+bower_components/
+build/
+dist/
+
+# Nanoc
+output/
+tmp/nanoc/
+
+# Erlang
+rel/example_project
+deps
+_build/
+_checkouts/
+
+# VisualStudio
+[Dd]ebug/
+[Dd]ebugPublic/
+[Rr]elease/
+[Rr]eleases/
+x64/
+x86/
+[Ww][Ii][Nn]32/
+[Aa][Rr][Mm]/
+[Aa][Rr][Mm]64/
+bld/
+[Bb]in/
+[Oo]bj/
+[Ll]og/
+[Ll]ogs/
+Generated\ Files/
+[Tt]est[Rr]esult*/
+[Dd]ebugPS/
+[Rr]eleasePS/
+BenchmarkDotNet.Artifacts/
+artifacts/
+_Chutzpah*
+ipch/
+$tf/
+_ReSharper*/
+_TeamCity*
+_NCrunch_*
+nCrunchTemp_*
+AutoTest.Net/
+[Ee]xpress/
+DocProject/buildhelp/
+DocProject/Help/Html2
+DocProject/Help/html
+publish/
+PublishScripts/
+**/[Pp]ackages/*
+!**/[Pp]ackages/build/
+csx/
+ecf/
+rcf/
+AppPackages/
+BundleArtifacts/
+!?*.[Cc]ache/
+ClientBin/
+~$*
+*~
+Generated_Code/
+_UpgradeReport_Files/
+Backup*/
+ServiceFabricBackup/
+FakesAssemblies/
+node_modules/
+**/*.HTMLClient/GeneratedArtifacts
+**/*.DesktopClient/GeneratedArtifacts
+**/*.Server/GeneratedArtifacts
+_Pvt_Extensions
+paket-files/
+__pycache__/
+OpenCover/
+ASALocalRun/
+healthchecksdb
+MigrationBackup/
+
+# Perl
+!Build/
+cover_db/
+_build/
+Build
+inc/
+/blib/
+/_eumm/
+/Makefile
+/pm_to_blib
+
+# OCaml
+_build/
+_opam/
+
+# Agda
+MAlonzo/**
+
+# Clojure
+/lib/
+/classes/
+/target/
+/checkouts/
+
+# OpenCart
+download/
+image/data/
+image/cache/
+system/cache/
+system/logs/
+system/storage/
+vqmod/logs/*
+vqmod/vqcache/*
+
+# Kotlin
+hs_err_pid*
+
+# Julia
+deps/downloads/
+deps/usr/
+docs/build/
+docs/site/
+
+# Opa
+_build
+_tracks
+opa-debug-js
+
+# Windows
+$RECYCLE.BIN/
+
+# MonoDevelop
+test-results/
+
+# JDeveloper
+temp/
+classes/
+deploy/
+javadoc/
+
+# CodeKit
+/min
+
+# VirtualEnv
+[Bb]in
+[Ii]nclude
+[Ll]ib
+[Ll]ib64
+[Ll]ocal
+[Ss]cripts
+
+# Tags
+TAGS
+!TAGS/
+tags
+!tags/
+GTAGS
+GRTAGS
+GPATH
+GSYMS
+
+# Virtuoso
+lvsRunDir/*
+drcRunDir/*
+
+# PSoCCreator
+Debug/
+Release/
+Export/
+*/codegentemp
+*/Generated_Source
+
+# Calabash
+rerun/
+reports/
+screenshots/
+test-servers/
+vendor
+
+# TextMate
+tmtags
+
+# Lazarus
+backup/
+lib/
+*.app/
+
+# macOS
+Icon
+
+Network Trash Folder
+Temporary Items
+
+# EiffelStudio
+EIFGENs
+
+# MATLAB
+helpsearch*/
+slprj/
+sccprj/
+codegen/
+octave-workspace
+
+# FlexBuilder
+bin/
+bin-debug/
+bin-release/
+
+# Eclipse
+bin/
+tmp/
+
+# Vim
+*~
+tags
+
+# SynopsysVCS
+simv
+simv.daidir/
+simv.db.dir/
+simv.vdb/
+urgReport/
+DVEfiles/
+
+# Emacs
+*~
+\#*\#
+auto-save-list
+tramp
+*_archive
+/eshell/history
+/eshell/lastdir
+/elpa/
+/auto/
+dist/
+/server/
+
+# Momentics
+x86/
+arm/
+arm-p/
+
+# Linux
+*~
+
+# SublimeText
+Package Control.cache/
+Package Control.ca-certs/
+
+# CVS
+/CVS/*
+**/CVS/*
+
+# Dreamweaver
+_notes
+_compareTemp
+configs/
+
+# Xcode
+xcuserdata/
+build/
+DerivedData/
+
+# WebMethods
+**/IntegrationServer/datastore/
+**/IntegrationServer/db/
+**/IntegrationServer/DocumentStore/
+**/IntegrationServer/lib/
+**/IntegrationServer/logs/
+**/IntegrationServer/replicate/
+**/IntegrationServer/sdk/
+**/IntegrationServer/support/
+**/IntegrationServer/update/
+**/IntegrationServer/userFtpRoot/
+**/IntegrationServer/web/
+**/IntegrationServer/WmRepository4/
+**/IntegrationServer/XAStore/
+**/IntegrationServer/packages/Wm*/
+
+# ModelSim
+[_@]*
+wlf*
+cov*/
+transcript*
+
+# NetBeans
+**/nbproject/private/
+build/
+nbbuild/
+dist/
+nbdist/
+
+# JetBrains
+cmake-build-*/
+out/
+
+# Octave
+helpsearch*/
+slprj/
+sccprj/
+codegen/
+octave-workspace
+
+# SBT
+dist/*
+target/
+lib_managed/
+project/boot/
+project/plugins/project/
+
+# XilinxISE
+iseconfig/
+xlnx_auto_0_xdb/
+xst/
+_ngo/
+_xmsgs/
+
+# Smalltalk
+/package-cache
+/play-cache
+/play-stash
+/github-cache
+
+# Magento
+/media/*
+!/media/customer
+/media/customer/*
+!/media/dhl
+/media/dhl/*
+!/media/downloadable
+/media/downloadable/*
+!/media/xmlconnect
+/media/xmlconnect/*
+!/media/xmlconnect/custom
+/media/xmlconnect/custom/*
+!/media/xmlconnect/original
+/media/xmlconnect/original/*
+!/media/xmlconnect/system
+/media/xmlconnect/system/*
+/var/*
+!/var/package
+/var/package/*
+
+# TurboGears2
+data/*
+dist
+build
+
+# ChefCookbook
+/cookbooks
+bin/*
+
+# TeX
+latex.out/
+*-gnuplottex-*
+*-tikzDictionary
+_minted*
+sympy-plots-for-*.tex/
+pythontex-files-*/
+TSWLatexianTemp*
+*~[0-9]*
+
+# Rails
+/public/system
+/coverage/
+/spec/tmp
+/log/*
+/tmp/*
+/vendor/bundle
+/vendor/assets/bower_components
+node_modules/
+/public/packs
+/public/packs-test
+/public/assets
+/storage/*
+/public/uploads
+
+# Dart
+build/
+doc/api/
+
+# Ruby
+/coverage/
+/InstalledFiles
+/pkg/
+/spec/reports/
+/test/tmp/
+/test/version_tmp/
+/tmp/
+build/
+build-iPhoneOS/
+build-iPhoneSimulator/
+/_yardoc/
+/doc/
+/rdoc/
+/vendor/bundle
+/lib/bundler/man/
+
+# Textpattern
+rpc/
+sites/site*/admin/
+sites/site*/private/
+sites/site*/public/admin/
+sites/site*/public/setup/
+sites/site*/public/theme/
+textpattern/
+
+# Autotools
+/ar-lib
+/mdate-sh
+/py-compile
+/test-driver
+/ylwrap
+/compile
+/configure
+/depcomp
+/install-sh
+/missing
+/stamp-h1
+Makefile
+
+# Qooxdoo
+cache
+cache-downloads
+inspector
+api
+
+# Maven
+target/
+
+# Waf
+waf-*-*/
+waf3-*-*/
+
+# Qt
+Makefile*
+*build-*
+
+# ForceDotCom
+Referenced Packages
+
+# SeamGen
+/bootstrap/data
+/bootstrap/tmp
+/classes/
+/dist/
+/exploded-archives/
+/test-build/
+/test-output/
+/test-report/
+/target/
+
+# RhodesRhomobile
+rholog-*
+sim-*
+bin/libs
+bin/RhoBundle
+bin/tmp
+bin/target
+
+# Xojo
+Builds*
+Debug*/Debug*\ Libs
+
+# Haskell
+dist
+dist-*
+cabal-dev
+
+# Elm
+elm-stuff
+repl-temp-*
+
+# AppceleratorTitanium
+build/
+
+# CraftCMS
+/craft/storage/*
+!/craft/storage/rebrand
+
+# Gradle
+**/build/
+
+# Elisp
+*~

--- a/src/test/kotlin/io/snyk/plugin/snykcode/core/IgnoreInfoHolderPlatformTestCase.kt
+++ b/src/test/kotlin/io/snyk/plugin/snykcode/core/IgnoreInfoHolderPlatformTestCase.kt
@@ -1,0 +1,93 @@
+package io.snyk.plugin.snykcode.core
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.vfs.StandardFileSystems
+import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.psi.PsiFile
+import com.intellij.testFramework.HeavyPlatformTestCase
+import com.intellij.testFramework.PlatformTestUtil
+import java.io.File
+import java.io.FileNotFoundException
+
+// `Heavy` tests should be used due to Project partial re-usage/erasure:
+// .dcignore is deleted between calls but Project is not reopened in BasePlatformTestCase
+// See: https://plugins.jetbrains.com/docs/intellij/light-and-heavy-tests.html
+class IgnoreInfoHolderPlatformTestCase : HeavyPlatformTestCase() {
+
+    fun testGenericDcIgnoreAddedOnProjectOpening() {
+        val genericDcIgnoreFile = File(project.basePath + "/.dcignore")
+        assertTrue(
+            "Generic .dcignore file was NOT added to the project",
+            genericDcIgnoreFile.exists()
+        )
+    }
+
+    fun testNodeModulesAreExcluded() {
+        assertTrue("No path found for project", project.basePath != null)
+        val filePathToCheck = project.basePath + "/node_modules/1.js"
+        File(filePathToCheck).parentFile.mkdir()
+        File(filePathToCheck).createNewFile()
+
+        val psiFileToCheck = findPsiFile(filePathToCheck)
+        initiateAllMissedIgnoreFilesRescan()
+        assertTrue(
+            "Files inside `node_modules` should be excluded(ignored) by default",
+            SnykCodeIgnoreInfoHolder.instance.isIgnoredFile(psiFileToCheck)
+        )
+    }
+
+    private fun initiateAllMissedIgnoreFilesRescan() {
+        SnykCodeUtils.instance.getAllSupportedFilesInProject(project, true, null)
+    }
+
+    fun testIgnoreCacheUpdateOnIgnoreFileContentChange() {
+        val filePathToCheck = project.basePath + "/2.js"
+        File(filePathToCheck).createNewFile()
+
+        initiateAllMissedIgnoreFilesRescan()
+        assertFalse(
+            "File $filePathToCheck should NOT be excluded(ignored) by default .dcignore",
+            SnykCodeIgnoreInfoHolder.instance.isIgnoredFile(findPsiFile(filePathToCheck))
+        )
+
+        val dcignoreFilePath = project.basePath + "/.dcignore"
+        File(dcignoreFilePath).writeText("2.js")
+        // trigger BulkFileListener to proceed .dcignore file change
+        ApplicationManager.getApplication().runWriteAction {
+            VirtualFileManager.getInstance().syncRefresh()
+        }
+        assertTrue(
+            "File $filePathToCheck should be excluded(ignored) by updated .dcignore",
+            SnykCodeIgnoreInfoHolder.instance.isIgnoredFile(findPsiFile(filePathToCheck))
+        )
+    }
+
+    fun testIgnoreCacheUpdateOnProjectClose() {
+        // to check default ignore behaviour still works
+        val filePathToCheck = project.basePath + "/node_modules/1.js"
+        File(filePathToCheck).parentFile.mkdir()
+        File(filePathToCheck).createNewFile()
+
+        val psiFileToCheck = findPsiFile(filePathToCheck)
+        initiateAllMissedIgnoreFilesRescan()
+        assertTrue(
+            "Files inside `node_modules` should be excluded(ignored) by default",
+            SnykCodeIgnoreInfoHolder.instance.isIgnoredFile(psiFileToCheck)
+        )
+
+        PlatformTestUtil.forceCloseProjectWithoutSaving(project)
+        myProject = null // to avoid double disposing effort in tearDown
+
+        assertFalse(
+            "No files should be excluded(ignored) after Project closing -> caches cleanUp",
+            SnykCodeIgnoreInfoHolder.instance.isIgnoredFile(psiFileToCheck)
+        )
+    }
+
+    private fun findPsiFile(path: String): PsiFile {
+        val vFileToCheck = StandardFileSystems.local().refreshAndFindFileByPath(path)
+            ?: throw FileNotFoundException(path)
+        return psiManager.findFile(vFileToCheck)
+            ?: throw FileNotFoundException(path)
+    }
+}


### PR DESCRIPTION
- to fully match https://git-scm.com/docs/gitignore#_pattern_format and glob syntax rules (https://docs.oracle.com/javase/8/docs/api/java/nio/file/FileSystem.html#getPathMatcher-java.lang.String-);
- caches invalidation and re-parsing on those files change;
- generic .dcignore added on project opening if no .gitignore/.dcignore exist;
- functional tests for IgnoreInfoHolder related basic functionality.