### PR TITLE
fix: mark obsolete CLI result when cache dropped [ROADRUNNER-120]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [2.1.3]
 ### Changed
+- Show OSS results as `obsolete` when it's outdated
 - Fix errors on Project close while scan is running
 - Fix and improve .dcignore and .gitignore parsing and usage
 - Bugfix for `missing file parameter` exception

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/FileTreeNode.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/FileTreeNode.kt
@@ -1,7 +1,10 @@
 package io.snyk.plugin.ui.toolwindow
 
+import com.intellij.openapi.project.Project
 import io.snyk.plugin.cli.CliVulnerabilitiesForFile
 import javax.swing.tree.DefaultMutableTreeNode
 
-class FileTreeNode(cliVulnerabilitiesForFile: CliVulnerabilitiesForFile)
-    : DefaultMutableTreeNode(cliVulnerabilitiesForFile)
+class FileTreeNode(
+    cliVulnerabilitiesForFile: CliVulnerabilitiesForFile,
+    val project: Project
+) : DefaultMutableTreeNode(cliVulnerabilitiesForFile)

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
@@ -490,14 +490,14 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
                 if (cliVulnerabilitiesForFile.vulnerabilities.isNotEmpty()) {
                     val cliGroupedResult = cliVulnerabilitiesForFile.toCliGroupedResult()
 
-                    val fileTreeNode = FileTreeNode(cliVulnerabilitiesForFile)
+                    val fileTreeNode = FileTreeNode(cliVulnerabilitiesForFile, project)
                     rootCliTreeNode.add(fileTreeNode)
 
                     cliGroupedResult.id2vulnerabilities.values
                         .filter { isSeverityFilterPassed(it.head.severity) }
                         .sortedByDescending { it.head.getSeverityIndex() }
                         .forEach {
-                            fileTreeNode.add(VulnerabilityTreeNode(it))
+                            fileTreeNode.add(VulnerabilityTreeNode(it, project))
                         }
                 }
             }

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/VulnerabilityTreeCellRenderer.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/VulnerabilityTreeCellRenderer.kt
@@ -1,6 +1,7 @@
 package io.snyk.plugin.ui.toolwindow
 
 import ai.deepcode.javaclient.core.SuggestionForFile
+import com.intellij.openapi.components.service
 import com.intellij.openapi.util.Iconable
 import com.intellij.psi.PsiFile
 import com.intellij.ui.ColoredTreeCellRenderer
@@ -37,12 +38,24 @@ class VulnerabilityTreeCellRenderer : ColoredTreeCellRenderer() {
                 val vulnerability = (value.userObject as Collection<Vulnerability>).first()
                 nodeIcon = SnykIcons.getSeverityIcon(vulnerability.severity)
                 text = vulnerability.getPackageNameTitle()
+
+                val toolWindowPanel = value.project.service<SnykToolWindowPanel>()
+                if (toolWindowPanel.currentCliResults == null) {
+                    attributes = SimpleTextAttributes.GRAYED_ATTRIBUTES
+                    nodeIcon = getDisabledIcon(nodeIcon)
+                }
             }
             is FileTreeNode -> {
                 val cliVulnerabilitiesForFile = value.userObject as CliVulnerabilitiesForFile
                 nodeIcon = PackageManagerIconProvider.getIcon(cliVulnerabilitiesForFile.packageManager.toLowerCase())
                 text = cliVulnerabilitiesForFile.displayTargetFile
-                // todo: mark obsolete results
+
+                val toolWindowPanel = value.project.service<SnykToolWindowPanel>()
+                if (toolWindowPanel.currentCliResults == null) {
+                    attributes = SimpleTextAttributes.GRAYED_ATTRIBUTES
+                    text += " (obsolete)"
+                    nodeIcon = getDisabledIcon(nodeIcon)
+                }
             }
             is SuggestionTreeNode -> {
                 val (suggestion, index) = value.userObject as Pair<SuggestionForFile, Int>

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/VulnerabilityTreeNode.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/VulnerabilityTreeNode.kt
@@ -1,6 +1,10 @@
 package io.snyk.plugin.ui.toolwindow
 
+import com.intellij.openapi.project.Project
 import io.snyk.plugin.cli.Vulnerability
 import javax.swing.tree.DefaultMutableTreeNode
 
-class VulnerabilityTreeNode(groupedVulns: Collection<Vulnerability>) : DefaultMutableTreeNode(groupedVulns)
+class VulnerabilityTreeNode(
+    groupedVulns: Collection<Vulnerability>,
+    val project: Project
+) : DefaultMutableTreeNode(groupedVulns)


### PR DESCRIPTION
UI presentation fix: Show OSS results as `obsolete` when it's outdated