### PR TITLE
Refactor SnykToolWindowPanel unit test to not use jetbrains test base class

### DIFF
--- a/src/main/kotlin/snyk/amplitude/AmplitudeExperimentService.kt
+++ b/src/main/kotlin/snyk/amplitude/AmplitudeExperimentService.kt
@@ -68,6 +68,7 @@ class AmplitudeExperimentService : Disposable {
     }
 
     fun isShowScanningReminderEnabled(): Boolean {
+        pluginSettings().usageAnalyticsEnabled || return false
         val variant = storage["intellij-show-scanning-reminder"] ?: return false
 
         val settings = pluginSettings()
@@ -77,6 +78,7 @@ class AmplitudeExperimentService : Disposable {
     }
 
     fun isPartOfExperimentalWelcomeWorkflow(): Boolean {
+        pluginSettings().usageAnalyticsEnabled || return false
         val variant = storage[CHANGE_AUTHENTICATE_BUTTON] ?: return false
         return variant.value == TEST_GROUP
     }

--- a/src/test/kotlin/io/snyk/plugin/SnykBaseTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/SnykBaseTest.kt
@@ -3,16 +3,20 @@ package io.snyk.plugin
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
+import com.intellij.util.messages.MessageBus
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.spyk
 import io.mockk.unmockkAll
+import io.snyk.plugin.events.SnykSettingsListener
 import org.junit.After
 import org.junit.Before
 
 open class SnykBaseTest {
-    val project = mockk<Project>()
+    val messageBus = mockk<MessageBus>(relaxed = true)
+    val snykSettingsSyncPublisher = spyk<SnykSettingsListener>()
+    val project = mockk<Project>(relaxed = true)
     val application = mockk<Application>(relaxed = true)
 
     @Before
@@ -20,6 +24,13 @@ open class SnykBaseTest {
         unmockkAll()
         mockkStatic(ApplicationManager::class)
         replaceApplicationWithMockAndSetUnitTestMode()
+        stubMessageBus()
+    }
+
+    private fun stubMessageBus() {
+        every { project.messageBus } returns messageBus
+        every { messageBus.isDisposed } returns false
+        every { messageBus.syncPublisher(SnykSettingsListener.SNYK_SETTINGS_TOPIC) } returns snykSettingsSyncPublisher
     }
 
     @After

--- a/src/test/kotlin/io/snyk/plugin/SnykBaseTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/SnykBaseTest.kt
@@ -1,0 +1,49 @@
+package io.snyk.plugin
+
+import com.intellij.openapi.application.Application
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.project.Project
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.spyk
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Before
+
+open class SnykBaseTest {
+    val project = mockk<Project>()
+    val application = mockk<Application>(relaxed = true)
+
+    @Before
+    open fun setUp() {
+        unmockkAll()
+        mockkStatic(ApplicationManager::class)
+        replaceApplicationWithMockAndSetUnitTestMode()
+    }
+
+    @After
+    open fun tearDown() {
+        unmockkAll()
+    }
+
+    private fun replaceApplicationWithMockAndSetUnitTestMode() {
+        every { ApplicationManager.getApplication() } returns application
+        every { application.isUnitTestMode } returns true
+        every { application.isHeadlessEnvironment } returns true
+    }
+
+    inline fun <reified T : Any> replaceServiceWithMock(relaxed: Boolean = false): T {
+        val mock: T = mockk(relaxed = relaxed)
+        every { application.getService(T::class.java) } returns mock
+        every { project.getService(T::class.java) } returns mock
+        return mock
+    }
+
+    inline fun <reified T : Any> replaceServiceWithSpy(): T {
+        val spy: T = spyk()
+        every { application.getService(T::class.java) } returns spy
+        every { project.getService(T::class.java) } returns spy
+        return spy
+    }
+}

--- a/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanelTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanelTest.kt
@@ -1,64 +1,80 @@
 package io.snyk.plugin.ui.toolwindow
 
-import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.actionSystem.ActionGroup
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.ActionToolbar
 import com.intellij.openapi.util.registry.Registry
-import com.intellij.testFramework.LightPlatform4TestCase
-import com.intellij.testFramework.replaceService
+import com.intellij.ui.ExpandableItemsHandlerFactory
 import com.intellij.ui.OnePixelSplitter
+import com.intellij.ui.TreeSpeedSearch
 import com.intellij.ui.treeStructure.Tree
 import io.mockk.every
 import io.mockk.justRun
-import io.mockk.mockk
 import io.mockk.mockkStatic
+import io.mockk.spyk
 import io.mockk.unmockkAll
 import io.mockk.unmockkStatic
 import io.mockk.verify
+import io.snyk.plugin.SnykBaseTest
 import io.snyk.plugin.services.SnykAnalyticsService
 import io.snyk.plugin.services.SnykApiService
 import io.snyk.plugin.services.SnykApplicationSettingsStateService
 import io.snyk.plugin.services.SnykTaskQueueService
+import io.snyk.plugin.services.download.SnykCliDownloaderService
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertNotNull
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
 import snyk.UIComponentFinder
 import snyk.amplitude.AmplitudeExperimentService
 import java.awt.Container
+import javax.swing.JTree
 
-class SnykToolWindowPanelTest : LightPlatform4TestCase() {
-    private val analyticsService: SnykAnalyticsService = mockk(relaxed = true)
-    private val taskQueueService = mockk<SnykTaskQueueService>(relaxed = true)
-    private val snykApiServiceMock = mockk<SnykApiService>()
-    private val settings = mockk<SnykApplicationSettingsStateService>(relaxed = true)
-    private val amplitudeExperimentationServiceMock = mockk<AmplitudeExperimentService>()
+class SnykToolWindowPanelTest : SnykBaseTest() {
+    private val analyticsService: SnykAnalyticsService = replaceServiceWithMock(true)
+    private val taskQueueService: SnykTaskQueueService = replaceServiceWithMock(true)
+    private val snykApiServiceMock: SnykApiService = replaceServiceWithMock(true)
+    private val settings: SnykApplicationSettingsStateService = replaceServiceWithMock(true)
+    private val amplitudeExperimentationServiceMock: AmplitudeExperimentService = replaceServiceWithMock()
+
     private lateinit var cut: SnykToolWindowPanel
 
+    @Before
     override fun setUp() {
         super.setUp()
-        unmockkAll()
-
-        ApplicationManager.getApplication()
-            .replaceService(SnykApplicationSettingsStateService::class.java, settings, project)
-        ApplicationManager.getApplication()
-            .replaceService(SnykApiService::class.java, snykApiServiceMock, project)
-        ApplicationManager.getApplication()
-            .replaceService(SnykTaskQueueService::class.java, taskQueueService, project)
-        ApplicationManager.getApplication()
-            .replaceService(SnykAnalyticsService::class.java, analyticsService, project)
-        ApplicationManager.getApplication()
-            .replaceService(AmplitudeExperimentService::class.java, amplitudeExperimentationServiceMock, project)
-
-        project.replaceService(AmplitudeExperimentService::class.java, amplitudeExperimentationServiceMock, project)
-        project.replaceService(SnykTaskQueueService::class.java, taskQueueService, project)
-        project.replaceService(SnykApplicationSettingsStateService::class.java, settings, project)
-        project.replaceService(SnykAnalyticsService::class.java, analyticsService, project)
-        project.replaceService(SnykApiService::class.java, snykApiServiceMock, project)
 
         every { settings.token } returns null
         every { settings.sastOnServerEnabled } returns true
         every { snykApiServiceMock.sastOnServerEnabled } returns true
+
+        /*
+        Mock the tree construction with spys, reusing functionality if possible.
+        If we want to test tree interactions, this MUST be changed/removed, but that
+        should be an integration or a UI test anyway
+        */
+        stubForTreeConstruction()
+
+        replaceServiceWithMock<SnykCliDownloaderService>(true)
     }
 
+    private fun stubForTreeConstruction() {
+        mockkStatic(ExpandableItemsHandlerFactory::class)
+        mockkStatic(TreeSpeedSearch::class)
+        mockkStatic(ActionManager::class)
+        val actionManager = spyk<ActionManager>()
+        every { ActionManager.getInstance() } returns actionManager
+        every { actionManager.getAction(any()) } returns spyk<ActionGroup>()
+        val actionToolbar = spyk<ActionToolbar>()
+        every { actionManager.createActionToolbar(any(), any(), any()) } returns actionToolbar
+        every { actionToolbar.component } returns spyk()
+        every { ExpandableItemsHandlerFactory.install(any<JTree>()) } returns spyk()
+    }
+
+    @After
     override fun tearDown() {
-        unmockkAll()
         super.tearDown()
+        unmockkAll()
     }
 
     @Test
@@ -121,6 +137,7 @@ class SnykToolWindowPanelTest : LightPlatform4TestCase() {
         every { amplitudeExperimentationServiceMock.isPartOfExperimentalWelcomeWorkflow() } returns true
         every { settings.token } returns "test-token"
         every { settings.pluginFirstRun } returns true
+
         mockkStatic(Registry::class)
         every { Registry.`is`("snyk.preview.iac.enabled", false) } returns true
 
@@ -134,6 +151,7 @@ class SnykToolWindowPanelTest : LightPlatform4TestCase() {
             settings.ossScanEnable = true
             settings.snykCodeSecurityIssuesScanEnable = true
             settings.snykCodeQualityIssuesScanEnable = true
+            settings.pluginFirstRun = false
         }
         unmockkStatic(Registry::class)
     }


### PR DESCRIPTION
also contains the commit to only enable experiments if tracking is enabled