### PR TITLE
Handle exceptions when downloading CLI binary from GitHub [ROAD-430]

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,3 +13,13 @@ trim_trailing_whitespace = false
 
 [*.kt]
 indent_size = 4
+wildcard_import_limit = 999
+ij_kotlin_packages_to_use_import_on_demand = ^
+ij_kotlin_name_count_to_use_star_import = 999
+ij_kotlin_name_count_to_use_star_import_for_members = 999
+ij_kotlin_imports_layout = *, java.**, javax.**, kotlin.**, ^
+
+[*.java]
+ij_java_names_count_to_use_import_on_demand = 999
+ij_java_class_count_to_use_import_on_demand = 999
+ij_java_packages_to_use_import_on_demand = ^

--- a/src/integTest/kotlin/io/snyk/plugin/services/SnykTaskQueueServiceTest.kt
+++ b/src/integTest/kotlin/io/snyk/plugin/services/SnykTaskQueueServiceTest.kt
@@ -4,8 +4,8 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.util.Disposer
 import com.intellij.testFramework.LightPlatformTestCase
 import com.intellij.testFramework.PlatformTestUtil
-import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.getCliFile
+import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.setupDummyCliFile
 import org.junit.Test
 

--- a/src/main/kotlin/io/snyk/plugin/cli/ConsoleCommandRunner.kt
+++ b/src/main/kotlin/io/snyk/plugin/cli/ConsoleCommandRunner.kt
@@ -12,7 +12,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Key
 import io.snyk.plugin.controlExternalProcessWithProgressIndicator
 import io.snyk.plugin.getWaitForResultsTimeout
-import io.snyk.plugin.ui.SnykBalloonNotifications
+import io.snyk.plugin.ui.SnykBalloonNotificationHelper
 import snyk.errorHandler.SentryErrorReporter
 import snyk.pluginInfo
 import java.nio.charset.Charset
@@ -40,7 +40,7 @@ open class ConsoleCommandRunner {
             OSProcessHandler(generalCommandLine)
         } catch (e: ExecutionException) {
             //  if CLI is still downloading (or temporarily blocked by Antivirus) we'll get ProcessNotCreatedException
-            SnykBalloonNotifications.showWarn("Not able to run CLI, try again later.", project)
+            SnykBalloonNotificationHelper.showWarn("Not able to run CLI, try again later.", project)
             return ""
         }
         val parentIndicator = ProgressManager.getInstance().progressIndicator

--- a/src/main/kotlin/io/snyk/plugin/services/SnykCliAuthenticationService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykCliAuthenticationService.kt
@@ -17,7 +17,7 @@ import com.intellij.util.PlatformIcons
 import io.snyk.plugin.cli.ConsoleCommandRunner
 import io.snyk.plugin.getCliFile
 import io.snyk.plugin.getPluginPath
-import io.snyk.plugin.ui.SnykBalloonNotifications
+import io.snyk.plugin.ui.SnykBalloonNotificationHelper
 import io.snyk.plugin.ui.getReadOnlyClickableHtmlJEditorPane
 import org.apache.commons.lang.StringEscapeUtils.escapeHtml
 import java.awt.BorderLayout
