### PR TITLE
fix: error when messageBus on disposed Project is called [ROADRUNNER-110]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [2.1.3]
 ### Changed
+- Fix errors on Project close while scan is running
 - Fix and improve .dcignore and .gitignore parsing and usage
 - Bugfix for `missing file parameter` exception
 

--- a/src/main/kotlin/io/snyk/plugin/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/Utils.kt
@@ -3,6 +3,7 @@ package io.snyk.plugin
 import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
+import com.intellij.util.messages.Topic
 import io.snyk.plugin.cli.Platform
 import io.snyk.plugin.services.SnykCliService
 import io.snyk.plugin.services.SnykApplicationSettingsStateService
@@ -25,6 +26,12 @@ fun getApplicationSettingsStateService(): SnykApplicationSettingsStateService = 
 fun getPluginPath() = PathManager.getPluginsPath() + "/snyk-intellij-plugin"
 
 fun isProjectSettingsAvailable(project: Project?) = nonNull(project) && !project!!.isDefault
+
+fun <L> getSyncPublisher(project: Project, topic: Topic<L>): L? {
+    val messageBus = project.messageBus
+    if (messageBus.isDisposed) return null
+    return messageBus.syncPublisher(topic)
+}
 
 val <T> List<T>.tail: List<T>
     get() = drop(1)

--- a/src/main/kotlin/io/snyk/plugin/services/SnykCodeService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykCodeService.kt
@@ -2,6 +2,8 @@ package io.snyk.plugin.services
 
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.project.Project
+import io.snyk.plugin.events.SnykScanListener
+import io.snyk.plugin.getSyncPublisher
 import io.snyk.plugin.snykcode.core.RunUtils
 import io.snyk.plugin.snykcode.core.SCLogger
 
@@ -14,5 +16,6 @@ class SnykCodeService(val project: Project) {
     fun scan() {
         SCLogger.instance.logInfo("Re-Analyse Project requested for: $project")
         RunUtils.instance.rescanInBackgroundCancellableDelayed(project, 0, false, false)
+        getSyncPublisher(project, SnykScanListener.SNYK_SCAN_TOPIC)?.scanningStarted()
     }
 }

--- a/src/main/kotlin/io/snyk/plugin/settings/SnykProjectSettingsConfigurable.kt
+++ b/src/main/kotlin/io/snyk/plugin/settings/SnykProjectSettingsConfigurable.kt
@@ -3,15 +3,12 @@ package io.snyk.plugin.settings
 import com.intellij.openapi.components.service
 import com.intellij.openapi.options.SearchableConfigurable
 import com.intellij.openapi.project.Project
+import io.snyk.plugin.*
 import io.snyk.plugin.events.SnykCliDownloadListener
-import io.snyk.plugin.getApplicationSettingsStateService
-import io.snyk.plugin.isProjectSettingsAvailable
-import io.snyk.plugin.isUrlValid
 import io.snyk.plugin.services.SnykAnalyticsService
 import io.snyk.plugin.services.SnykApplicationSettingsStateService
 import io.snyk.plugin.services.SnykProjectSettingsStateService
 import io.snyk.plugin.snykcode.core.SnykCodeParams
-import io.snyk.plugin.toSnykCodeApiUrl
 import io.snyk.plugin.ui.SnykSettingsDialog
 import io.snyk.plugin.ui.toolwindow.SnykToolWindowPanel
 import javax.swing.JComponent
@@ -63,7 +60,7 @@ class SnykProjectSettingsConfigurable(val project: Project) : SearchableConfigur
         }
 
         project.service<SnykToolWindowPanel>().cleanUiAndCaches()
-        project.messageBus.syncPublisher(SnykCliDownloadListener.CLI_DOWNLOAD_TOPIC).checkCliExistsFinished()
+        getSyncPublisher(project, SnykCliDownloadListener.CLI_DOWNLOAD_TOPIC)?.checkCliExistsFinished()
     }
 
     private fun isTokenModified(): Boolean =

