### PR TITLE
fix: set production Sentry environment when running release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
         env:
           PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
           ORG_GRADLE_PROJECT_amplitudeExperimentApiKey: ${{ secrets.AMPLITUDE_EXPERIMENT_API_KEY }}
+          ORG_GRADLE_PROJECT_environment: "PRODUCTION"
           ORG_GRADLE_PROJECT_iterativelyEnvironment: "PRODUCTION"
           ORG_GRADLE_PROJECT_segmentWriteKey: ${{ secrets.SEGMENT_WRITE_KEY }}
         run: ./gradlew publishPlugin


### PR DESCRIPTION
This PR sets Sentry environment ("PRODUCTION") when running `release` GH workflow.
Otherwise it will be "DEVELOPMENT".