### PR TITLE
chore: move getting plugin info into utility class

### DIFF
--- a/src/integTest/kotlin/io/snyk/plugin/cli/ConsoleCommandRunnerTest.kt
+++ b/src/integTest/kotlin/io/snyk/plugin/cli/ConsoleCommandRunnerTest.kt
@@ -3,15 +3,20 @@ package io.snyk.plugin.cli
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.openapi.components.service
+import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.progress.EmptyProgressIndicator
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.progress.impl.CoreProgressManager
 import com.intellij.testFramework.LightPlatformTestCase
-import io.snyk.plugin.*
+import io.snyk.plugin.getApplicationSettingsStateService
+import io.snyk.plugin.getCli
+import io.snyk.plugin.getCliFile
+import io.snyk.plugin.getPluginPath
 import io.snyk.plugin.services.SnykCliDownloaderService
 import org.junit.Test
+import snyk.PLUGIN_ID
 import java.util.concurrent.TimeUnit
 
 class ConsoleCommandRunnerTest : LightPlatformTestCase() {
@@ -26,13 +31,9 @@ class ConsoleCommandRunnerTest : LightPlatformTestCase() {
     @Test
     fun testSetupCliEnvironmentVariables() {
         val generalCommandLine = GeneralCommandLine("")
+        val snykPluginVersion = PluginManagerCore.getPlugin(PluginId.getId(PLUGIN_ID))?.version ?: "UNKNOWN"
 
         ConsoleCommandRunner().setupCliEnvironmentVariables(generalCommandLine, "test-api-token")
-
-        val snykPluginVersion: String by lazy {
-            val featureTrainerPluginId = PluginManagerCore.getPluginByClassName(SnykPostStartupActivity::class.java.name)
-            PluginManagerCore.getPlugin(featureTrainerPluginId)?.version ?: "UNKNOWN"
-        }
 
         assertEquals("test-api-token", generalCommandLine.environment["SNYK_TOKEN"])
         assertEquals("JETBRAINS_IDE", generalCommandLine.environment["SNYK_INTEGRATION_NAME"])
@@ -40,7 +41,6 @@ class ConsoleCommandRunnerTest : LightPlatformTestCase() {
         assertEquals("INTELLIJ IDEA IC", generalCommandLine.environment["SNYK_INTEGRATION_ENVIRONMENT"])
         assertEquals("2020.2", generalCommandLine.environment["SNYK_INTEGRATION_ENVIRONMENT_VERSION"])
     }
-
 
     @Test
     fun testCommandExecutionRequestWhileCliIsDownloading() {
@@ -68,11 +68,17 @@ class ConsoleCommandRunnerTest : LightPlatformTestCase() {
                     while (!cliFile.exists()) {
                         Thread.sleep(10) // lets wait till actual download begin
                     }
-                    assertTrue("Downloading of CLI should be in progress at this stage.", snykCliDownloaderService.isCliDownloading())
+                    assertTrue(
+                        "Downloading of CLI should be in progress at this stage.",
+                        snykCliDownloaderService.isCliDownloading()
+                    )
                     // No exception should happened while CLI is downloading and any CLI command is invoked
                     val commands = getCli(project).buildCliCommandsList(getApplicationSettingsStateService())
                     val output = ConsoleCommandRunner().execute(commands, getPluginPath(), "", project)
-                    assertTrue("Should be NO output for CLI command while CLI is downloading, but received:\n$output", output.isEmpty())
+                    assertTrue(
+                        "Should be NO output for CLI command while CLI is downloading, but received:\n$output",
+                        output.isEmpty()
+                    )
                 }
             },
             EmptyProgressIndicator(),
@@ -81,5 +87,4 @@ class ConsoleCommandRunnerTest : LightPlatformTestCase() {
 
         testRunFuture.get(5000, TimeUnit.MILLISECONDS)
     }
-
 }

--- a/src/main/kotlin/io/snyk/plugin/cli/ConsoleCommandRunner.kt
+++ b/src/main/kotlin/io/snyk/plugin/cli/ConsoleCommandRunner.kt
@@ -6,24 +6,17 @@ import com.intellij.execution.process.OSProcessHandler
 import com.intellij.execution.process.ProcessAdapter
 import com.intellij.execution.process.ProcessEvent
 import com.intellij.execution.process.ScriptRunnerUtil
-import com.intellij.ide.plugins.PluginManagerCore
-import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Key
-import io.snyk.plugin.SnykPostStartupActivity
-import io.snyk.plugin.ui.SnykBalloonNotifications
 import io.snyk.plugin.controlExternalProcessWithProgressIndicator
+import io.snyk.plugin.ui.SnykBalloonNotifications
 import org.apache.log4j.Logger
+import snyk.pluginInfo
 import java.nio.charset.Charset
 
 open class ConsoleCommandRunner {
     private val logger: Logger = Logger.getLogger(ConsoleCommandRunner::class.java)
-
-    private val snykPluginVersion: String by lazy {
-        val featureTrainerPluginId = PluginManagerCore.getPluginByClassName(SnykPostStartupActivity::class.java.name)
-        PluginManagerCore.getPlugin(featureTrainerPluginId)?.version ?: "UNKNOWN"
-    }
 
     open fun execute(
         commands: List<String>,
@@ -79,18 +72,10 @@ open class ConsoleCommandRunner {
             generalCommandLine.environment["SNYK_TOKEN"] = apiToken
         }
 
-        generalCommandLine.environment["SNYK_INTEGRATION_NAME"] = "JETBRAINS_IDE"
-        generalCommandLine.environment["SNYK_INTEGRATION_VERSION"] = snykPluginVersion
-
-        val applicationInfo = ApplicationInfo.getInstance()
-
-        val versionName = when (val name = applicationInfo.versionName) {
-            "IntelliJ IDEA", "PyCharm" -> "$name ${applicationInfo.apiVersion.substring(0, 2)}"
-            else -> name
-        }
-
-        generalCommandLine.environment["SNYK_INTEGRATION_ENVIRONMENT"] = versionName.toUpperCase()
-        generalCommandLine.environment["SNYK_INTEGRATION_ENVIRONMENT_VERSION"] = applicationInfo.fullVersion
+        generalCommandLine.environment["SNYK_INTEGRATION_NAME"] = pluginInfo.integrationName
+        generalCommandLine.environment["SNYK_INTEGRATION_VERSION"] = pluginInfo.integrationVersion
+        generalCommandLine.environment["SNYK_INTEGRATION_ENVIRONMENT"] = pluginInfo.integrationEnvironment
+        generalCommandLine.environment["SNYK_INTEGRATION_ENVIRONMENT_VERSION"] = pluginInfo.integrationEnvironmentVersion
     }
 
     companion object {

--- a/src/main/kotlin/io/snyk/plugin/net/TokenInterceptor.kt
+++ b/src/main/kotlin/io/snyk/plugin/net/TokenInterceptor.kt
@@ -2,6 +2,7 @@ package io.snyk.plugin.net
 
 import okhttp3.Interceptor
 import okhttp3.Response
+import snyk.pluginInfo
 
 class TokenInterceptor(private val token: String) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
@@ -9,7 +10,7 @@ class TokenInterceptor(private val token: String) : Interceptor {
         request.addHeader("Authorization", "token $token")
             .addHeader("Accept", "application/json")
             .addHeader("Content-Type", "application/json")
-            .addHeader("User-Agent", "snyk-intellij-plugin")
+            .addHeader("User-Agent", "snyk-intellij-plugin/${pluginInfo.integrationVersion}")
         return chain.proceed(request.build())
     }
 }

--- a/src/main/kotlin/snyk/PluginInformation.kt
+++ b/src/main/kotlin/snyk/PluginInformation.kt
@@ -1,0 +1,41 @@
+package snyk
+
+import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.openapi.application.ApplicationInfo
+import com.intellij.openapi.extensions.PluginId
+
+const val PLUGIN_ID = "io.snyk.snyk-intellij-plugin"
+
+/**
+ * Snyk IntelliJ plugin information.
+ */
+val pluginInfo: PluginInformation by lazy {
+    getPluginInformation()
+}
+
+private fun getPluginInformation(): PluginInformation {
+    val snykPluginVersion = PluginManagerCore.getPlugin(PluginId.getId(PLUGIN_ID))?.version ?: "UNKNOWN"
+
+    val applicationInfo = ApplicationInfo.getInstance()
+    val integrationEnvironment = when (val name = applicationInfo.versionName) {
+        "IntelliJ IDEA", "PyCharm" -> "$name ${applicationInfo.apiVersion.substring(0, 2)}"
+        else -> name
+    }
+
+    return PluginInformation(
+        integrationName = "JETBRAINS_IDE",
+        integrationVersion = snykPluginVersion,
+        integrationEnvironment = integrationEnvironment.toUpperCase(),
+        integrationEnvironmentVersion = applicationInfo.fullVersion
+    )
+}
+
+/**
+ * Holds all relevant information for the Snyk plugin such version, integration name, environment etc.
+ */
+data class PluginInformation(
+    val integrationName: String,
+    val integrationVersion: String,
+    val integrationEnvironment: String,
+    val integrationEnvironmentVersion: String
+)

--- a/src/test/kotlin/snyk/advisor/api/AdvisorApiClientTest.kt
+++ b/src/test/kotlin/snyk/advisor/api/AdvisorApiClientTest.kt
@@ -31,7 +31,7 @@ class AdvisorApiClientTest {
     fun setUp() {
         clientUnderTest = AdvisorApiClient.create(
             baseUrl = server.url("/").toString(),
-            token = "random-local-test-token",
+            token = "",
             httpClient = mockHttpClient
         )
     }


### PR DESCRIPTION
This PR extract getting plugin information logic into `PluginInformation.kt` class.
We'll need this information by setting:
- envvars
- user-agent header
- sentry alerting (later)