### PR TITLE
feat: use mockk instead of mockito, minor version bump for junit and …

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,12 +34,12 @@ dependencies {
   }
   implementation("ly.iterative.itly:sdk-jvm:1.2.7")
 
-  testImplementation("com.squareup.okhttp3:mockwebserver:4.9.1")
-  testImplementation("junit:junit:4.13") {
+  testImplementation("com.squareup.okhttp3:mockwebserver:4.9.2")
+  testImplementation("junit:junit:4.13.2") {
     exclude(group = "org.hamcrest")
   }
   testImplementation("org.hamcrest:hamcrest:2.2")
-  testImplementation("org.mockito:mockito-core:3.5.2")
+  testImplementation("io.mockk:mockk:1.12.0")
 
   detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.17.1")
 }

--- a/src/integTest/kotlin/io/snyk/plugin/services/SnykCliDownloaderServiceTest.kt
+++ b/src/integTest/kotlin/io/snyk/plugin/services/SnykCliDownloaderServiceTest.kt
@@ -3,12 +3,13 @@ package io.snyk.plugin.services
 import com.intellij.openapi.components.service
 import com.intellij.openapi.progress.EmptyProgressIndicator
 import com.intellij.testFramework.LightPlatformTestCase
+import io.mockk.every
+import io.mockk.spyk
 import io.snyk.plugin.cli.Platform
-import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.getCliFile
 import io.snyk.plugin.getPluginPath
+import io.snyk.plugin.pluginSettings
 import org.junit.Test