@@ -86,7 +86,7 @@ class SnykCliAuthenticationService(val project: Project) {
                 }
                 val authSucceed = finalOutput.contains("Your account has been authenticated.")
                 if (!authSucceed && finalOutput != ConsoleCommandRunner.PROCESS_CANCELLED_BY_USER) {
-                    SnykBalloonNotifications.showError("Failed to authenticate.", project)
+                    SnykBalloonNotificationHelper.showError("Failed to authenticate.", project)
                 }
                 val exitCode = if (authSucceed) DialogWrapper.OK_EXIT_CODE else DialogWrapper.CLOSE_EXIT_CODE
                 ApplicationManager.getApplication().invokeLater(
@@ -174,7 +174,7 @@ class AuthDialog() : DialogWrapper(true) {
     inner class CopyUrlAction(var url: String = "") : AbstractAction("&Copy URL", PlatformIcons.COPY_ICON) {
         override fun actionPerformed(e: ActionEvent) {
             CopyPasteManager.getInstance().setContents(StringSelection(url))
-            SnykBalloonNotifications.showInfoBalloonForComponent(
+            SnykBalloonNotificationHelper.showInfoBalloonForComponent(
                 "URL copied",
                 getButton(this) ?: viewer,
                 showAbove = getButton(this) != null

--- a/src/main/kotlin/io/snyk/plugin/services/SnykCliDownloaderErrorHandler.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykCliDownloaderErrorHandler.kt
@@ -1,0 +1,50 @@
+package io.snyk.plugin.services
+
+import com.intellij.ide.BrowserUtil
+import com.intellij.notification.NotificationAction
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.project.Project
+import com.intellij.util.io.HttpRequests
+import io.snyk.plugin.getCliFile
+import io.snyk.plugin.ui.SnykBalloonNotificationHelper
+import java.io.IOException
+
+class SnykCliDownloaderErrorHandler {
+    fun showErrorWithRetryAndContactAction(message: String, indicator: ProgressIndicator, project: Project) {
+        SnykBalloonNotificationHelper.showError(message, project,
+            NotificationAction.createSimple("Retry CLI download") {
+                project.getService(SnykCliDownloaderService::class.java).downloadLatestRelease(indicator, project)
+            },
+            NotificationAction.createSimple("Contact support...") {
+                BrowserUtil.browse("https://snyk.io/contact-us/?utm_source=JETBRAINS_IDE")
+            })
+    }
+
+    fun handleIOException(exception: IOException, indicator: ProgressIndicator, project: Project) {
+        val downloaderService = project.getService(SnykCliDownloaderService::class.java)
+
+        val latestReleaseInfo = downloaderService.getLatestReleaseInfo()
+        if (latestReleaseInfo != null) {
+            val cliVersion = latestReleaseInfo.tagName
+            val cliFile = getCliFile()
+            downloaderService.downloadFile(cliFile, cliVersion, indicator)
+        }
+        showErrorWithRetryAndContactAction(getNetworkErrorNotificationMessage(exception), indicator, project)
+    }
+
+    fun getNetworkErrorNotificationMessage(exception: IOException) =
+        "The download of the Snyk CLI was interrupted by a network error (${exception.localizedMessage}). " +
+            "Do you want to try again?"
+
+    fun handleHttpStatusException(exception: HttpRequests.HttpStatusException, project: Project) {
+        SnykBalloonNotificationHelper.showError(
+            getHttpStatusErrorNotificationMessage(exception),
+            project,
+            NotificationAction.createSimple("Contact support...") {
+                BrowserUtil.browse("https://snyk.io/contact-us/?utm_source=JETBRAINS_IDE")
+            })
+    }
+
+    fun getHttpStatusErrorNotificationMessage(exception: HttpRequests.HttpStatusException) =
+        "The download request of the current Snyk CLI was not successful (${exception.localizedMessage})."
+}

--- a/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
@@ -8,16 +8,20 @@ import com.intellij.openapi.progress.BackgroundTaskQueue
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
-import io.snyk.plugin.*
-import snyk.oss.OssResult
 import io.snyk.plugin.events.SnykCliDownloadListener
 import io.snyk.plugin.events.SnykScanListener
 import io.snyk.plugin.events.SnykTaskQueueListener
+import io.snyk.plugin.getOssService
+import io.snyk.plugin.getSnykCode
+import io.snyk.plugin.getSyncPublisher
+import io.snyk.plugin.isSnykCodeRunning
+import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.snykcode.core.RunUtils
 import io.snyk.plugin.ui.SnykBalloonNotifications
 import io.snyk.plugin.ui.toolwindow.SnykToolWindowPanel
 import org.jetbrains.annotations.TestOnly
 import snyk.common.SnykError
+import snyk.oss.OssResult
 
 @Service
 class SnykTaskQueueService(val project: Project) {

--- a/src/main/kotlin/io/snyk/plugin/snykcode/core/PDU.kt
+++ b/src/main/kotlin/io/snyk/plugin/snykcode/core/PDU.kt
@@ -14,11 +14,11 @@ import com.intellij.openapi.util.TextRange
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
-import snyk.common.SnykError
 import io.snyk.plugin.events.SnykScanListener
 import io.snyk.plugin.getSyncPublisher
-import io.snyk.plugin.ui.SnykBalloonNotifications
+import io.snyk.plugin.ui.SnykBalloonNotificationHelper
 import io.snyk.plugin.ui.toolwindow.SnykToolWindowPanel
+import snyk.common.SnykError
 import java.util.function.Consumer
 
 class PDU private constructor() : PlatformDependentUtilsBase() {
@@ -148,13 +148,13 @@ class PDU private constructor() : PlatformDependentUtilsBase() {
     }
 
     override fun showInfo(message: String, project: Any?) {
-        runForProject(project, Consumer { prj -> SnykBalloonNotifications.showInfo(message, prj) })
+        runForProject(project, Consumer { prj -> SnykBalloonNotificationHelper.showInfo(message, prj) })
     }
 
     override fun showWarn(message: String, project: Any?, wasWarnShown: Boolean) {
         if (!wasWarnShown) {
             runForProject(project, Consumer { prj ->
-                SnykBalloonNotifications.showWarn(message, prj)
+                SnykBalloonNotificationHelper.showWarn(message, prj)
                 getSyncPublisher(prj, SnykScanListener.SNYK_SCAN_TOPIC)?.scanningSnykCodeError(
                     SnykError(message, prj.basePath ?: "")
                 )
@@ -166,7 +166,7 @@ class PDU private constructor() : PlatformDependentUtilsBase() {
 
     override fun showError(message: String, project: Any?) {
         runForProject(project, Consumer { prj ->
-            SnykBalloonNotifications.showError(message, prj)
+            SnykBalloonNotificationHelper.showError(message, prj)
             getSyncPublisher(prj, SnykScanListener.SNYK_SCAN_TOPIC)?.scanningSnykCodeError(
                 SnykError(message, prj.basePath ?: "")
             )

--- a/src/main/kotlin/io/snyk/plugin/snykcode/core/SnykCodeIgnoreInfoHolder.kt
+++ b/src/main/kotlin/io/snyk/plugin/snykcode/core/SnykCodeIgnoreInfoHolder.kt
@@ -6,7 +6,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiManager
 import io.snyk.plugin.services.SnykTaskQueueService
-import io.snyk.plugin.ui.SnykBalloonNotifications
+import io.snyk.plugin.ui.SnykBalloonNotificationHelper
 import java.io.File
 
 class SnykCodeIgnoreInfoHolder private constructor() : DeepCodeIgnoreInfoHolderBase(
@@ -42,7 +42,10 @@ class SnykCodeIgnoreInfoHolder private constructor() : DeepCodeIgnoreInfoHolderB
             val fullDcIgnoreText = this.javaClass.classLoader.getResource("full.dcignore")?.readText()
                 ?: throw RuntimeException("full.dcignore can not be found in plugin's resources")
             dcignore.writeText(fullDcIgnoreText)
-            SnykBalloonNotifications.showInfo("We added generic .dcignore file to upload only project's source code.", project)
+            SnykBalloonNotificationHelper.showInfo(
+                "We added generic .dcignore file to upload only project's source code.",
+                project
+            )
         }
     }
 

--- a/src/main/kotlin/io/snyk/plugin/ui/SnykBalloonNotificationHelper.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/SnykBalloonNotificationHelper.kt
@@ -1,0 +1,102 @@
+package io.snyk.plugin.ui
+
+import com.intellij.icons.AllIcons
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationDisplayType
+import com.intellij.notification.NotificationGroup
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.PlatformDataKeys
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.MessageType
+import com.intellij.openapi.ui.popup.Balloon
+import com.intellij.openapi.ui.popup.JBPopupFactory
+import com.intellij.ui.awt.RelativePoint
+import java.awt.Color
+import java.awt.Component
+import java.awt.Point
+import javax.swing.Icon
+
+object SnykBalloonNotificationHelper {
+
+    private val logger = logger<SnykBalloonNotifications>()
+    const val title = "Snyk"
+    private const val groupNeedAction = "SnykNeedAction"
+    private const val groupAutoHide = "SnykAutoHide"
+    val GROUP = NotificationGroup(groupNeedAction, NotificationDisplayType.STICKY_BALLOON)
+
+    fun showError(message: String, project: Project, vararg actions: AnAction) =
+        showNotification(message, project, NotificationType.ERROR, *actions)
+
+    fun showInfo(message: String, project: Project, vararg actions: AnAction) =
+        showNotification(message, project, NotificationType.INFORMATION, *actions)
+
+    fun showWarn(message: String, project: Project, vararg actions: AnAction) =
+        showNotification(message, project, NotificationType.WARNING, *actions)
+
+    // TODO(pavel): refactor showNotification function to make it more generic + default arguments
+    private fun showNotification(
+        message: String,
+        project: Project,
+        type: NotificationType,
+        vararg actions: AnAction
+    ): Notification {
+        when (type) {
+            NotificationType.ERROR, NotificationType.WARNING -> logger.warn(message)
+            else -> logger.info(message)
+        }
+        val notification = if (actions.isEmpty()) {
+            Notification(groupAutoHide, title, message, type)
+        } else {
+            GROUP.createNotification(title, message, type).apply {
+                actions.forEach { this.addAction(it) }
+            }
+        }
+        notification.notify(project)
+        return notification
+    }
+
+    fun createBalloon(message: String, icon: Icon, color: Color): Balloon =
+        JBPopupFactory.getInstance().createHtmlTextBalloonBuilder(message, icon, color, null)
+            .setHideOnClickOutside(true)
+            .setFadeoutTime(5000)
+            .createBalloon()
+
+    fun showBalloonForComponent(
+        balloon: Balloon,
+        component: Component,
+        showAbove: Boolean,
+        point: Point? = null
+    ) {
+        balloon.show(
+            RelativePoint(
+                component,
+                point ?: Point(component.width / 2, if (showAbove) 0 else component.height)
+            ),
+            if (showAbove) Balloon.Position.above else Balloon.Position.below
+        )
+    }
+
+    fun showInfoBalloonForComponent(message: String, component: Component, showAbove: Boolean = false): Balloon {
+        return SnykBalloonNotificationHelper.createBalloon(
+            message,
+            AllIcons.General.BalloonInformation,
+            MessageType.INFO.popupBackground
+        ).apply {
+            SnykBalloonNotificationHelper.showBalloonForComponent(this, component, showAbove)
+        }
+    }
+
+    fun showWarnBalloonAtEventPlace(message: String, e: AnActionEvent, showAbove: Boolean = false) {
+        val component = e.inputEvent?.component ?: e.getData(PlatformDataKeys.CONTEXT_COMPONENT) ?: return
+        // todo: case if no Component exist (action invoked from Search?)
+        val balloon = SnykBalloonNotificationHelper.createBalloon(
+            message,
+            AllIcons.General.BalloonWarning,
+            MessageType.WARNING.popupBackground
+        )
+        SnykBalloonNotificationHelper.showBalloonForComponent(balloon, component, showAbove)
+    }
+}

--- a/src/main/kotlin/io/snyk/plugin/ui/SnykBalloonNotifications.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/SnykBalloonNotifications.kt
@@ -1,15 +1,9 @@
 package io.snyk.plugin.ui
 
-import com.intellij.icons.AllIcons
 import com.intellij.ide.BrowserUtil
 import com.intellij.notification.Notification
 import com.intellij.notification.NotificationAction
-import com.intellij.notification.NotificationDisplayType
-import com.intellij.notification.NotificationGroup
 import com.intellij.notification.NotificationType
-import com.intellij.openapi.actionSystem.AnAction
-import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.actionSystem.PlatformDataKeys.CONTEXT_COMPONENT
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.options.ShowSettingsUtil
@@ -18,187 +12,117 @@ import com.intellij.openapi.ui.MessageType
 import com.intellij.openapi.ui.popup.Balloon
 import com.intellij.openapi.ui.popup.JBPopupFactory
 import com.intellij.ui.BrowserHyperlinkListener
-import com.intellij.ui.awt.RelativePoint
 import com.intellij.util.Alarm
 import io.snyk.plugin.analytics.getSelectedProducts
-import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.getSnykCodeSettingsUrl
+import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.services.SnykAnalyticsService
 import io.snyk.plugin.services.SnykTaskQueueService
 import io.snyk.plugin.settings.SnykProjectSettingsConfigurable
 import io.snyk.plugin.snykToolWindow
 import io.snyk.plugin.startSastEnablementCheckLoop
+import io.snyk.plugin.ui.SnykBalloonNotificationHelper.GROUP
 import snyk.analytics.AnalysisIsTriggered
-import java.awt.Color
-import java.awt.Component
-import java.awt.Point
 import java.awt.event.MouseEvent
-import javax.swing.Icon
 
-class SnykBalloonNotifications {
+object SnykBalloonNotifications {
 
-    companion object {
-        private val logger = logger<SnykBalloonNotifications>()
-        const val title = "Snyk"
-        private const val groupNeedAction = "SnykNeedAction"
-        private const val groupAutoHide = "SnykAutoHide"
-        private val GROUP = NotificationGroup(groupNeedAction, NotificationDisplayType.STICKY_BALLOON)
+    private val logger = logger<SnykBalloonNotifications>()
+    private val alarm = Alarm()
 
-        const val sastForOrgEnablementMessage = "Snyk Code is disabled by your organisation's configuration."
-        const val networkErrorAlertMessage = "Not able to connect to Snyk server."
+    const val sastForOrgEnablementMessage = "Snyk Code is disabled by your organisation's configuration."
+    const val networkErrorAlertMessage = "Not able to connect to Snyk server."
 
-        private val alarm = Alarm()
-
-        fun showError(message: String, project: Project, vararg actions: AnAction) =
-            showNotification(message, project, NotificationType.ERROR, *actions)
-
-        fun showInfo(message: String, project: Project, vararg actions: AnAction) =
-            showNotification(message, project, NotificationType.INFORMATION, *actions)
-
-        fun showWarn(message: String, project: Project, vararg actions: AnAction) =
-            showNotification(message, project, NotificationType.WARNING, *actions)
-
-        // TODO(pavel): refactor showNotification function to make it more generic + default arguments
-        private fun showNotification(
-            message: String,
-            project: Project,
-            type: NotificationType,
-            vararg actions: AnAction
-        ): Notification {
-            when (type) {
-                NotificationType.ERROR, NotificationType.WARNING -> logger.warn(message)
-                else -> logger.info(message)
-            }
-            val notification = if (actions.isEmpty()) {
-                Notification(groupAutoHide, title, message, type)
-            } else {
-                GROUP.createNotification(title, message, type).apply {
-                    actions.forEach { this.addAction(it) }
-                }
-            }
-            notification.notify(project)
-            return notification
-        }
-
-        fun showWelcomeNotification(project: Project) {
-            val welcomeMessage = "Welcome to Snyk! Check out our tool window to start analyzing your code"
-            logger.info(welcomeMessage)
-            val notification = GROUP.createNotification(
-                welcomeMessage,
-                NotificationType.INFORMATION
-            ).addAction(
-                NotificationAction.createSimpleExpiring("Configure Snyk\u2026") {
-                    snykToolWindow(project)?.show()
-                }
-            )
-            notification.notify(project)
-        }
-
-        fun showSastForOrgEnablement(project: Project): Notification {
-            val notification = showInfo(
-                "$sastForOrgEnablementMessage To enable navigate to ",
-                project,
-                NotificationAction.createSimpleExpiring("Snyk > Settings > Snyk Code") {
-                    BrowserUtil.browse(getSnykCodeSettingsUrl())
-                    startSastEnablementCheckLoop(project)
-                }
-            )
-            var currentAttempt = 1
-            val maxAttempts = 200
-            lateinit var checkIfSastEnabled: () -> Unit
-            checkIfSastEnabled = {
-                if (pluginSettings().sastOnServerEnabled == true) {
-                    notification.expire()
-                } else if (!alarm.isDisposed && currentAttempt < maxAttempts) {
-                    currentAttempt++
-                    alarm.addRequest(checkIfSastEnabled, 1000)
-                }
-            }
-            checkIfSastEnabled.invoke()
-
-            return notification
-        }
-
-        fun showFeedbackRequest(project: Project) = showInfo(
-            "Thank you for using Snyk! Want to help us by taking part in Snyk’s plugin research and get a \$100 Amazon gift card in return?",
-            project,
-            NotificationAction.createSimpleExpiring("Schedule user testing here") {
-                pluginSettings().showFeedbackRequest = false
-                BrowserUtil.browse("https://calendly.com/snyk-georgi/45min")
-            },
-            NotificationAction.createSimpleExpiring("Don’t show again") {
-                pluginSettings().showFeedbackRequest = false
-            }
-        )
-
-        fun showScanningReminder(project: Project) = showInfo(
-            "Scan your project for security vulnerabilities and code issues",
-            project,
-            NotificationAction.createSimpleExpiring("Run scan") {
+    fun showWelcomeNotification(project: Project) {
+        val welcomeMessage = "Welcome to Snyk! Check out our tool window to start analyzing your code"
+        logger.info(welcomeMessage)
+        val notification = GROUP.createNotification(
+            welcomeMessage,
+            NotificationType.INFORMATION
+        ).addAction(
+            NotificationAction.createSimpleExpiring("Configure Snyk\u2026") {
                 snykToolWindow(project)?.show()
-                project.service<SnykTaskQueueService>().scan()
-                project.service<SnykAnalyticsService>().logAnalysisIsTriggered(
-                    AnalysisIsTriggered.builder()
-                        .analysisType(getSelectedProducts(pluginSettings()))
-                        .ide(AnalysisIsTriggered.Ide.JETBRAINS)
-                        .triggeredByUser(true)
-                        .build()
-                )
             }
         )
+        notification.notify(project)
+    }
 
-        fun showNetworkErrorAlert(project: Project) = showError(
-            "$networkErrorAlertMessage Check connection and network settings.",
+    fun showSastForOrgEnablement(project: Project): Notification {
+        val notification = SnykBalloonNotificationHelper.showInfo(
+            "$sastForOrgEnablementMessage To enable navigate to ",
             project,
-            NotificationAction.createSimpleExpiring("Snyk Settings") {
-                ShowSettingsUtil.getInstance()
-                    .showSettingsDialog(project, SnykProjectSettingsConfigurable::class.java)
+            NotificationAction.createSimpleExpiring("Snyk > Settings > Snyk Code") {
+                BrowserUtil.browse(getSnykCodeSettingsUrl())
+                startSastEnablementCheckLoop(project)
             }
         )
-
-        fun showInfoBalloonForComponent(message: String, component: Component, showAbove: Boolean = false): Balloon {
-            return createBalloon(message, AllIcons.General.BalloonInformation, MessageType.INFO.popupBackground).apply {
-                showBalloonForComponent(this, component, showAbove)
+        var currentAttempt = 1
+        val maxAttempts = 200
+        lateinit var checkIfSastEnabled: () -> Unit
+        checkIfSastEnabled = {
+            if (pluginSettings().sastOnServerEnabled == true) {
+                notification.expire()
+            } else if (!alarm.isDisposed && currentAttempt < maxAttempts) {
+                currentAttempt++
+                alarm.addRequest(checkIfSastEnabled, 1000)
             }
         }
+        checkIfSastEnabled.invoke()
 
-        fun showAdvisorMoreDetailsPopup(htmlMessage: String, mouseEvent: MouseEvent): Balloon {
-            val balloon = JBPopupFactory.getInstance().createHtmlTextBalloonBuilder(
-                htmlMessage,
-                null,
-                MessageType.WARNING.popupBackground,
-                BrowserHyperlinkListener.INSTANCE
-            )
-                .setHideOnClickOutside(true)
-                .setAnimationCycle(300)
-                .createBalloon()
+        return notification
+    }
 
-            showBalloonForComponent(balloon, mouseEvent.component, true, mouseEvent.point)
-
-            return balloon
+    fun showFeedbackRequest(project: Project) = SnykBalloonNotificationHelper.showInfo(
+        "Thank you for using Snyk! Want to help us by taking part in Snyk’s plugin research and " +
+            "get a \$100 Amazon gift card in return?",
+        project,
+        NotificationAction.createSimpleExpiring("Schedule user testing here") {
+            pluginSettings().showFeedbackRequest = false
+            BrowserUtil.browse("https://calendly.com/snyk-georgi/45min")
+        },
+        NotificationAction.createSimpleExpiring("Don’t show again") {
+            pluginSettings().showFeedbackRequest = false
         }
+    )
 
-        fun showWarnBalloonAtEventPlace(message: String, e: AnActionEvent, showAbove: Boolean = false) {
-            val component = e.inputEvent?.component ?: e.getData(CONTEXT_COMPONENT) ?: return
-            //todo: case if no Component exist (action invoked from Search?)
-            val balloon = createBalloon(message, AllIcons.General.BalloonWarning, MessageType.WARNING.popupBackground)
-            showBalloonForComponent(balloon, component, showAbove)
-        }
-
-        private fun createBalloon(message: String, icon: Icon, color: Color): Balloon =
-            JBPopupFactory.getInstance().createHtmlTextBalloonBuilder(message, icon, color, null)
-                .setHideOnClickOutside(true)
-                .setFadeoutTime(5000)
-                .createBalloon()
-
-        private fun showBalloonForComponent(balloon: Balloon, component: Component, showAbove: Boolean, point: Point? = null) {
-            balloon.show(
-                RelativePoint(
-                    component,
-                    point ?: Point(component.width / 2, if (showAbove) 0 else component.height)
-                ),
-                if (showAbove) Balloon.Position.above else Balloon.Position.below
+    fun showScanningReminder(project: Project) = SnykBalloonNotificationHelper.showInfo(
+        "Scan your project for security vulnerabilities and code issues",
+        project,
+        NotificationAction.createSimpleExpiring("Run scan") {
+            snykToolWindow(project)?.show()
+            project.service<SnykTaskQueueService>().scan()
+            project.service<SnykAnalyticsService>().logAnalysisIsTriggered(
+                AnalysisIsTriggered.builder()
+                    .analysisType(getSelectedProducts(pluginSettings()))
+                    .ide(AnalysisIsTriggered.Ide.JETBRAINS)
+                    .triggeredByUser(true)
+                    .build()
             )
         }
+    )
+
+    fun showNetworkErrorAlert(project: Project) = SnykBalloonNotificationHelper.showError(
+        "$networkErrorAlertMessage Check connection and network settings.",
+        project,
+        NotificationAction.createSimpleExpiring("Snyk Settings") {
+            ShowSettingsUtil.getInstance()
+                .showSettingsDialog(project, SnykProjectSettingsConfigurable::class.java)
+        }
+    )
+
+    fun showAdvisorMoreDetailsPopup(htmlMessage: String, mouseEvent: MouseEvent): Balloon {
+        val balloon = JBPopupFactory.getInstance().createHtmlTextBalloonBuilder(
+            htmlMessage,
+            null,
+            MessageType.WARNING.popupBackground,
+            BrowserHyperlinkListener.INSTANCE
+        )
+            .setHideOnClickOutside(true)
+            .setAnimationCycle(300)
+            .createBalloon()
+
+        SnykBalloonNotificationHelper.showBalloonForComponent(balloon, mouseEvent.component, true, mouseEvent.point)
+
+        return balloon
     }
 }

--- a/src/main/kotlin/io/snyk/plugin/ui/actions/SnykTreeScanTypeFilterAction.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/actions/SnykTreeScanTypeFilterAction.kt
@@ -8,12 +8,12 @@ import com.intellij.openapi.actionSystem.ex.ComboBoxAction
 import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.project.Project
 import io.snyk.plugin.events.SnykResultsFilteringListener
-import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.getSyncPublisher
 import io.snyk.plugin.isIacEnabled
 import io.snyk.plugin.isSnykCodeAvailable
+import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.settings.SnykProjectSettingsConfigurable
-import io.snyk.plugin.ui.SnykBalloonNotifications
+import io.snyk.plugin.ui.SnykBalloonNotificationHelper
 import io.snyk.plugin.ui.snykCodeAvailabilityPostfix
 import javax.swing.JComponent
 
@@ -116,7 +116,7 @@ class SnykTreeScanTypeFilterAction : ComboBoxAction() {
             settings.iacScanEnabled
         ).count { it } == 1
         if (onlyOneEnabled) {
-            SnykBalloonNotifications.showWarnBalloonAtEventPlace("At least one Scan type should be selected", e)
+            SnykBalloonNotificationHelper.showWarnBalloonAtEventPlace("At least one Scan type should be selected", e)
         }
         return onlyOneEnabled
     }

--- a/src/main/kotlin/io/snyk/plugin/ui/actions/SnykTreeSeverityFilterActionBase.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/actions/SnykTreeSeverityFilterActionBase.kt
@@ -3,7 +3,7 @@ package io.snyk.plugin.ui.actions
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.ToggleAction
 import io.snyk.plugin.pluginSettings
-import io.snyk.plugin.ui.SnykBalloonNotifications
+import io.snyk.plugin.ui.SnykBalloonNotificationHelper
 
 abstract class SnykTreeSeverityFilterActionBase : ToggleAction() {
 
@@ -18,7 +18,10 @@ abstract class SnykTreeSeverityFilterActionBase : ToggleAction() {
         ).count { it } == 1
 
         if (onlyOneEnabled) {
-            SnykBalloonNotifications.showWarnBalloonAtEventPlace("At least one Severity type should be selected", e)
+            SnykBalloonNotificationHelper.showWarnBalloonAtEventPlace(
+                "At least one Severity type should be selected",
+                e
+            )
         }
 
         return onlyOneEnabled

--- a/src/main/kotlin/io/snyk/plugin/ui/settings/ScanTypesPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/settings/ScanTypesPanel.kt
@@ -19,7 +19,7 @@ import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.services.SnykApiService
 import io.snyk.plugin.snykcode.core.SnykCodeUtils
 import io.snyk.plugin.startSastEnablementCheckLoop
-import io.snyk.plugin.ui.SnykBalloonNotifications
+import io.snyk.plugin.ui.SnykBalloonNotificationHelper
 import java.awt.Component
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
@@ -155,7 +155,7 @@ class ScanTypesPanel(
     inner class ShowHintMouseAdapter(val component: Component, val text: String) : MouseAdapter() {
         override fun mouseClicked(e: MouseEvent?) {
             currentHint?.hide()
-            currentHint = SnykBalloonNotifications.showInfoBalloonForComponent(text, component, true)
+            currentHint = SnykBalloonNotificationHelper.showInfoBalloonForComponent(text, component, true)
         }
     }
 

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
@@ -21,20 +21,17 @@ import io.snyk.plugin.Severity
 import io.snyk.plugin.analytics.getIssueSeverityOrNull
 import io.snyk.plugin.analytics.getIssueType
 import io.snyk.plugin.analytics.getSelectedProducts
-import snyk.common.SnykError
-import snyk.oss.OssResult
-import snyk.oss.Vulnerability
 import io.snyk.plugin.events.SnykCliDownloadListener
 import io.snyk.plugin.events.SnykResultsFilteringListener
 import io.snyk.plugin.events.SnykScanListener
 import io.snyk.plugin.events.SnykSettingsListener
 import io.snyk.plugin.events.SnykTaskQueueListener
-import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.head
 import io.snyk.plugin.isCliDownloading
-import io.snyk.plugin.isScanRunning
 import io.snyk.plugin.isOssRunning
+import io.snyk.plugin.isScanRunning
 import io.snyk.plugin.isSnykCodeRunning
+import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.services.SnykAnalyticsService
 import io.snyk.plugin.services.SnykCliDownloaderService
 import io.snyk.plugin.services.SnykTaskQueueService
@@ -43,7 +40,7 @@ import io.snyk.plugin.snykcode.core.AnalysisData
 import io.snyk.plugin.snykcode.core.PDU
 import io.snyk.plugin.snykcode.core.SnykCodeIgnoreInfoHolder
 import io.snyk.plugin.snykcode.severityAsString
-import io.snyk.plugin.ui.SnykBalloonNotifications
+import io.snyk.plugin.ui.SnykBalloonNotificationHelper
 import snyk.analytics.AnalysisIsReady
 import snyk.analytics.AnalysisIsReady.Result
 import snyk.analytics.AnalysisIsTriggered
@@ -51,6 +48,9 @@ import snyk.analytics.IssueIsViewed
 import snyk.analytics.ProductSelectionIsViewed
 import snyk.analytics.WelcomeIsViewed
 import snyk.analytics.WelcomeIsViewed.Ide.JETBRAINS
+import snyk.common.SnykError
+import snyk.oss.OssResult
+import snyk.oss.Vulnerability
 import java.awt.BorderLayout
 import java.time.Instant
 import java.util.Objects.nonNull
@@ -161,7 +161,7 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
                 override fun scanningOssError(snykError: SnykError) {
                     currentOssResults = null
                     ApplicationManager.getApplication().invokeLater {
-                        SnykBalloonNotifications.showError(snykError.message, project)
+                        SnykBalloonNotificationHelper.showError(snykError.message, project)
                         if (snykError.message.startsWith("Authentication failed. Please check the API token on ")) {
                             pluginSettings().token = null
                             displayAuthPanel()

--- a/src/main/kotlin/snyk/advisor/AdvisorScoreProvider.kt
+++ b/src/main/kotlin/snyk/advisor/AdvisorScoreProvider.kt
@@ -184,7 +184,8 @@ class AdvisorScoreProvider(
 
         /** see [com.intellij.xdebugger.impl.evaluate.XDebuggerEditorLinePainter.getNormalAttributes] */
         private fun getNormalAttributes(): TextAttributes {
-            val attributes = EditorColorsManager.getInstance().globalScheme.getAttributes(DefaultLanguageHighlighterColors.BLOCK_COMMENT)
+            val attributes = EditorColorsManager.getInstance()
+                .globalScheme.getAttributes(DefaultLanguageHighlighterColors.BLOCK_COMMENT)
             return if (attributes == null || attributes.foregroundColor == null) {
                 TextAttributes(
                     JBColor { if (EditorColorsManager.getInstance().isDarkEditor) Color(0x3d8065) else Gray._135 },

--- a/src/test/kotlin/io/snyk/plugin/services/SnykCliDownloaderErrorHandlerTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/services/SnykCliDownloaderErrorHandlerTest.kt
@@ -1,0 +1,173 @@
+package io.snyk.plugin.services
+
+import com.intellij.notification.NotificationAction
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.project.Project
+import com.intellij.util.io.HttpRequests
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.verify
+import io.snyk.plugin.getCliFile
+import io.snyk.plugin.ui.SnykBalloonNotificationHelper
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.io.IOException
+import kotlin.test.assertEquals
+
+class SnykCliDownloaderErrorHandlerTest {
+
+    private lateinit var cut: SnykCliDownloaderErrorHandler
+
+    @Before
+    fun setUp() {
+        cut = SnykCliDownloaderErrorHandler()
+        mockkObject(SnykBalloonNotificationHelper)
+    }
+
+    @After
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun showErrorWithWithRetryAndContactAction_shouldShowErrorWithActions() {
+        val notificationMessage = "Test message"
+        val project = mockk<Project>()
+        val retryActionSlot = slot<NotificationAction>()
+        val contactActionSlot = slot<NotificationAction>()
+        val messageSlot = slot<String>()
+        val projectSlot = slot<Project>()
+
+        every {
+            SnykBalloonNotificationHelper.showError(
+                capture(messageSlot),
+                capture(projectSlot),
+                capture(retryActionSlot),
+                capture(contactActionSlot)
+            )
+        } returns mockk()
+
+        cut.showErrorWithRetryAndContactAction(notificationMessage, mockk(), project)
+
+        assertEquals("Retry CLI download", retryActionSlot.captured.templateText)
+        assertEquals("Contact support...", contactActionSlot.captured.templateText)
+        assertEquals(notificationMessage, messageSlot.captured)
+        assertEquals(project, projectSlot.captured)
+
+        verify(exactly = 1) {
+            SnykBalloonNotificationHelper.showError(any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun handleIOException_shouldTryAgainAndShowErrorWithActions() {
+        val project = mockk<Project>()
+        val indicator = mockk<ProgressIndicator>()
+        val retryActionSlot = slot<NotificationAction>()
+        val contactActionSlot = slot<NotificationAction>()
+        val messageSlot = slot<String>()
+        val projectSlot = slot<Project>()
+        val downloaderService = mockk<SnykCliDownloaderService>()
+        val latestReleaseInfo =
+            LatestReleaseInfo(1, "release-url", "release-name", "release-tagName")
+        val exception = IOException("Read Timed Out")
+        val notificationMessage = cut.getNetworkErrorNotificationMessage(exception)
+
+        every {
+            SnykBalloonNotificationHelper.showError(
+                capture(messageSlot),
+                capture(projectSlot),
+                capture(retryActionSlot),
+                capture(contactActionSlot)
+            )
+        } returns mockk()
+
+        every { project.getService(SnykCliDownloaderService::class.java) } returns downloaderService
+        every { downloaderService.getLatestReleaseInfo() } returns latestReleaseInfo
+        every { downloaderService.downloadFile(any(), any(), any()) } returns getCliFile()
+
+        cut.handleIOException(exception, indicator, project)
+
+        // verify notification
+        assertEquals("Retry CLI download", retryActionSlot.captured.templateText)
+        assertEquals("Contact support...", contactActionSlot.captured.templateText)
+        assertEquals(notificationMessage, messageSlot.captured)
+        assertEquals(project, projectSlot.captured)
+
+        verify(exactly = 1) {
+            downloaderService.downloadFile(getCliFile(), latestReleaseInfo.tagName, indicator)
+            SnykBalloonNotificationHelper.showError(any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun handleIOException_shouldOnlyShowErrorWithActionsWhenReleaseInfoEmpty() {
+        val project = mockk<Project>()
+        val indicator = mockk<ProgressIndicator>()
+        val retryActionSlot = slot<NotificationAction>()
+        val contactActionSlot = slot<NotificationAction>()
+        val messageSlot = slot<String>()
+        val projectSlot = slot<Project>()
+        val downloaderService = mockk<SnykCliDownloaderService>()
+        val exception = IOException("Read Timed Out")
+
+        every {
+            SnykBalloonNotificationHelper.showError(
+                capture(messageSlot),
+                capture(projectSlot),
+                capture(retryActionSlot),
+                capture(contactActionSlot)
+            )
+        } returns mockk()
+
+        every { project.getService(SnykCliDownloaderService::class.java) } returns downloaderService
+        every { downloaderService.getLatestReleaseInfo() } returns null
+
+        cut.handleIOException(exception, indicator, project)
+
+        // verify notification
+        assertEquals("Retry CLI download", retryActionSlot.captured.templateText)
+        assertEquals("Contact support...", contactActionSlot.captured.templateText)
+        assertEquals(cut.getNetworkErrorNotificationMessage(exception), messageSlot.captured)
+        assertEquals(project, projectSlot.captured)
+
+        verify(exactly = 1) {
+            SnykBalloonNotificationHelper.showError(any(), any(), any(), any())
+        }
+
+        verify(exactly = 0) {
+            downloaderService.downloadFile(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun handleHttpStatusException_shouldDisplayErrorMessage() {
+        val project = mockk<Project>()
+        val exception = HttpRequests.HttpStatusException("Forbidden", 403, "url")
+
+        val contactActionSlot = slot<NotificationAction>()
+        val messageSlot = slot<String>()
+        val projectSlot = slot<Project>()
+        every {
+            SnykBalloonNotificationHelper.showError(
+                capture(messageSlot),
+                capture(projectSlot),
+                capture(contactActionSlot)
+            )
+        } returns mockk()
+
+        cut.handleHttpStatusException(exception, project)
+
+        assertEquals(cut.getHttpStatusErrorNotificationMessage(exception), messageSlot.captured)
+        assertEquals(project, projectSlot.captured)
+        assertEquals("Contact support...", contactActionSlot.captured.templateText)
+
+        verify(exactly = 1) {
+            SnykBalloonNotificationHelper.showError(any(), any(), any())
+        }
+    }
+}


### PR DESCRIPTION
We have been getting reports of IOExceptions and HttpStatusException for failing downloads. In order to better handle them, I have added an error handler that is responsible for error handling the CLI download. The functionality is covered with integration and unit tests.

When an IO error (SocketTimeout, Connection Reset, DNS, etc) occurs
- retry once
- display error balloon notification with retry & contact support actions

When an HTTP Status Exception (HTTP 4xx, 5xx) occurs:
- display error balloon
- don't retry download