### PR TITLE
fix: welcome(onboarding) screen simplification by removing interactive alerts [ROAD-164]

### DIFF
--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/OnboardPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/OnboardPanel.kt
@@ -22,7 +22,7 @@ class OnboardPanel(project: Project) {
         return@lazy ScanTypesPanel(
             project,
             disposable,
-            snykCodeQualityIssueCheckboxVisible = false
+            simplifyForOnboardPanel = true
         ).panel
     }
 


### PR DESCRIPTION
Depending on sastEnable flag on server user will see:
![image](https://user-images.githubusercontent.com/14268320/123053991-1bbd8280-d40d-11eb-9925-5481ee31bf90.png)
![image](https://user-images.githubusercontent.com/14268320/123054073-2d9f2580-d40d-11eb-9ea2-f7e2cadd07ea.png)
