### PR TITLE
fix exceptions when parsing OSS CLI output [ROAD-250]

### DIFF
--- a/src/integTest/kotlin/snyk/oss/OssServiceTest.kt
+++ b/src/integTest/kotlin/snyk/oss/OssServiceTest.kt
@@ -173,6 +173,28 @@ class OssServiceTest : LightPlatformTestCase() {
     }
 
     @Test
+    fun testConvertRawCliStringToCliResultWithEmptyRawString() {
+        val cli = getOssService(project)
+
+        val cliResult = cli.convertRawCliStringToCliResult("")
+        assertFalse(cliResult.isSuccessful())
+    }
+
+    @Test
+    fun testConvertRawCliStringToCliResultWithMissformedJson() {
+        val cli = getOssService(project)
+
+        val cliResult = cli.convertRawCliStringToCliResult("""
+                    {
+                      "ok": false,
+                      "error": ["could not be","array here"],
+                      "path": "some/path/here"
+                    }
+                """.trimIndent())
+        assertFalse(cliResult.isSuccessful())
+    }
+
+    @Test
     fun testConvertRawCliStringToCliResultFieldsInitialisation() {
         val cli = getOssService(project)
 

--- a/src/main/kotlin/io/snyk/plugin/ui/SnykBalloonNotifications.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/SnykBalloonNotifications.kt
@@ -11,6 +11,7 @@ import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.PlatformDataKeys.CONTEXT_COMPONENT
 import com.intellij.openapi.components.service
+import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.MessageType
@@ -36,6 +37,7 @@ import javax.swing.Icon
 class SnykBalloonNotifications {
 
     companion object {
+        private val logger = logger<SnykBalloonNotifications>()
         const val title = "Snyk"
         private const val groupNeedAction = "SnykNeedAction"
         private const val groupAutoHide = "SnykAutoHide"
@@ -52,7 +54,16 @@ class SnykBalloonNotifications {
         fun showWarn(message: String, project: Project, vararg actions: AnAction) =
             showNotification(message, project, NotificationType.WARNING, *actions)
 
-        private fun showNotification(message: String, project: Project, type: NotificationType, vararg actions: AnAction): Notification {
+        private fun showNotification(
+            message: String,
+            project: Project,
+            type: NotificationType,
+            vararg actions: AnAction
+        ): Notification {
+            when(type) {
+                NotificationType.ERROR, NotificationType.WARNING -> logger.warn(message)
+                else -> logger.info(message)
+            }
             val notification = if (actions.isEmpty()) {
                 Notification(groupAutoHide, title, message, type)
             } else {

--- a/src/main/kotlin/snyk/oss/OssService.kt
+++ b/src/main/kotlin/snyk/oss/OssService.kt
@@ -1,6 +1,7 @@
 package snyk.oss
 
 import com.google.gson.Gson
+import com.google.gson.JsonSyntaxException
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.project.Project
 import io.snyk.plugin.cli.CliError
@@ -23,25 +24,35 @@ class OssService(project: Project) : CliService<OssResult>(
      * If result string not contains 'error' string and contain 'vulnerabilities' it says that everything is correct.
      * If result string not contains '{' it means CLI return an error.
      * And if result string contains 'error' and not contain 'vulnerabilities' it means CLI return error in JSON format.
-     * if result == [ConsoleCommandRunner.PROCESS_CANCELLED_BY_USER] - CLI scan process was terminated by user..
+     * if result == [ConsoleCommandRunner.PROCESS_CANCELLED_BY_USER] - CLI scan process was terminated by user.
+     * if result is Empty - CLI fail to run (some notification already done in CLI execution code).
      */
     override fun convertRawCliStringToCliResult(rawStr: String): OssResult =
-        when {
-            rawStr == ConsoleCommandRunner.PROCESS_CANCELLED_BY_USER -> OssResult(null, null)
-            rawStr.first() == '[' -> {
-                OssResult(Gson().fromJson(rawStr, Array<OssVulnerabilitiesForFile>::class.java), null)
-            }
-            rawStr.first() == '{' -> {
-                if (isSuccessCliJsonString(rawStr)) {
-                    OssResult(arrayOf(Gson().fromJson(rawStr, OssVulnerabilitiesForFile::class.java)), null)
-                } else {
-                    val cliError = Gson().fromJson(rawStr, CliError::class.java)
-                    OssResult(null, SnykError(cliError.message, cliError.path))
+        try {
+            when {
+                rawStr == ConsoleCommandRunner.PROCESS_CANCELLED_BY_USER -> {
+                    OssResult(null, null)
+                }
+                rawStr.isEmpty() -> {
+                    OssResult(null, SnykError("CLI fail to produce any output", projectPath))
+                }
+                rawStr.first() == '[' -> {
+                    OssResult(Gson().fromJson(rawStr, Array<OssVulnerabilitiesForFile>::class.java), null)
+                }
+                rawStr.first() == '{' -> {
+                    if (isSuccessCliJsonString(rawStr)) {
+                        OssResult(arrayOf(Gson().fromJson(rawStr, OssVulnerabilitiesForFile::class.java)), null)
+                    } else {
+                        val cliError = Gson().fromJson(rawStr, CliError::class.java)
+                        OssResult(null, SnykError(cliError.message, cliError.path))
+                    }
+                }
+                else -> {
+                    OssResult(null, SnykError(rawStr, projectPath))
                 }
             }
-            else -> {
-                OssResult(null, SnykError(rawStr, projectPath))
-            }
+        } catch (e: JsonSyntaxException) {
+            OssResult(null, SnykError(e.message ?: e.toString(), projectPath))
         }
 
     private fun isSuccessCliJsonString(jsonStr: String): Boolean =


### PR DESCRIPTION
fix: empty oss-cli output case;
fix: miss-formed oss-cli JSON output case;
feat: log all notification shown to user.

PS should fix #153 