### PR TITLE
Create sentry release when releasing [ROAD-432]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,3 +23,13 @@ jobs:
           ORG_GRADLE_PROJECT_iterativelyEnvironment: "PRODUCTION"
           ORG_GRADLE_PROJECT_segmentWriteKey: ${{ secrets.SEGMENT_WRITE_KEY }}
         run: ./gradlew publishPlugin
+
+      - name: Create Sentry release
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        with:
+          version: ${{ github.event.release.tag_name }}
+


### PR DESCRIPTION
Sentry releases should be created when the plugin is released. This PR adds a release step to do this using the Sentry github extension.

Extension: https://github.com/getsentry/action-release/blob/master/action.yml