### PR TITLE
fix: network related exceptions and notifications. Related to [ROAD-35]

### DIFF
--- a/src/main/kotlin/io/snyk/plugin/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/Utils.kt
@@ -70,14 +70,15 @@ fun toSnykCodeApiUrl(customEndpointUrl: String?): String =
     if (customEndpointUrl != null && isSnykCodeSupportedEndpoint(customEndpointUrl)) {
         customEndpointUrl
             .replace("https://", "https://deeproxy.")
+            .removeTrailingSlashes()
             .removeSuffix("api")
     } else {
         "https://deeproxy.snyk.io/"
     }
 
 private fun isSnykCodeSupportedEndpoint(customEndpointUrl: String) =
-    customEndpointUrl == "https://dev.snyk.io/api" ||
-    customEndpointUrl == "https://snyk.io/api"
+    customEndpointUrl.removeTrailingSlashes() == "https://dev.snyk.io/api" ||
+    customEndpointUrl.removeTrailingSlashes() == "https://snyk.io/api"
 
 fun getSnykCodeSettingsUrl(): String {
     val endpoint = getApplicationSettingsStateService().customEndpointUrl
@@ -87,8 +88,10 @@ fun getSnykCodeSettingsUrl(): String {
         endpoint
             // example: https://snyk.io/api/ -> https://app.snyk.io
             .replace("https://", "https://app.")
-            .replace(Regex("/+$"), "") // remove trailing slashes if any
+            .removeTrailingSlashes()
             .removeSuffix("/api")
     }
     return "$baseUrl/manage/snyk-code"
 }
+
+private fun String.removeTrailingSlashes() : String = this.replace( Regex("/+$"), "")

--- a/src/main/kotlin/io/snyk/plugin/net/SnykApiClient.kt
+++ b/src/main/kotlin/io/snyk/plugin/net/SnykApiClient.kt
@@ -33,6 +33,7 @@ class SnykApiClient constructor(
         return userServiceEndpoint
     }
     private fun <T> executeRequest(apiName: String, retrofitCall: Call<T>): T? = try {
+        log.debug("Executing request to $apiName")
         val response = retrofitCall.execute()
         if (!response.isSuccessful) {
             log.warn("Failed to execute `$apiName` call: ${response.errorBody()?.string()}")

--- a/src/main/kotlin/io/snyk/plugin/net/SnykApiClient.kt
+++ b/src/main/kotlin/io/snyk/plugin/net/SnykApiClient.kt
@@ -39,7 +39,7 @@ class SnykApiClient constructor(
         }
         response.body()
     } catch (t: Throwable) {
-        log.error("Failed to execute '$apiName' network request. ${t.message}", t)
+        log.warn("Failed to execute '$apiName' network request: ${t.message}", t)
         null
     }
 

--- a/src/main/kotlin/io/snyk/plugin/services/SnykAnalyticsService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykAnalyticsService.kt
@@ -40,7 +40,12 @@ class SnykAnalyticsService : Disposable {
             log.warn("Token is null or empty, user public id will not be obtained.")
             return ""
         }
-        return service<SnykApiService>().userId ?: ""
+        val userId = service<SnykApiService>().userId
+        if (userId == null) {
+            log.warn("Not able to obtain User public id.")
+            return ""
+        }
+        return userId
     }
 
     fun identify() {
@@ -59,7 +64,7 @@ class SnykAnalyticsService : Disposable {
         try {
             action()
         } catch (t: Throwable) {
-            log.error("Failed to execute '$message' analytic event. ${t.message}", t)
+            log.warn("Failed to execute '$message' analytic event. ${t.message}", t)
         }
     }
 }

