### PR TITLE
fix: set maximal attempts for ask for sast feature

### DIFF
--- a/src/main/kotlin/io/snyk/plugin/ui/settings/ScanTypesPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/settings/ScanTypesPanel.kt
@@ -84,14 +84,17 @@ class ScanTypesPanel(
                         url = getSnykCodeSettingsUrl(),
                         forceShow = true)
 
-                    // check sastEnablement every 1 sec.
+                    // check sastEnablement every 2 sec.
+                    var currentAttempt = 1
+                    val maxAttempts = 20
                     lateinit var checkIfSastEnabled: () -> Unit
                     checkIfSastEnabled = {
                         settings.sastOnServerEnabled = service<SnykApiService>().sastOnServerEnabled ?: false
                         if (settings.sastOnServerEnabled) {
                             doShowFilesToUpload()
-                        } else if (!alarm.isDisposed) {
-                            alarm.addRequest(checkIfSastEnabled, 1000)
+                        } else if (!alarm.isDisposed && currentAttempt < maxAttempts) {
+                            currentAttempt++;
+                            alarm.addRequest(checkIfSastEnabled, 2000)
                         }
                     }
                     checkIfSastEnabled.invoke()


### PR DESCRIPTION
This PR fix the issue with infinite loop to ask API for enabling/disabling SAST feature. Maximal attempt count is 20.