-import org.mockito.Mockito
 import java.io.File
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -54,8 +55,8 @@ class SnykCliDownloaderServiceTest : LightPlatformTestCase() {
     fun testDownloadLatestCliReleaseWhenNoReleaseInfoAvailable() {
         val cliDownloaderService = project.service<SnykCliDownloaderService>()
 
-        val cliDownloaderServiceSpy = Mockito.spy(cliDownloaderService)
-        Mockito.doReturn(null).`when`<SnykCliDownloaderService>(cliDownloaderServiceSpy).requestLatestReleasesInformation()
+        val cliDownloaderServiceSpy = spyk(cliDownloaderService )
+        every { cliDownloaderServiceSpy.requestLatestReleasesInformation() } returns null
 
         assertNoThrowable {
             cliDownloaderServiceSpy.downloadLatestRelease(EmptyProgressIndicator(), project)

--- a/src/integTest/kotlin/snyk/iac/IacServiceTest.kt
+++ b/src/integTest/kotlin/snyk/iac/IacServiceTest.kt
@@ -2,14 +2,15 @@ package snyk.iac
 
 import com.intellij.openapi.components.service
 import com.intellij.testFramework.LightPlatformTestCase
+import io.mockk.every
+import io.mockk.mockk
 import io.snyk.plugin.cli.ConsoleCommandRunner
-import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.getCliFile
 import io.snyk.plugin.getIacService
+import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.services.SnykProjectSettingsStateService
 import io.snyk.plugin.setupDummyCliFile
 import org.junit.Test
-import org.mockito.Mockito
 
 class IacServiceTest : LightPlatformTestCase() {
 
@@ -40,21 +41,23 @@ class IacServiceTest : LightPlatformTestCase() {
     fun testScanWithErrorResult() {
         setupDummyCliFile()
 
-        val mockRunner = Mockito.mock(ConsoleCommandRunner::class.java)
+        val mockRunner = mockk<ConsoleCommandRunner>()
 
         val errorMsg = "Some error here"
         val errorPath = "/Users/user/Desktop/example-npm-project"
-        Mockito
-            .`when`(mockRunner.execute(
+
+        every {
+            mockRunner.execute(
                 listOf(getCliFile().absolutePath, "iac", "test", "--json"),
                 project.basePath!!,
-                project = project))
-            .thenReturn("""
-                    {
-                      "error": "$errorMsg",
-                      "path": "$errorPath"
-                    }
-                """.trimIndent())
+                project = project
+            )
+        } returns """
+            {
+              "error": "$errorMsg",
+              "path": "$errorPath"
+            }
+        """.trimIndent()
 
         getIacService(project).setConsoleCommandRunner(mockRunner)
 
@@ -69,14 +72,15 @@ class IacServiceTest : LightPlatformTestCase() {
     fun testScanWithSuccessfulIacResult() {
         setupDummyCliFile()
 
-        val mockRunner = Mockito.mock(ConsoleCommandRunner::class.java)
+        val mockRunner = mockk<ConsoleCommandRunner>()
 
-        Mockito
-            .`when`(mockRunner.execute(
+        every {
+            mockRunner.execute(
                 listOf(getCliFile().absolutePath, "iac", "test", "--json"),
                 project.basePath!!,
-                project = project))
-            .thenReturn(wholeProjectJson)
+                project = project
+            )
+        } returns (wholeProjectJson)
 
         getIacService(project).setConsoleCommandRunner(mockRunner)
 

--- a/src/integTest/kotlin/snyk/oss/OssServiceTest.kt
+++ b/src/integTest/kotlin/snyk/oss/OssServiceTest.kt
@@ -2,14 +2,15 @@ package snyk.oss
 
 import com.intellij.openapi.components.service
 import com.intellij.testFramework.LightPlatformTestCase
+import io.mockk.every
+import io.mockk.mockk
 import io.snyk.plugin.cli.ConsoleCommandRunner
-import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.getCliFile
 import io.snyk.plugin.getOssService
+import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.services.SnykProjectSettingsStateService
 import io.snyk.plugin.setupDummyCliFile
 import org.junit.Test
-import org.mockito.Mockito
 
 class OssServiceTest : LightPlatformTestCase() {
 
@@ -57,17 +58,17 @@ class OssServiceTest : LightPlatformTestCase() {
     fun testScanWithErrorResult() {
         setupDummyCliFile()
 
-        val mockRunner = Mockito.mock(ConsoleCommandRunner::class.java)
+        val mockRunner = mockk<ConsoleCommandRunner>()
 
-        Mockito
-            .`when`(mockRunner.execute(listOf(getCliFile().absolutePath, "test", "--json"), project.basePath!!, project = project))
-            .thenReturn("""
-                    {
-                      "ok": false,
-                      "error": "Missing node_modules folder: we can't test without dependencies.\nPlease run 'npm install' first.",
-                      "path": "/Users/user/Desktop/example-npm-project"
-                    }
-                """.trimIndent())
+        every {
+            mockRunner.execute(listOf(getCliFile().absolutePath, "test", "--json"), project.basePath!!, project = project)
+        } returns """
+              {
+                  "ok": false,
+                  "error": "Missing node_modules folder: we can't test without dependencies.\nPlease run 'npm install' first.",
+                  "path": "/Users/user/Desktop/example-npm-project"
+              }
+            """.trimIndent()
 
         getOssService(project).setConsoleCommandRunner(mockRunner)
 
@@ -84,11 +85,11 @@ class OssServiceTest : LightPlatformTestCase() {
     fun testScanWithSuccessfulCliResult() {
         setupDummyCliFile()
 
-        val mockRunner = Mockito.mock(ConsoleCommandRunner::class.java)
+        val mockRunner = mockk<ConsoleCommandRunner>()
 
-        Mockito
-            .`when`(mockRunner.execute(listOf(getCliFile().absolutePath, "test", "--json"), project.basePath!!, project = project))
-            .thenReturn(getResourceAsString("group-vulnerabilities-test.json"))
+        every {
+            mockRunner.execute(listOf(getCliFile().absolutePath, "test", "--json"), project.basePath!!, project = project)
+        } returns getResourceAsString("group-vulnerabilities-test.json")
 
         getOssService(project).setConsoleCommandRunner(mockRunner)
 
@@ -109,11 +110,11 @@ class OssServiceTest : LightPlatformTestCase() {
     fun testScanWithLicenseVulnerabilities() {
         setupDummyCliFile()
 
-        val mockRunner = Mockito.mock(ConsoleCommandRunner::class.java)
+        val mockRunner = mockk<ConsoleCommandRunner>()
 
-        Mockito
-            .`when`(mockRunner.execute(listOf(getCliFile().absolutePath, "test", "--json"), project.basePath!!, project = project))
-            .thenReturn(getResourceAsString("licence-vulnerabilities.json"))
+        every {
+            mockRunner.execute(listOf(getCliFile().absolutePath, "test", "--json"), project.basePath!!, project = project)
+        } returns getResourceAsString("licence-vulnerabilities.json")
 
         getOssService(project).setConsoleCommandRunner(mockRunner)
 
@@ -205,14 +206,14 @@ class OssServiceTest : LightPlatformTestCase() {
         touchAllFields(cliResult)
     }
 
-    private  fun touchAllFields(ossResultToCheck: OssResult) {
+    private fun touchAllFields(ossResultToCheck: OssResult) {
         ossResultToCheck.allCliIssues?.forEach {
             it.displayTargetFile
             it.packageManager
             it.projectName
             it.uniqueCount
             it.vulnerabilities.forEach { vuln ->
-                with(vuln){
+                with(vuln) {
                     id
                     license
                     identifiers?.CVE


### PR DESCRIPTION
Substitute mockito with mockk, as mockk supports kotlin much better than mockito

Minor version bump of junit
Minor version bump of mockwebserver

Done in preparation for implementing ROAD-430 error handling when failing to download the CLI