### PR TITLE
chore: compatibility with IntelliJ 2021.2 platform

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   gradleValidation:
     name: Validate Gradle Wrapper
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Fetch Sources
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
   test:
     name: Test
     needs: gradleValidation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Fetch Sources
         uses: actions/checkout@v2

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   detekt:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Fetch Sources
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   release:
     name: Publish Plugin
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     container: gradle:jdk8
     steps:
       - name: Fetch Sources

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Snyk Vulnerability Scanner Changelog
 
+## [Unreleased]
+### Changed
+- Make plugin compatible with 2021.2 version
+
 ## [2.2.0]
 ### Added
 - [Advisor](https://snyk.io/advisor) support for NPM packages in package.json

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,6 @@
 import io.gitlab.arturbosch.detekt.Detekt
 import org.apache.tools.ant.filters.ReplaceTokens
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
-import org.jetbrains.changelog.closure
 import org.jetbrains.changelog.markdownToHTML
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -9,8 +8,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 fun properties(key: String) = project.findProperty(key).toString()
 
 plugins {
-  id("org.jetbrains.changelog") version "0.4.0"
-  id("org.jetbrains.intellij") version "0.4.22"
+  id("org.jetbrains.changelog") version "1.2.1"
+  id("org.jetbrains.intellij") version "1.1.2"
   id("org.jetbrains.kotlin.jvm") version "1.3.72"
   id("io.gitlab.arturbosch.detekt") version ("1.17.1")
 }
@@ -47,10 +46,10 @@ dependencies {
 // configuration for gradle-intellij-plugin plugin.
 // read more: https://github.com/JetBrains/gradle-intellij-plugin
 intellij {
-  pluginName = properties("pluginName")
-  version = properties("platformVersion")
+  pluginName.set(properties("pluginName"))
+  version.set(properties("platformVersion"))
 
-  downloadSources = properties("platformDownloadSources").toBoolean()
+  downloadSources.set(properties("platformDownloadSources").toBoolean())
 }
 
 // configure for detekt plugin.
@@ -104,11 +103,11 @@ tasks {
   }
 
   patchPluginXml {
-    version(properties("pluginVersion"))
-    sinceBuild(properties("pluginSinceBuild"))
-    untilBuild(properties("pluginUntilBuild"))
+    version.set(properties("pluginVersion"))
+    sinceBuild.set(properties("pluginSinceBuild"))
+    untilBuild.set(properties("pluginUntilBuild"))
 
-    pluginDescription(closure {
+    pluginDescription.set(
       File("$projectDir/README.md").readText().lines().run {
         val start = "<!-- Plugin description start -->"
         val end = "<!-- Plugin description end -->"
@@ -118,25 +117,21 @@ tasks {
         }
         subList(indexOf(start) + 1, indexOf(end))
       }.joinToString("\n").run { markdownToHTML(this) }
-    })
-
-    changeNotes(
-      closure {
-        changelog.getLatest().toHTML()
-      }
     )
+
+    changeNotes.set(provider { changelog.getLatest().toHTML() })
   }
 
   publishPlugin {
-    token(System.getenv("PUBLISH_TOKEN"))
-    channels(properties("pluginVersion").split('-').getOrElse(1) { "default" }.split('.').first())
+    token.set(System.getenv("PUBLISH_TOKEN"))
+    channels.set(listOf(properties("pluginVersion").split('-').getOrElse(1) { "default" }.split('.').first()))
   }
 
   runIde {
     maxHeapSize = "2g"
-    autoReloadPlugins = false
+    autoReloadPlugins.set(false)
     if (properties("localIdeDirectory").isNotEmpty()) {
-      ideDirectory(properties("localIdeDirectory"))
+      ideDir.set(File(properties("localIdeDirectory")))
     }
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,17 @@
+pluginGroup=io.snyk.intellij
+pluginName=Snyk Vulnerability Scanner
 pluginVersion=2.2.0
+
+# for insight into build numbers and IntelliJ Platform versions
+# see https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild=202
-pluginUntilBuild=211.*
-#
+pluginUntilBuild=212.*
+
 platformVersion=2020.2
-#
+platformDownloadSources=true
+
 localIdeDirectory=
+
+# opt-out flag for bundling Kotlin standard library
+# see https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library
+kotlin.stdlib.default.dependency=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/io/snyk/plugin/services/SnykAnalyticsService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykAnalyticsService.kt
@@ -165,7 +165,7 @@ class SnykAnalyticsService : Disposable {
     private fun loadIterativelyEnvironment(): Environment {
         return try {
             val prop = Properties()
-            prop.load(javaClass.classLoader.getResourceAsStream("/application.properties"))
+            prop.load(javaClass.classLoader.getResourceAsStream("application.properties"))
             val environment = prop.getProperty("iteratively.analytics.environment") ?: "DEVELOPMENT"
 
             if (environment.isEmpty()) {
@@ -183,7 +183,7 @@ class SnykAnalyticsService : Disposable {
     private fun loadSegmentWriteKey(): String {
         return try {
             val prop = Properties()
-            prop.load(javaClass.classLoader.getResourceAsStream("/application.properties"))
+            prop.load(javaClass.classLoader.getResourceAsStream("application.properties"))
             prop.getProperty("segment.analytics.write-key") ?: ""
         } catch (t: Throwable) {
             log.warn("Could not load Segment write key.", t)


### PR DESCRIPTION
This PR update `pluginUntilBuild` version to `212.*`.
For compatibility reasons:
- update gradle version to `6.9`
- update `org.jetbrains.changelog` plugin version to `1.2.1`
- update `org.jetbrains.intellij` version to `1.1.2`