### PR TITLE
fix: welcome and auth screen was missed to display [ROAD-175]

### DIFF
--- a/src/main/kotlin/io/snyk/plugin/events/SnykSettingsListener.kt
+++ b/src/main/kotlin/io/snyk/plugin/events/SnykSettingsListener.kt
@@ -1,0 +1,13 @@
+package io.snyk.plugin.events
+
+import com.intellij.util.messages.Topic
+
+interface SnykSettingsListener {
+    companion object {
+        val SNYK_SETTINGS_TOPIC =
+            Topic.create("Snyk Settings changed", SnykSettingsListener::class.java)
+    }
+
+    fun settingsChanged()
+
+}

--- a/src/main/kotlin/io/snyk/plugin/settings/SnykProjectSettingsConfigurable.kt
+++ b/src/main/kotlin/io/snyk/plugin/settings/SnykProjectSettingsConfigurable.kt
@@ -4,7 +4,7 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.options.SearchableConfigurable
 import com.intellij.openapi.project.Project
 import io.snyk.plugin.*
-import io.snyk.plugin.events.SnykCliDownloadListener
+import io.snyk.plugin.events.SnykSettingsListener
 import io.snyk.plugin.services.SnykAnalyticsService
 import io.snyk.plugin.services.SnykApplicationSettingsStateService
 import io.snyk.plugin.services.SnykProjectSettingsStateService
@@ -61,7 +61,7 @@ class SnykProjectSettingsConfigurable(val project: Project) : SearchableConfigur
         }
 
         project.service<SnykToolWindowPanel>().cleanUiAndCaches()
-        getSyncPublisher(project, SnykCliDownloadListener.CLI_DOWNLOAD_TOPIC)?.checkCliExistsFinished()
+        getSyncPublisher(project, SnykSettingsListener.SNYK_SETTINGS_TOPIC)?.settingsChanged()
     }
 
     private fun isTokenModified(): Boolean =

--- a/src/main/kotlin/io/snyk/plugin/ui/actions/SnykRunScanAction.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/actions/SnykRunScanAction.kt
@@ -29,8 +29,9 @@ class SnykRunScanAction : AnAction(AllIcons.Actions.Execute), DumbAware {
     override fun update(actionEvent: AnActionEvent) {
         val project = actionEvent.project
         if (project != null && !project.isDisposed) {
+            val settings = getApplicationSettingsStateService()
             actionEvent.presentation.isEnabled =
-                !isScanRunning(project) && !getApplicationSettingsStateService().pluginFirstRun
+                !isScanRunning(project) && !settings.pluginFirstRun && !settings.token.isNullOrEmpty()
         }
     }
 }

--- a/src/main/kotlin/io/snyk/plugin/ui/settings/ScanTypesPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/settings/ScanTypesPanel.kt
@@ -130,19 +130,19 @@ class ScanTypesPanel(
         setSnykCodeAvailability(true)
         showSnykCodeAlert("")
         setSnykCodeComment("Checking number of files to be uploaded...") {
-            getUploadingFilesMessage(false)
+            getUploadingFilesMessage()
         }
     }
 
     private fun shouldSnykCodeCommentBeVisible() =
         snykCodeCheckbox?.isSelected == true || snykCodeQualityCheckbox?.isSelected == true
 
-    private fun getUploadingFilesMessage(scanAllMissedIgnoreFile: Boolean = false): String {
+    private fun getUploadingFilesMessage(): String {
         val allSupportedFilesInProject =
-            SnykCodeUtils.instance.getAllSupportedFilesInProject(project, scanAllMissedIgnoreFile, null)
+            SnykCodeUtils.instance.getAllSupportedFilesInProject(project, true, null)
         val allSupportedFilesCount = allSupportedFilesInProject.size
         val allFilesCount = SnykCodeUtils.instance.allProjectFilesCount(project)
-        return "We will upload and analyze up to $allSupportedFilesCount files " +
+        return "We will upload and analyze $allSupportedFilesCount files " +
             "(${(100.0 * allSupportedFilesCount / allFilesCount).toInt()}%)" +
             " out of $allFilesCount files"
     }

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/OnboardPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/OnboardPanel.kt
@@ -7,7 +7,7 @@ import com.intellij.ui.layout.panel
 import icons.SnykIcons
 import io.snyk.plugin.analytics.EventPropertiesProvider
 import io.snyk.plugin.analytics.Segment
-import io.snyk.plugin.events.SnykCliDownloadListener.Companion.CLI_DOWNLOAD_TOPIC
+import io.snyk.plugin.events.SnykSettingsListener
 import io.snyk.plugin.getApplicationSettingsStateService
 import io.snyk.plugin.getSyncPublisher
 import io.snyk.plugin.services.SnykAnalyticsService
@@ -53,7 +53,7 @@ class OnboardPanel(project: Project) {
                     )
 
                     getApplicationSettingsStateService().pluginFirstRun = false
-                    getSyncPublisher(project, CLI_DOWNLOAD_TOPIC)?.checkCliExistsFinished()
+                    getSyncPublisher(project, SnykSettingsListener.SNYK_SETTINGS_TOPIC)?.settingsChanged()
                     project.service<SnykTaskQueueService>().scan()
                 }
             }

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykAuthPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykAuthPanel.kt
@@ -5,7 +5,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.uiDesigner.core.GridConstraints
 import com.intellij.uiDesigner.core.GridLayoutManager
 import icons.SnykIcons
-import io.snyk.plugin.events.SnykCliDownloadListener.Companion.CLI_DOWNLOAD_TOPIC
+import io.snyk.plugin.events.SnykSettingsListener
 import io.snyk.plugin.getApplicationSettingsStateService
 import io.snyk.plugin.getSyncPublisher
 import io.snyk.plugin.services.SnykAnalyticsService
@@ -64,7 +64,7 @@ class SnykAuthPanel(project: Project) : JPanel() {
                 val userId = analytics.obtainUserId(token)
                 analytics.alias(userId)
 
-                getSyncPublisher(project, CLI_DOWNLOAD_TOPIC)?.checkCliExistsFinished()
+                getSyncPublisher(project, SnykSettingsListener.SNYK_SETTINGS_TOPIC)?.settingsChanged()
             }
         })
 


### PR DESCRIPTION
fix: welcome and auth screen was missed to display if toolWindow was closed when project opening
fix: Run action availability before auth passed