### PR TITLE
fix: ExecutionException from tests reported to Sentry [ROAD-447]

### DIFF
--- a/src/main/kotlin/io/snyk/plugin/cli/ConsoleCommandRunner.kt
+++ b/src/main/kotlin/io/snyk/plugin/cli/ConsoleCommandRunner.kt
@@ -40,7 +40,9 @@ open class ConsoleCommandRunner {
             OSProcessHandler(generalCommandLine)
         } catch (e: ExecutionException) {
             //  if CLI is still downloading (or temporarily blocked by Antivirus) we'll get ProcessNotCreatedException
-            SnykBalloonNotificationHelper.showWarn("Not able to run CLI, try again later.", project)
+            val message = "Not able to run CLI, try again later."
+            SnykBalloonNotificationHelper.showWarn(message, project)
+            logger.warn(message, e)
             return ""
         }
         val parentIndicator = ProgressManager.getInstance().progressIndicator

--- a/src/main/kotlin/snyk/PluginInformation.kt
+++ b/src/main/kotlin/snyk/PluginInformation.kt
@@ -1,3 +1,4 @@
+@file:JvmName("PluginInformationKt")
 package snyk
 
 import com.intellij.ide.plugins.PluginManagerCore

--- a/src/main/kotlin/snyk/errorHandler/SentryErrorReporter.kt
+++ b/src/main/kotlin/snyk/errorHandler/SentryErrorReporter.kt
@@ -1,5 +1,6 @@
 package snyk.errorHandler
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Attachment
 import com.intellij.openapi.diagnostic.SubmittedReportInfo
 import com.intellij.openapi.diagnostic.SubmittedReportInfo.SubmissionStatus
@@ -104,6 +105,8 @@ object SentryErrorReporter {
      * Note: [io.snyk.plugin.services.SnykApplicationSettingsStateService.crashReportingEnabled] is respected
      */
     fun captureException(throwable: Throwable): SentryId {
+        if (ApplicationManager.getApplication().isUnitTestMode) return SentryId.EMPTY_ID
+
         val settings = pluginSettings()
         return if (settings.crashReportingEnabled) {
             val sentryId = Sentry.captureException(throwable)

--- a/src/test/kotlin/snyk/errorHandler/SentryErrorReporterTest.kt
+++ b/src/test/kotlin/snyk/errorHandler/SentryErrorReporterTest.kt
@@ -1,0 +1,89 @@
+package snyk.errorHandler
+
+import com.intellij.openapi.application.Application
+import com.intellij.openapi.application.ApplicationManager
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.verify
+import io.sentry.Sentry
+import io.sentry.protocol.SentryId
+import io.snyk.plugin.pluginSettings
+import io.snyk.plugin.services.SnykApplicationSettingsStateService
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import snyk.PluginInformation
+import snyk.pluginInfo
+
+class SentryErrorReporterTest {
+    @Before
+    fun setUp() {
+        clearAllMocks()
+        mockkStatic(Sentry::class)
+        // never send to Sentry
+        every { Sentry.captureException(any()) } returns SentryId()
+    }
+
+    @After
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `captureException should send exceptions to Sentry when crashReportingEnabled is true`() {
+        val settings = mockPluginInformation()
+        setUnitTesting(false)
+        settings.crashReportingEnabled = true
+
+        SentryErrorReporter.captureException(RuntimeException("test"))
+
+        verify(exactly = 1) { Sentry.captureException(any()) }
+    }
+
+    @Test
+    fun `captureException should not send exceptions to Sentry when crashReportingEnabled is false`() {
+        val settings = mockPluginInformation()
+        setUnitTesting(false)
+        settings.crashReportingEnabled = false
+
+        val e = RuntimeException("test")
+        SentryErrorReporter.captureException(e)
+
+        verify(exactly = 0) { Sentry.captureException(any()) }
+    }
+
+    @Test
+    fun `captureException should not send exceptions to Sentry when testing detected`() {
+        val settings = mockPluginInformation()
+        settings.crashReportingEnabled = true
+        setUnitTesting(true)
+        SentryErrorReporter.captureException(RuntimeException("test"))
+
+        verify(exactly = 0) { Sentry.captureException(any()) }
+    }
+
+    private fun mockPluginInformation(): SnykApplicationSettingsStateService {
+        mockkStatic("io.snyk.plugin.Utils")
+        val settings = SnykApplicationSettingsStateService()
+        every { pluginSettings() } returns settings
+
+        mockkStatic("snyk.PluginInformationKt")
+        val pluginInformation = PluginInformation(
+            "testIntegrationName",
+            "testIntegrationVersion",
+            "testIntegrationEnvironment",
+            "testIntegrationEnvironmentVersion"
+        )
+        every { pluginInfo } returns pluginInformation
+        return settings
+    }
+
+    private fun setUnitTesting(boolean: Boolean) {
+        mockkStatic(ApplicationManager::class)
+        val applicationMock = mockk<Application>()
+        every { ApplicationManager.getApplication() } returns applicationMock
+        every { applicationMock.isUnitTestMode } returns boolean
+    }
+}


### PR DESCRIPTION
Prevent call to Sentry from ConsoleCommandRunner tests by mocking Sentry Error Reporter. Side-effect is that we can verify that actual Sentry error reporting is triggered by the integration tests.