### PR TITLE
fix(experiment): add setting to show scanner reminder only once

### DIFF
--- a/src/main/kotlin/io/snyk/plugin/SnykPostStartupActivity.kt
+++ b/src/main/kotlin/io/snyk/plugin/SnykPostStartupActivity.kt
@@ -59,6 +59,7 @@ class SnykPostStartupActivity : StartupActivity.DumbAware {
 
             if (service<AmplitudeExperimentService>().isShowScanningReminderEnabled()) {
                 SnykBalloonNotifications.showScanningReminder(project)
+                settings.scanningReminderWasShown = true
             }
         }
     }

--- a/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
@@ -52,6 +52,9 @@ class SnykApplicationSettingsStateService : PersistentStateComponent<SnykApplica
     var lastTimeFeedbackRequestShown: Date = Date.from(Instant.now()) // we'll give 2 weeks to evaluate initially
     var showFeedbackRequest = true
 
+    // experiment section
+    var scanningReminderWasShown: Boolean = false
+
     /**
      * Random UUID used by analytics events if enabled.
      */

--- a/src/main/kotlin/snyk/amplitude/AmplitudeExperimentService.kt
+++ b/src/main/kotlin/snyk/amplitude/AmplitudeExperimentService.kt
@@ -3,6 +3,7 @@ package snyk.amplitude
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.logger
+import io.snyk.plugin.getApplicationSettingsStateService
 import snyk.amplitude.api.AmplitudeExperimentApiClient
 import snyk.amplitude.api.AmplitudeExperimentApiClient.Defaults.FALLBACK_VARIANT
 import snyk.amplitude.api.ExperimentUser
@@ -62,6 +63,10 @@ class AmplitudeExperimentService : Disposable {
 
     fun isShowScanningReminderEnabled(): Boolean {
         val variant = storage["intellij-show-scanning-reminder"] ?: return false
-        return variant.value == "test"
+
+        val settings = getApplicationSettingsStateService()
+        LOG.debug("Scanning reminder: variant - ${variant.value}, was shown - ${settings.scanningReminderWasShown}")
+
+        return variant.value == "test" && !settings.scanningReminderWasShown
     }
 }


### PR DESCRIPTION
This PR adds a settings to show scanner reminder only once (since it's not possible to set it from Amplitude side).