### PR TITLE
fix: 🐛 Network shouldn't be accessed in EDT or inside read action

### DIFF
--- a/src/integTest/kotlin/io/snyk/plugin/services/download/CliDownloaderErrorHandlerIntegTest.kt
+++ b/src/integTest/kotlin/io/snyk/plugin/services/download/CliDownloaderErrorHandlerIntegTest.kt
@@ -1,0 +1,79 @@
+package io.snyk.plugin.services.download
+
+import com.intellij.openapi.progress.EmptyProgressIndicator
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.progress.Task
+import com.intellij.openapi.project.Project
+import com.intellij.testFramework.LightPlatformTestCase
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.spyk
+import io.mockk.verify
+import io.snyk.plugin.getCliFile
+import io.snyk.plugin.ui.SnykBalloonNotificationHelper
+import java.io.IOException
+
+class CliDownloaderErrorHandlerIntegTest : LightPlatformTestCase() {
+    private lateinit var progressManager: ProgressManager
+    private lateinit var cliDownloaderServiceMock: SnykCliDownloaderService
+    private lateinit var cliDownloaderMock: CliDownloader
+    private lateinit var projectSpy: Project
+    private lateinit var cut: CliDownloaderErrorHandler
+    private lateinit var indicator: EmptyProgressIndicator
+
+    override fun setUp() {
+        super.setUp()
+        clearAllMocks()
+        mockkObject(SnykBalloonNotificationHelper)
+
+        mockkStatic(ProgressManager::class)
+        progressManager = spyk(ProgressManager.getInstance())
+        every { ProgressManager.getInstance() } returns progressManager
+
+        cliDownloaderServiceMock = mockk()
+        cliDownloaderMock = mockk()
+        projectSpy = spyk(project)
+        cut = CliDownloaderErrorHandler()
+        indicator = EmptyProgressIndicator()
+        every { projectSpy.getService(SnykCliDownloaderService::class.java) } returns cliDownloaderServiceMock
+        every { cliDownloaderServiceMock.downloader } returns cliDownloaderMock
+    }
+
+    override fun tearDown() {
+        super.tearDown()
+        clearAllMocks()
+    }
+
+    fun testHandleIOExceptionShouldRetryDownloadAndShowBalloonIfItFails() {
+        val e = IOException("Expected Test Exception, don't panic")
+        every { cliDownloaderMock.downloadFile(any(), any()) } throws e
+
+        cut.handleIOException(e, indicator, projectSpy)
+
+        verify(exactly = 1) { cliDownloaderMock.downloadFile(getCliFile(), indicator) }
+        verify(exactly = 1) { progressManager.run(any<Task.Backgroundable>()) }
+        verify(exactly = 1) {
+            SnykBalloonNotificationHelper.showError(
+                cut.getNetworkErrorNotificationMessage(e), projectSpy, any(), any()
+            )
+        }
+    }
+
+    fun testHandleChecksumVerificationExceptionShouldRetryDownloadAndShowBalloonIfItFails() {
+        val e = ChecksumVerificationException("Expected Test Exception, don't panic")
+        every { cliDownloaderMock.downloadFile(any(), any()) } throws e
+
+        cut.handleChecksumVerificationException(e, indicator, projectSpy)
+
+        verify(exactly = 1) { cliDownloaderMock.downloadFile(getCliFile(), indicator) }
+        verify(exactly = 1) { progressManager.run(any<Task.Backgroundable>()) }
+        verify(exactly = 1) {
+            SnykBalloonNotificationHelper.showError(
+                cut.getChecksumFailedNotificationMessage(e), projectSpy, any(), any()
+            )
+        }
+    }
+}

