### PR TITLE
fix: consider 'ignoreUnknownCA' option for Snyk Code API client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Snyk Vulnerability Scanner Changelog
 
+## [2.1.4]
+### Fixed
+- Consider `ignoreUnknownCA` option for Snyk Code
+
 ## [2.1.3]
 ### Changed
 - Show OSS results as `obsolete` when it's outdated

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
   implementation("com.atlassian.commonmark:commonmark:0.15.2")
   implementation("com.google.code.gson:gson:2.8.6")
   implementation("com.segment.analytics.java:analytics:+")
-  implementation("io.snyk.code.sdk:snyk-code-client:2.1.9")
+  implementation("io.snyk.code.sdk:snyk-code-client:2.1.10")
 
   testImplementation("junit:junit:4.13") {
     exclude(group = "org.hamcrest")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion=2.1.3
+pluginVersion=2.1.4-rc.1
 pluginSinceBuild=202
 pluginUntilBuild=211.*
 #

--- a/src/main/kotlin/io/snyk/plugin/settings/SnykProjectSettingsConfigurable.kt
+++ b/src/main/kotlin/io/snyk/plugin/settings/SnykProjectSettingsConfigurable.kt
@@ -44,6 +44,7 @@ class SnykProjectSettingsConfigurable(val project: Project) : SearchableConfigur
 
         applicationSettingsStateService.customEndpointUrl = customEndpoint
         SnykCodeParams.instance.apiUrl = toSnykCodeApiUrl(customEndpoint)
+        SnykCodeParams.instance.isDisableSslVerification = snykSettingsDialog.isIgnoreUnknownCA()
 
         applicationSettingsStateService.token = snykSettingsDialog.getToken()
         SnykCodeParams.instance.sessionToken = snykSettingsDialog.getToken()

--- a/src/main/kotlin/io/snyk/plugin/snykcode/core/SnykCodeParams.kt
+++ b/src/main/kotlin/io/snyk/plugin/snykcode/core/SnykCodeParams.kt
@@ -8,6 +8,7 @@ class SnykCodeParams private constructor() : DeepCodeParamsBase(
     true,
     "ignored - will be set in init{}",
     false,
+    false,
     1,
     getApplicationSettingsStateService().token,
     "",
@@ -15,7 +16,7 @@ class SnykCodeParams private constructor() : DeepCodeParamsBase(
 ) {
 
     init {
-        apiUrl = toSnykCodeApiUrl(getApplicationSettingsStateService().customEndpointUrl)
+        setApiUrl(toSnykCodeApiUrl(getApplicationSettingsStateService().customEndpointUrl), getApplicationSettingsStateService().ignoreUnknownCA)
     }
 
     override fun consentGiven(project: Any): Boolean {


### PR DESCRIPTION
This PR respects 'ignore unknown CA' option (sams as `--insecure` for CLI) for Snyk Code API client.
Related PR: https://github.com/snyk/code-sdk-java/pull/24