### PR TITLE
feat: implement Sentry error reporter as error submitter [ROAD-261]

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
   implementation("com.atlassian.commonmark:commonmark:0.15.2")
   implementation("com.google.code.gson:gson:2.8.6")
   implementation("com.segment.analytics.java:analytics:3.1.0")
+  implementation("io.sentry:sentry:5.1.2")
   implementation("io.snyk.code.sdk:snyk-code-client:2.1.10")
   implementation("ly.iterative.itly:plugin-iteratively:1.2.7")
   implementation("ly.iterative.itly:plugin-schema-validator:1.2.7") {
@@ -80,14 +81,17 @@ tasks {
   }
 
   withType<ProcessResources> {
+    val environment = project.findProperty("environment") ?: "DEVELOPMENT"
     filesMatching("application.properties") {
       val amplitudeExperimentApiKey = project.findProperty("amplitudeExperimentApiKey") ?: ""
-      val iterativelyEnvironment = project.findProperty("iterativelyEnvironment") ?: "DEVELOPMENT"
       val segmentWriteKey = project.findProperty("segmentWriteKey") ?: ""
+      val sentryDsnKey = project.findProperty("sentryDsn") ?: ""
       val tokens = mapOf(
         "amplitude.experiment.api-key" to amplitudeExperimentApiKey,
-        "iteratively.analytics.environment" to iterativelyEnvironment,
-        "segment.analytics.write-key" to segmentWriteKey
+        "environment" to environment,
+        "iteratively.analytics.environment" to environment,
+        "segment.analytics.write-key" to segmentWriteKey,
+        "sentry.dsn" to sentryDsnKey
       )
       filter<ReplaceTokens>("tokens" to tokens)
     }

--- a/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
@@ -39,6 +39,7 @@ class SnykApplicationSettingsStateService : PersistentStateComponent<SnykApplica
     var snykCodeQualityIssuesScanEnable: Boolean = false
     var sastOnServerEnabled: Boolean? = null
     var usageAnalyticsEnabled = true
+    var crashReportingEnabled = true
 
     var lowSeverityEnabled = true
     var mediumSeverityEnabled = true

--- a/src/main/kotlin/io/snyk/plugin/settings/SnykProjectSettingsConfigurable.kt
+++ b/src/main/kotlin/io/snyk/plugin/settings/SnykProjectSettingsConfigurable.kt
@@ -31,6 +31,7 @@ class SnykProjectSettingsConfigurable(val project: Project) : SearchableConfigur
         || isOrganizationModified()
         || isIgnoreUnknownCAModified()
         || isSendUsageAnalyticsModified()
+        || isCrashReportingModified()
         || isAdditionalParametersModified()
         || snykSettingsDialog.isScanTypeChanged()
 
@@ -51,6 +52,7 @@ class SnykProjectSettingsConfigurable(val project: Project) : SearchableConfigur
         applicationSettingsStateService.organization = snykSettingsDialog.getOrganization()
         applicationSettingsStateService.ignoreUnknownCA = snykSettingsDialog.isIgnoreUnknownCA()
         applicationSettingsStateService.usageAnalyticsEnabled = snykSettingsDialog.isUsageAnalyticsEnabled()
+        applicationSettingsStateService.crashReportingEnabled = snykSettingsDialog.isCrashReportingEnabled()
         snykSettingsDialog.saveScanTypeChanges()
 
         if (isProjectSettingsAvailable(project)) {
@@ -75,6 +77,9 @@ class SnykProjectSettingsConfigurable(val project: Project) : SearchableConfigur
 
     private fun isSendUsageAnalyticsModified(): Boolean =
         snykSettingsDialog.isUsageAnalyticsEnabled() != applicationSettingsStateService.usageAnalyticsEnabled
+
+    private fun isCrashReportingModified(): Boolean =
+        snykSettingsDialog.isCrashReportingEnabled() != applicationSettingsStateService.crashReportingEnabled
 
     private fun isAdditionalParametersModified(): Boolean =
         isProjectSettingsAvailable(project)

--- a/src/main/kotlin/io/snyk/plugin/settings/SnykProjectSettingsConfigurable.kt
+++ b/src/main/kotlin/io/snyk/plugin/settings/SnykProjectSettingsConfigurable.kt
@@ -3,11 +3,15 @@ package io.snyk.plugin.settings
 import com.intellij.openapi.components.service
 import com.intellij.openapi.options.SearchableConfigurable
 import com.intellij.openapi.project.Project
-import io.snyk.plugin.*
 import io.snyk.plugin.events.SnykSettingsListener
+import io.snyk.plugin.getApplicationSettingsStateService
+import io.snyk.plugin.getSyncPublisher
+import io.snyk.plugin.isProjectSettingsAvailable
+import io.snyk.plugin.isUrlValid
 import io.snyk.plugin.services.SnykApplicationSettingsStateService
 import io.snyk.plugin.services.SnykProjectSettingsStateService
 import io.snyk.plugin.snykcode.core.SnykCodeParams
+import io.snyk.plugin.toSnykCodeApiUrl
 import io.snyk.plugin.ui.SnykSettingsDialog
 import io.snyk.plugin.ui.toolwindow.SnykToolWindowPanel
 import javax.swing.JComponent
@@ -26,14 +30,14 @@ class SnykProjectSettingsConfigurable(val project: Project) : SearchableConfigur
 
     override fun createComponent(): JComponent = snykSettingsDialog.getRootPanel()
 
-    override fun isModified(): Boolean = isTokenModified()
-        || isCustomEndpointModified()
-        || isOrganizationModified()
-        || isIgnoreUnknownCAModified()
-        || isSendUsageAnalyticsModified()
-        || isCrashReportingModified()
-        || isAdditionalParametersModified()
-        || snykSettingsDialog.isScanTypeChanged()
+    override fun isModified(): Boolean = isTokenModified() ||
+        isCustomEndpointModified() ||
+        isOrganizationModified() ||
+        isIgnoreUnknownCAModified() ||
+        isSendUsageAnalyticsModified() ||
+        isCrashReportingModified() ||
+        isAdditionalParametersModified() ||
+        snykSettingsDialog.isScanTypeChanged()
 
     override fun apply() {
         val customEndpoint = snykSettingsDialog.getCustomEndpoint()

--- a/src/main/kotlin/io/snyk/plugin/ui/SnykSettingsDialog.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/SnykSettingsDialog.kt
@@ -53,6 +53,7 @@ class SnykSettingsDialog(
     private val organizationTextField: JTextField = JTextField()
     private val ignoreUnknownCACheckBox: JCheckBox = JCheckBox()
     private val usageAnalyticsCheckBox: JCheckBox = JCheckBox()
+    private val crashReportingCheckBox = JCheckBox()
     private val additionalParametersTextField: JTextField = ExpandableTextField()
     private val scanTypesPanelOuter = ScanTypesPanel(project, rootPanel)
     private val scanTypesPanel = scanTypesPanelOuter.panel
@@ -94,6 +95,7 @@ class SnykSettingsDialog(
             organizationTextField.text = applicationSettings.organization
             ignoreUnknownCACheckBox.isSelected = applicationSettings.ignoreUnknownCA
             usageAnalyticsCheckBox.isSelected = applicationSettings.usageAnalyticsEnabled
+            crashReportingCheckBox.isSelected = applicationSettings.crashReportingEnabled
 
             additionalParametersTextField.text = applicationSettings.getAdditionalParameters(project)
         }
@@ -453,6 +455,19 @@ class SnykSettingsDialog(
             )
         )
 
+        crashReportingCheckBox.text = "Allow automatically sending crash reports"
+        userExperiencePanel.add(
+            crashReportingCheckBox,
+            UIGridConstraints(
+                1, 0, 1, 1,
+                UIGridConstraints.ANCHOR_NORTHWEST,
+                UIGridConstraints.FILL_NONE,
+                UIGridConstraints.SIZEPOLICY_FIXED,
+                UIGridConstraints.SIZEPOLICY_FIXED,
+                null, null, null, 0, false
+            )
+        )
+
         /** Spacer ------------------ */
 
         val generalSettingsSpacer = Spacer()
@@ -482,6 +497,8 @@ class SnykSettingsDialog(
     fun isIgnoreUnknownCA(): Boolean = ignoreUnknownCACheckBox.isSelected
 
     fun isUsageAnalyticsEnabled(): Boolean = usageAnalyticsCheckBox.isSelected
+
+    fun isCrashReportingEnabled(): Boolean = crashReportingCheckBox.isSelected
 
     fun isScanTypeChanged(): Boolean = scanTypesPanel.isModified()
 

--- a/src/main/kotlin/snyk/PropertyLoader.kt
+++ b/src/main/kotlin/snyk/PropertyLoader.kt
@@ -1,0 +1,60 @@
+package snyk
+
+import com.intellij.openapi.diagnostic.logger
+import snyk.PropertyLoader.PropertyKeys.ENVIRONMENT
+import snyk.PropertyLoader.PropertyKeys.SENTRY_DSN
+import java.io.IOException
+import java.util.Properties
+
+object PropertyLoader {
+    private val LOG = logger<PropertyLoader>()
+    private const val DEFAULT_PROPERTY_FILE = "application.properties"
+
+    private val properties = Properties()
+
+    init {
+        try {
+            properties.load(javaClass.classLoader.getResourceAsStream(DEFAULT_PROPERTY_FILE))
+        } catch (e: IllegalArgumentException) {
+            LOG.warn("Property file contains a malformed Unicode escape sequence", e)
+        } catch (e: IOException) {
+            LOG.warn("Could not load $DEFAULT_PROPERTY_FILE", e)
+        }
+    }
+
+    /**
+     * The plugin environment (default value is `DEVELOPMENT`)
+     */
+    val environment: String by lazy {
+        val loadedValue = properties.getProperty(ENVIRONMENT)
+        val defaultValue = "DEVELOPMENT"
+        if (loadedValue == null) {
+            logMissingProperty(ENVIRONMENT, defaultValue)
+        }
+        loadedValue ?: defaultValue
+    }
+
+    /**
+     * The Sentry DSN
+     */
+    val sentryDsn: String by lazy {
+        val loadedValue = properties.getProperty(SENTRY_DSN)
+        val defaultValue = ""
+        if (loadedValue == null) {
+            logMissingProperty(SENTRY_DSN, defaultValue)
+        }
+        loadedValue ?: defaultValue
+    }
+
+    private fun logMissingProperty(value: String, defaultValue: String) {
+        LOG.warn("Property '$value' was not found in $DEFAULT_PROPERTY_FILE, use '$defaultValue' as default value")
+    }
+
+    /**
+     * Property keys from `src/main/resources/application.properties` file.
+     */
+    private object PropertyKeys {
+        const val ENVIRONMENT = "environment"
+        const val SENTRY_DSN = "sentry.dsn"
+    }
+}

--- a/src/main/kotlin/snyk/errorHandler/SentryErrorReporter.kt
+++ b/src/main/kotlin/snyk/errorHandler/SentryErrorReporter.kt
@@ -106,8 +106,11 @@ object SentryErrorReporter {
     fun captureException(throwable: Throwable): SentryId {
         val settings = getApplicationSettingsStateService()
         return if (settings.crashReportingEnabled) {
-            Sentry.captureException(throwable)
+            val sentryId = Sentry.captureException(throwable)
+            LOG.info("Sentry event reported: $sentryId")
+            sentryId
         } else {
+            LOG.info("Sentry crash reporting is disabled")
             SentryId.EMPTY_ID
         }
     }

--- a/src/main/kotlin/snyk/errorHandler/SentryErrorReporter.kt
+++ b/src/main/kotlin/snyk/errorHandler/SentryErrorReporter.kt
@@ -15,6 +15,7 @@ import io.sentry.protocol.Message
 import io.sentry.protocol.OperatingSystem
 import io.sentry.protocol.SentryId
 import io.sentry.protocol.SentryRuntime
+import io.snyk.plugin.getApplicationSettingsStateService
 import snyk.PropertyLoader
 import snyk.pluginInfo
 
@@ -94,6 +95,20 @@ object SentryErrorReporter {
                 LOG.warn("Unable to submit Sentry error information")
                 consumer.consume(SubmittedReportInfo(SubmissionStatus.FAILED))
             }
+        }
+    }
+
+    /**
+     * Captures exception with Sentry. This method should be used in `try-catch` blocks.
+     *
+     * Note: [io.snyk.plugin.services.SnykApplicationSettingsStateService.crashReportingEnabled] is respected
+     */
+    fun captureException(throwable: Throwable): SentryId {
+        val settings = getApplicationSettingsStateService()
+        return if (settings.crashReportingEnabled) {
+            Sentry.captureException(throwable)
+        } else {
+            SentryId.EMPTY_ID
         }
     }
 }

--- a/src/main/kotlin/snyk/errorHandler/SentryErrorReporter.kt
+++ b/src/main/kotlin/snyk/errorHandler/SentryErrorReporter.kt
@@ -1,0 +1,99 @@
+package snyk.errorHandler
+
+import com.intellij.openapi.diagnostic.Attachment
+import com.intellij.openapi.diagnostic.SubmittedReportInfo
+import com.intellij.openapi.diagnostic.SubmittedReportInfo.SubmissionStatus
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.util.SystemInfo
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.util.Consumer
+import io.sentry.DuplicateEventDetectionEventProcessor
+import io.sentry.Sentry
+import io.sentry.SentryEvent
+import io.sentry.SentryLevel
+import io.sentry.protocol.Message
+import io.sentry.protocol.OperatingSystem
+import io.sentry.protocol.SentryId
+import io.sentry.protocol.SentryRuntime
+import snyk.PropertyLoader
+import snyk.pluginInfo
+
+object SentryErrorReporter {
+    private val LOG = logger<SentryErrorReporter>()
+    private const val MAX_ERROR_MESSAGE_LENGTH = 2000
+
+    init {
+        Sentry.init { options ->
+            options.dsn = PropertyLoader.sentryDsn
+            options.environment = PropertyLoader.environment
+            options.release = pluginInfo.integrationVersion
+            options.eventProcessors.removeIf { eventProcessor ->
+                // users might have written different error messages that might then be discarded
+                eventProcessor is DuplicateEventDetectionEventProcessor
+            }
+
+            options.setBeforeSend { event, _ ->
+                val os = OperatingSystem()
+                os.name = SystemInfo.OS_NAME
+                os.version = "${SystemInfo.OS_VERSION}-${SystemInfo.OS_ARCH}"
+                event.contexts.setOperatingSystem(os)
+
+                val runtime = SentryRuntime()
+                runtime.name = pluginInfo.integrationEnvironment
+                runtime.version = pluginInfo.integrationEnvironmentVersion
+                event.contexts.setRuntime(runtime)
+
+                event.setTag("java.vendor", SystemInfo.JAVA_VENDOR)
+                event.setTag("java.version", SystemInfo.JAVA_VERSION)
+                event.setTag("java.runtime.version", SystemInfo.JAVA_RUNTIME_VERSION)
+
+                // clear the server name
+                event.serverName = null
+
+                event
+            }
+        }
+    }
+
+    fun submitErrorReport(
+        error: Throwable,
+        consumer: Consumer<SubmittedReportInfo>,
+        attachments: List<Attachment> = emptyList(),
+        description: String = ""
+    ) {
+        val event = SentryEvent()
+
+        val message = Message()
+        if (!StringUtil.isEmptyOrSpaces(description)) {
+            message.message = description
+            event.setTag("with.description", "true")
+        }
+
+        event.message = message
+        event.level = SentryLevel.ERROR
+        event.throwable = error
+
+        Sentry.withScope { scope ->
+            for (attachment in attachments) {
+                val fileAttachment = io.sentry.Attachment(attachment.bytes, attachment.path)
+                scope.addAttachment(fileAttachment)
+            }
+
+            val errorMessage = error.message
+            if (errorMessage != null && errorMessage.length > MAX_ERROR_MESSAGE_LENGTH) {
+                val fileAttachment = io.sentry.Attachment(errorMessage.toByteArray(Charsets.UTF_8), "errorMessage.txt")
+                scope.addAttachment(fileAttachment)
+            }
+
+            val sentryId = Sentry.captureEvent(event)
+
+            if (sentryId != SentryId.EMPTY_ID) {
+                LOG.info("Sentry event reported: $sentryId")
+                consumer.consume(SubmittedReportInfo(SubmissionStatus.NEW_ISSUE))
+            } else {
+                LOG.warn("Unable to submit Sentry error information")
+                consumer.consume(SubmittedReportInfo(SubmissionStatus.FAILED))
+            }
+        }
+    }
+}

--- a/src/main/kotlin/snyk/errorHandler/SnykErrorReportSubmitter.kt
+++ b/src/main/kotlin/snyk/errorHandler/SnykErrorReportSubmitter.kt
@@ -1,0 +1,45 @@
+package snyk.errorHandler
+
+import com.intellij.diagnostic.AbstractMessage
+import com.intellij.diagnostic.PluginException
+import com.intellij.openapi.diagnostic.Attachment
+import com.intellij.openapi.diagnostic.ErrorReportSubmitter
+import com.intellij.openapi.diagnostic.IdeaLoggingEvent
+import com.intellij.openapi.diagnostic.SubmittedReportInfo
+import com.intellij.util.Consumer
+import java.awt.Component
+
+class SnykErrorReportSubmitter : ErrorReportSubmitter() {
+    override fun getReportActionText(): String {
+        return "Report to Snyk"
+    }
+
+    override fun submit(
+        events: Array<out IdeaLoggingEvent>,
+        additionalInfo: String?,
+        parentComponent: Component,
+        consumer: Consumer<SubmittedReportInfo>
+    ): Boolean {
+        for (event in events) {
+            var throwable = event.throwable
+            val description = additionalInfo ?: ""
+            var attachments = listOf<Attachment>()
+
+            if (event.data is AbstractMessage) {
+                throwable = (event.data as AbstractMessage).throwable
+                attachments = (event.data as AbstractMessage).includedAttachments
+            }
+            if (throwable is PluginException && throwable.cause != null) {
+                // unwrap PluginManagerCore.createPluginException
+                throwable = throwable.cause
+            }
+            SentryErrorReporter.submitErrorReport(
+                throwable,
+                consumer = consumer,
+                description = description,
+                attachments = attachments
+            )
+        }
+        return true
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -22,6 +22,7 @@
 
     <editorFactoryListener implementation="snyk.advisor.AdvisorEditorFactoryListener"/>
 
+    <errorHandler implementation="snyk.errorHandler.SnykErrorReportSubmitter"/>
   </extensions>
 
   <actions>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,5 @@
 amplitude.experiment.api-key=@amplitude.experiment.api-key@
+environment=@environment@
 iteratively.analytics.environment=@iteratively.analytics.environment@
 segment.analytics.write-key=@segment.analytics.write-key@
+sentry.dsn=https://33e9484001e8411693945d7d1a8a2f64@o30291.ingest.sentry.io/5956531


### PR DESCRIPTION
This PR implements the extension point `com.intellij.errorHandler` to integrate the plugin with the IDE's dialog to report fatal errors.

### Additional info
<details>
  <summary>Click to see example screenshots</summary>
  <img width="818" alt="image" src="https://user-images.githubusercontent.com/60606414/133176576-abf2d769-eb22-4c9b-a57f-4648673e892e.png">
</details>