--- a/src/integTest/kotlin/io/snyk/plugin/services/download/CliDownloaderServiceIntegTest.kt
+++ b/src/integTest/kotlin/io/snyk/plugin/services/download/CliDownloaderServiceIntegTest.kt
@@ -1,4 +1,4 @@
-package io.snyk.plugin.services
+package io.snyk.plugin.services.download
 
 import com.intellij.openapi.components.service
 import com.intellij.openapi.progress.EmptyProgressIndicator
@@ -15,9 +15,6 @@ import io.snyk.plugin.getCliFile
 import io.snyk.plugin.getPluginPath
 import io.snyk.plugin.pluginSettings
 import org.apache.http.HttpStatus
-import io.snyk.plugin.services.download.CliDownloader
-import io.snyk.plugin.services.download.CliDownloaderErrorHandler
-import io.snyk.plugin.services.download.SnykCliDownloaderService
 import org.junit.Before
 import org.junit.Test
 import java.io.File

--- a/src/main/kotlin/io/snyk/plugin/services/download/CliDownloaderErrorHandler.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/download/CliDownloaderErrorHandler.kt
@@ -2,7 +2,9 @@ package io.snyk.plugin.services.download
 
 import com.intellij.ide.BrowserUtil
 import com.intellij.notification.NotificationAction
+import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.runBackgroundableTask
 import com.intellij.openapi.project.Project
 import com.intellij.util.io.HttpRequests
 import io.snyk.plugin.getCliFile
@@ -14,6 +16,9 @@ class CliDownloaderErrorHandler {
         SnykBalloonNotificationHelper.showError(message, project,
             NotificationAction.createSimple("Retry CLI download") {
                 project.getService(SnykCliDownloaderService::class.java).downloadLatestRelease(indicator, project)
+                runBackgroundableTask("Retry Snyk CLI Download", project, false) {
+                    project.getService(SnykCliDownloaderService::class.java).downloadLatestRelease(it, project)
+                }
             },
             NotificationAction.createSimple("Contact support...") {
                 BrowserUtil.browse("https://snyk.io/contact-us/?utm_source=JETBRAINS_IDE")
@@ -21,9 +26,20 @@ class CliDownloaderErrorHandler {
     }
 
     fun handleIOException(exception: IOException, indicator: ProgressIndicator, project: Project) {
-        val downloader = project.getService(SnykCliDownloaderService::class.java).downloader
-        downloader.downloadFile(getCliFile(), indicator)
-        showErrorWithRetryAndContactAction(getNetworkErrorNotificationMessage(exception), indicator, project)
+        retryDownload(project, indicator, getNetworkErrorNotificationMessage(exception))
+    }
+
+    private fun retryDownload(project: Project, indicator: ProgressIndicator, message: String) {
+        try {
+            runBackgroundableTask("Retry CLI Download", project, false) {
+                val downloader = project.getService(SnykCliDownloaderService::class.java).downloader
+                downloader.downloadFile(getCliFile(), indicator)
+            }
+        } catch (throwable: Throwable) { // we must catch throwable as IntelliJ could throw AssertionError
+            // IntelliJ throws an exception if we log an error, and in this case it is just the retry that failed
+            logger<CliDownloaderErrorHandler>().warn("Retry of downloading the Snyk CLI failed.", throwable)
+            showErrorWithRetryAndContactAction(message, indicator, project)
+        }
     }
 
     fun getNetworkErrorNotificationMessage(exception: IOException) =
@@ -47,9 +63,7 @@ class CliDownloaderErrorHandler {
         indicator: ProgressIndicator,
         project: Project
     ) {
-        val downloader = project.getService(SnykCliDownloaderService::class.java).downloader
-        downloader.downloadFile(getCliFile(), indicator)
-        showErrorWithRetryAndContactAction(getChecksumFailedNotificationMessage(e), indicator, project)
+        retryDownload(project, indicator, getChecksumFailedNotificationMessage(e))
     }
 
     fun getChecksumFailedNotificationMessage(exception: ChecksumVerificationException) =


### PR DESCRIPTION
Moved CLI download retry logic into background thread