--- a/src/main/kotlin/io/snyk/plugin/snykcode/core/PDU.kt
+++ b/src/main/kotlin/io/snyk/plugin/snykcode/core/PDU.kt
@@ -15,6 +15,7 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
 import io.snyk.plugin.cli.CliError
 import io.snyk.plugin.events.SnykScanListener
+import io.snyk.plugin.getSyncPublisher
 import io.snyk.plugin.ui.SnykBalloonNotifications
 import io.snyk.plugin.ui.toolwindow.SnykToolWindowPanel
 import java.util.function.Consumer
@@ -152,7 +153,7 @@ class PDU private constructor() : PlatformDependentUtilsBase() {
     override fun showWarn(message: String, project: Any?, wasWarnShown: Boolean) {
         runForProject(project, Consumer { prj ->
             SnykBalloonNotifications.showWarn(message, prj)
-            prj.messageBus.syncPublisher(SnykScanListener.SNYK_SCAN_TOPIC).scanningSnykCodeError(
+            getSyncPublisher(prj, SnykScanListener.SNYK_SCAN_TOPIC)?.scanningSnykCodeError(
                 CliError(false, message, prj.basePath ?: "")
             )
         })
@@ -161,7 +162,7 @@ class PDU private constructor() : PlatformDependentUtilsBase() {
     override fun showError(message: String, project: Any?) {
         runForProject(project, Consumer { prj ->
             SnykBalloonNotifications.showError(message, prj)
-            prj.messageBus.syncPublisher(SnykScanListener.SNYK_SCAN_TOPIC).scanningSnykCodeError(
+            getSyncPublisher(prj, SnykScanListener.SNYK_SCAN_TOPIC)?.scanningSnykCodeError(
                 CliError(false, message, prj.basePath ?: "")
             )
         })

--- a/src/main/kotlin/io/snyk/plugin/snykcode/core/RunUtils.kt
+++ b/src/main/kotlin/io/snyk/plugin/snykcode/core/RunUtils.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Computable
 import io.snyk.plugin.events.SnykScanListener
+import io.snyk.plugin.getSyncPublisher
 import io.snyk.plugin.snykcode.SnykCodeResults
 import java.util.function.Consumer
 
@@ -56,8 +57,6 @@ class RunUtils private constructor() : RunUtilsBase(
     override fun updateAnalysisResultsUIPresentation(projectAsAny: Any, files: Collection<Any>) {
         val project = PDU.toProject(projectAsAny)
         if (project.isDisposed) return
-        val cliScanPublisher =
-            project.messageBus.syncPublisher(SnykScanListener.SNYK_SCAN_TOPIC)
         val scanResults = if (files.isEmpty()) {
             SnykCodeResults()
         } else {
@@ -65,7 +64,7 @@ class RunUtils private constructor() : RunUtilsBase(
                 AnalysisData.instance.getAnalysis(files).mapKeys { PDU.toPsiFile(it.key) }
             )
         }
-        cliScanPublisher.scanningSnykCodeFinished(scanResults)
+        getSyncPublisher(project, SnykScanListener.SNYK_SCAN_TOPIC)?.scanningSnykCodeFinished(scanResults)
     }
 
     private class MyBackgroundable(project: Project, title: String, private val consumer: Consumer<Any>) :

--- a/src/main/kotlin/io/snyk/plugin/ui/actions/SnykTreeHighSeverityFilterAction.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/actions/SnykTreeHighSeverityFilterAction.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import icons.SnykIcons
 import io.snyk.plugin.events.SnykResultsFilteringListener
 import io.snyk.plugin.getApplicationSettingsStateService
+import io.snyk.plugin.getSyncPublisher
 
 class SnykTreeHighSeverityFilterAction: SnykTreeSeverityFilterActionBase() {
 
@@ -21,6 +22,6 @@ class SnykTreeHighSeverityFilterAction: SnykTreeSeverityFilterActionBase() {
         if (!state && isLastSeverityDisabling(e)) return
 
         getApplicationSettingsStateService().highSeverityEnabled = state
-        e.project!!.messageBus.syncPublisher(SnykResultsFilteringListener.SNYK_FILTERING_TOPIC).filtersChanged()
+        getSyncPublisher(e.project!!, SnykResultsFilteringListener.SNYK_FILTERING_TOPIC)?.filtersChanged()
     }
 }

--- a/src/main/kotlin/io/snyk/plugin/ui/actions/SnykTreeLowSeverityFilterAction.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/actions/SnykTreeLowSeverityFilterAction.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import icons.SnykIcons
 import io.snyk.plugin.events.SnykResultsFilteringListener
 import io.snyk.plugin.getApplicationSettingsStateService
+import io.snyk.plugin.getSyncPublisher
 
 class SnykTreeLowSeverityFilterAction: SnykTreeSeverityFilterActionBase() {
 
@@ -21,6 +22,6 @@ class SnykTreeLowSeverityFilterAction: SnykTreeSeverityFilterActionBase() {
         if (!state && isLastSeverityDisabling(e)) return
 
         getApplicationSettingsStateService().lowSeverityEnabled = state
-        e.project!!.messageBus.syncPublisher(SnykResultsFilteringListener.SNYK_FILTERING_TOPIC).filtersChanged()
+        getSyncPublisher(e.project!!, SnykResultsFilteringListener.SNYK_FILTERING_TOPIC)?.filtersChanged()
     }
 }

--- a/src/main/kotlin/io/snyk/plugin/ui/actions/SnykTreeMediumSeverityFilterAction.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/actions/SnykTreeMediumSeverityFilterAction.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import icons.SnykIcons
 import io.snyk.plugin.events.SnykResultsFilteringListener
 import io.snyk.plugin.getApplicationSettingsStateService
+import io.snyk.plugin.getSyncPublisher
 
 class SnykTreeMediumSeverityFilterAction: SnykTreeSeverityFilterActionBase() {
 
@@ -21,6 +22,6 @@ class SnykTreeMediumSeverityFilterAction: SnykTreeSeverityFilterActionBase() {
         if (!state && isLastSeverityDisabling(e)) return
 
         getApplicationSettingsStateService().mediumSeverityEnabled = state
-        e.project!!.messageBus.syncPublisher(SnykResultsFilteringListener.SNYK_FILTERING_TOPIC).filtersChanged()
+        getSyncPublisher(e.project!!, SnykResultsFilteringListener.SNYK_FILTERING_TOPIC)?.filtersChanged()
     }
 }

--- a/src/main/kotlin/io/snyk/plugin/ui/actions/SnykTreeScanTypeFilterAction.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/actions/SnykTreeScanTypeFilterAction.kt
@@ -5,10 +5,10 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.DefaultActionGroup
 import com.intellij.openapi.actionSystem.ToggleAction
 import com.intellij.openapi.actionSystem.ex.ComboBoxAction
-import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import io.snyk.plugin.events.SnykResultsFilteringListener
 import io.snyk.plugin.getApplicationSettingsStateService
+import io.snyk.plugin.getSyncPublisher
 import io.snyk.plugin.isSnykCodeAvailable
 import io.snyk.plugin.ui.SnykBalloonNotifications
 import javax.swing.JComponent
@@ -78,9 +78,7 @@ class SnykTreeScanTypeFilterAction : ComboBoxAction() {
     }
 
     private fun fireFiltersChangedEvent(project: Project) {
-        val filteringPublisher =
-            project.messageBus.syncPublisher(SnykResultsFilteringListener.SNYK_FILTERING_TOPIC)
-        filteringPublisher.filtersChanged()
+        getSyncPublisher(project, SnykResultsFilteringListener.SNYK_FILTERING_TOPIC)?.filtersChanged()
     }
 
     private fun isLastScanTypeDisabling(e: AnActionEvent): Boolean {

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/OnboardPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/OnboardPanel.kt
@@ -8,6 +8,7 @@ import io.snyk.plugin.analytics.EventPropertiesProvider
 import io.snyk.plugin.analytics.Segment
 import io.snyk.plugin.events.SnykCliDownloadListener.Companion.CLI_DOWNLOAD_TOPIC
 import io.snyk.plugin.getApplicationSettingsStateService
+import io.snyk.plugin.getSyncPublisher
 import io.snyk.plugin.services.SnykAnalyticsService
 import io.snyk.plugin.services.SnykTaskQueueService
 import io.snyk.plugin.snykcode.core.SnykCodeUtils
@@ -54,8 +55,8 @@ class OnboardPanel(project: Project) {
                     )
 
                     getApplicationSettingsStateService().pluginFirstRun = false
-                    project.messageBus.syncPublisher(CLI_DOWNLOAD_TOPIC).checkCliExistsFinished()
-                    project.getService(SnykTaskQueueService::class.java).scan()
+                    getSyncPublisher(project, CLI_DOWNLOAD_TOPIC)?.checkCliExistsFinished()
+                    project.service<SnykTaskQueueService>().scan()
                 }
             }
         }

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykAuthPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykAuthPanel.kt
@@ -7,6 +7,7 @@ import com.intellij.uiDesigner.core.GridLayoutManager
 import icons.SnykIcons
 import io.snyk.plugin.events.SnykCliDownloadListener.Companion.CLI_DOWNLOAD_TOPIC
 import io.snyk.plugin.getApplicationSettingsStateService
+import io.snyk.plugin.getSyncPublisher
 import io.snyk.plugin.services.SnykAnalyticsService
 import io.snyk.plugin.services.SnykCliAuthenticationService
 import io.snyk.plugin.snykcode.core.SnykCodeParams
@@ -63,8 +64,7 @@ class SnykAuthPanel(project: Project) : JPanel() {
                 val userId = analytics.obtainUserId(token)
                 analytics.alias(userId)
 
-                project.messageBus.syncPublisher(CLI_DOWNLOAD_TOPIC)
-                    .checkCliExistsFinished()
+                getSyncPublisher(project, CLI_DOWNLOAD_TOPIC)?.checkCliExistsFinished()
             }
         })
 

--- a/src/test/kotlin/io/snyk/plugin/services/SnykTaskQueueServiceTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/services/SnykTaskQueueServiceTest.kt
@@ -2,6 +2,7 @@ package io.snyk.plugin.services
 
 import com.intellij.openapi.components.service
 import com.intellij.testFramework.LightPlatformTestCase
+import com.intellij.testFramework.PlatformTestUtil
 import io.snyk.plugin.cli.ConsoleCommandRunner
 import io.snyk.plugin.getCli
 import io.snyk.plugin.getCliFile
@@ -34,5 +35,16 @@ class SnykTaskQueueServiceTest : LightPlatformTestCase() {
         assertTrue(snykTaskQueueService.getTaskQueue().isEmpty)
 
         assertNull(snykTaskQueueService.getCurrentProgressIndicator())
+    }
+
+    @Test
+    fun testProjectClosedWhileTaskRunning() {
+        val snykTaskQueueService = project.service<SnykTaskQueueService>()
+
+        PlatformTestUtil.forceCloseProjectWithoutSaving(project)
+        setProject(null) // to avoid double disposing effort in tearDown
+
+        // the Task should roll out gracefully without any Exception or Error
+        snykTaskQueueService.downloadLatestRelease()
     }
 }


### PR DESCRIPTION
Same thing is needed for every `project.service<>()` call in any background task (due to Project could be disposed anytime before our code invocation) 
And probably for most(all?) Project method call. 
Will be handled in other PRs