### PR TITLE
fix: remove deprecated methods [ROAD-334]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Snyk Vulnerability Scanner Changelog
 
+## [Unreleased]
+### Fixed
+- Remove IntelliJ API methods that are scheduled for removal in 2021.3
+
 ## [2.4.1]
 ### Fixed
 - Fix ClassCastException when updating the plugin without rebooting IDE

--- a/src/main/kotlin/io/snyk/plugin/ui/settings/ScanTypesPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/settings/ScanTypesPanel.kt
@@ -10,10 +10,11 @@ import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.components.labels.LinkLabel
 import com.intellij.ui.layout.panel
 import com.intellij.util.Alarm
+import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.UIUtil
-import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.getSnykCodeSettingsUrl
 import io.snyk.plugin.isSnykCodeAvailable
+import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.services.SnykApiService
 import io.snyk.plugin.snykcode.core.SnykCodeUtils
 import io.snyk.plugin.startSastEnablementCheckLoop
@@ -56,7 +57,7 @@ class ScanTypesPanel(
                     { settings.ossScanEnable },
                     { settings.ossScanEnable = it },
                     cliScanComments
-                ).withLeftGap(2) // needed due to bug with selection: left side is cut
+                )
                 label("").component.convertIntoHelpHintLabel(
                     "Find and automatically fix open source vulnerabilities"
                 )
@@ -69,7 +70,7 @@ class ScanTypesPanel(
                     { settings.advisorEnable },
                     { settings.advisorEnable = it },
                     null
-                ).withLeftGap(2) // needed due to bug with selection: left side is cut
+                )
                 label("").component.convertIntoHelpHintLabel(
                     "Discover the health (maintenance, community, popularity & security)\n" +
                         "status of your open source packages"
@@ -82,7 +83,7 @@ class ScanTypesPanel(
                     SNYK_CODE_SECURITY_ISSUES,
                     { settings.snykCodeSecurityIssuesScanEnable },
                     { settings.snykCodeSecurityIssuesScanEnable = it }
-                ).withLeftGap(2) // needed due to bug with selection: left side is cut
+                )
                     .component
                 label("").component.convertIntoHelpHintLabel(
                     "Find and fix vulnerabilities in your application code in real time"
@@ -124,6 +125,8 @@ class ScanTypesPanel(
                     .withLargeLeftGap()
             }
         }
+    }.apply {
+        border = JBUI.Borders.empty(2)
     }
 
     private fun JLabel.convertIntoHelpHintLabel(text: String) {

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/OnboardPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/OnboardPanel.kt
@@ -4,10 +4,11 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
 import com.intellij.ui.layout.panel
+import com.intellij.util.ui.JBUI
 import io.snyk.plugin.analytics.getSelectedProducts
 import io.snyk.plugin.events.SnykSettingsListener
-import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.getSyncPublisher
+import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.services.SnykAnalyticsService
 import io.snyk.plugin.services.SnykTaskQueueService
 import io.snyk.plugin.ui.settings.ScanTypesPanel
@@ -54,5 +55,7 @@ class OnboardPanel(project: Project) {
                 }
             }
         }
+    }.apply {
+        border = JBUI.Borders.empty(2)
     }
 }


### PR DESCRIPTION
This PR removes usage of deprecated `withLeftGap()` method.
*Note for reviewers*: check plugin verifier logs to be sure no warnings are reported.