--- a/src/main/kotlin/io/snyk/plugin/services/SnykApiService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykApiService.kt
@@ -82,11 +82,11 @@ class SnykApiService: Disposable {
             val retrofit = try {
                 createRetrofit(
                     token = appSettings.token ?: "",
-                    baseUrl = endpoint,
+                    baseUrl = if (endpoint.endsWith('/')) endpoint else "$endpoint/",
                     disableSslVerification = appSettings.ignoreUnknownCA
                 )
-            } catch (e: Exception) {
-                log.warn("Failed to create Retrofit client for endpoint: $endpoint", e)
+            } catch (t: Throwable) {
+                log.warn("Failed to create Retrofit client for endpoint: $endpoint", t)
                 return null
             }
             return SnykApiClient(retrofit)

--- a/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
@@ -26,7 +26,7 @@ class SnykApplicationSettingsStateService : PersistentStateComponent<SnykApplica
     var cliScanEnable: Boolean = true
     var snykCodeSecurityIssuesScanEnable: Boolean = true
     var snykCodeQualityIssuesScanEnable: Boolean = false
-    var sastOnServerEnabled = false
+    var sastOnServerEnabled: Boolean? = null
     var usageAnalyticsEnabled = true
 
     var lowSeverityEnabled = true

--- a/src/main/kotlin/io/snyk/plugin/ui/SnykBalloonNotifications.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/SnykBalloonNotifications.kt
@@ -12,9 +12,11 @@ import com.intellij.openapi.ui.popup.Balloon
 import com.intellij.openapi.ui.popup.JBPopupFactory
 import com.intellij.ui.LightColors
 import com.intellij.ui.awt.RelativePoint
+import com.intellij.util.Alarm
 import io.snyk.plugin.getApplicationSettingsStateService
 import io.snyk.plugin.getSnykCodeSettingsUrl
 import io.snyk.plugin.settings.SnykProjectSettingsConfigurable
+import io.snyk.plugin.startSastEnablementCheckLoop
 import java.awt.Point
 
 class SnykBalloonNotifications {
@@ -25,6 +27,8 @@ class SnykBalloonNotifications {
         private const val groupAutoHide = "SnykAutoHide"
         private val GROUP = NotificationGroup(groupNeedAction, NotificationDisplayType.STICKY_BALLOON)
 
+        private val alarm = Alarm()
+
         fun showError(message: String, project: Project, vararg actions: AnAction) =
             showNotification(message, project, NotificationType.ERROR, *actions)
 
@@ -34,7 +38,7 @@ class SnykBalloonNotifications {
         fun showWarn(message: String, project: Project, vararg actions: AnAction) =
             showNotification(message, project, NotificationType.WARNING, *actions)
 
-        private fun showNotification(message: String, project: Project, type: NotificationType, vararg actions: AnAction) {
+        private fun showNotification(message: String, project: Project, type: NotificationType, vararg actions: AnAction): Notification {
             val notification = if (actions.isEmpty()) {
                 Notification(groupAutoHide, title, message, type)
             } else {
@@ -43,15 +47,33 @@ class SnykBalloonNotifications {
                 }
             }
             notification.notify(project)
+            return notification
         }
 
-        fun showSastForOrgEnablement(project: Project) = showInfo(
-            "Snyk Code is disabled by your organisation's configuration. To enable navigate to ",
-            project,
-            NotificationAction.createSimpleExpiring("Snyk > Settings > Snyk Code") {
-                BrowserUtil.browse(getSnykCodeSettingsUrl())
+        fun showSastForOrgEnablement(project: Project): Notification {
+            val notification = showInfo(
+                "Snyk Code is disabled by your organisation's configuration. To enable navigate to ",
+                project,
+                NotificationAction.createSimpleExpiring("Snyk > Settings > Snyk Code") {
+                    BrowserUtil.browse(getSnykCodeSettingsUrl())
+                    startSastEnablementCheckLoop(project)
+                }
+            )
+            var currentAttempt = 1
+            val maxAttempts = 200
+            lateinit var checkIfSastEnabled: () -> Unit
+            checkIfSastEnabled = {
+                if (getApplicationSettingsStateService().sastOnServerEnabled == true) {
+                    notification.expire()
+                } else if (!alarm.isDisposed && currentAttempt < maxAttempts) {
+                    currentAttempt++;
+                    alarm.addRequest(checkIfSastEnabled, 1000)
+                }
             }
-        )
+            checkIfSastEnabled.invoke()
+
+            return notification
+        }
 
         fun showFeedbackRequest(project: Project) = showInfo(
             "Take part in Snyk's plugin research and get a \$100 Amazon gift card!",

--- a/src/main/kotlin/io/snyk/plugin/ui/SnykBalloonNotifications.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/SnykBalloonNotifications.kt
@@ -6,6 +6,7 @@ import com.intellij.notification.*
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.PlatformDataKeys.CONTEXT_COMPONENT
+import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.popup.Balloon
 import com.intellij.openapi.ui.popup.JBPopupFactory
@@ -13,6 +14,7 @@ import com.intellij.ui.LightColors
 import com.intellij.ui.awt.RelativePoint
 import io.snyk.plugin.getApplicationSettingsStateService
 import io.snyk.plugin.getSnykCodeSettingsUrl
+import io.snyk.plugin.settings.SnykProjectSettingsConfigurable
 import java.awt.Point
 
 class SnykBalloonNotifications {
@@ -60,6 +62,15 @@ class SnykBalloonNotifications {
             },
             NotificationAction.createSimpleExpiring("Don’t show again") {
                 getApplicationSettingsStateService().showFeedbackRequest = false
+            }
+        )
+
+        fun showNetworkErrorAlert(project: Project) = showError(
+            "Not able to connect to Snyk server. Check connection and network settings.",
+            project,
+            NotificationAction.createSimpleExpiring("Snyk Settings") {
+                ShowSettingsUtil.getInstance()
+                    .showSettingsDialog(project, SnykProjectSettingsConfigurable::class.java)
             }
         )
 

--- a/src/main/kotlin/io/snyk/plugin/ui/SnykSettingsDialog.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/SnykSettingsDialog.kt
@@ -425,14 +425,6 @@ class SnykSettingsDialog(
             } else {
                 ValidationInfo("")
             }
-            // disable SnykCode if custom endpoint is used
-            if (textField == customEndpointTextField) {
-                val snykCodeEnabled = isSnykCodeAvailable(textField.text)
-                scanTypesPanelOuter.setSnykCodeAvailability(snykCodeEnabled)
-                scanTypesPanelOuter.showSnykCodeAlert(
-                    if (snykCodeEnabled) "" else "Snyk Code only works in SAAS mode for the time being (i.e. no Custom Endpoint usage)"
-                )
-            }
             validationInfo
         }).installOn(textField)
 

--- a/src/main/kotlin/io/snyk/plugin/ui/UIUtils.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/UIUtils.kt
@@ -93,6 +93,6 @@ fun buildTextAreaWithLabelPanel(title: String, text: String): JPanel {
 
 fun snykCodeAvailabilityPostfix(): String = when {
     !isSnykCodeAvailable(getApplicationSettingsStateService().customEndpointUrl) -> " (disabled for endpoint)"
-    !getApplicationSettingsStateService().sastOnServerEnabled -> " (disabled for organization)"
+    !(getApplicationSettingsStateService().sastOnServerEnabled ?: false) -> " (disabled for organization)"
     else -> ""
 }

--- a/src/main/kotlin/io/snyk/plugin/ui/actions/SnykTreeScanTypeFilterAction.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/actions/SnykTreeScanTypeFilterAction.kt
@@ -52,7 +52,7 @@ class SnykTreeScanTypeFilterAction : ComboBoxAction() {
     }
 
     private fun isSnykCodeAvailable(): Boolean =
-        isSnykCodeAvailable(settings.customEndpointUrl) && settings.sastOnServerEnabled
+        isSnykCodeAvailable(settings.customEndpointUrl) && (settings.sastOnServerEnabled ?: false)
 
     private fun showSettings(project: Project) {
         ShowSettingsUtil.getInstance().showSettingsDialog(project, SnykProjectSettingsConfigurable::class.java)

--- a/src/test/kotlin/io/snyk/plugin/services/SnykTaskQueueServiceTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/services/SnykTaskQueueServiceTest.kt
@@ -60,18 +60,13 @@ class SnykTaskQueueServiceTest : LightPlatformTestCase() {
         settings.snykCodeSecurityIssuesScanEnable = true
         settings.snykCodeQualityIssuesScanEnable = true
 
-        val mockRunner = Mockito.mock(SnykApiService::class.java)
-        Mockito
-            .`when`(mockRunner.sastOnServerEnabled)
-            .thenReturn(false)
-
         snykTaskQueueService.scan()
         // needed due to luck of disposing services by Idea test framework (bug?)
         Disposer.dispose(service<SnykApiService>())
 
-        assertTrue(!settings.sastOnServerEnabled)
-        assertTrue(!settings.snykCodeSecurityIssuesScanEnable)
-        assertTrue(!settings.snykCodeQualityIssuesScanEnable)
+        assertNull(settings.sastOnServerEnabled)
+        assertFalse(settings.snykCodeSecurityIssuesScanEnable)
+        assertFalse(settings.snykCodeQualityIssuesScanEnable)
 
     }
 }


### PR DESCRIPTION
- Should fix https://snyk.zendesk.com/agent/tickets/10881
- Explicit notification to the user in case of connection/network errors
- Unification for option/condition checks:
  - ~~Change sastEnable check from check in loop to explicit user's check to avoid servers overload and time outing for slow users~~ loop start only after link to SnykCode option web page opened
  - Change "endpoint support" check from endpoint field listener to explicit user's check to avoid collisions with other checks