### PR TITLE
feat: Identify running docker daemon [ROAD-456]

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     exclude(group = "org.slf4j")
   }
   implementation("ly.iterative.itly:sdk-jvm:1.2.10")
+  implementation("org.testcontainers:testcontainers:1.16.2")
 
   testImplementation("com.squareup.okhttp3:mockwebserver:4.9.2")
   testImplementation("junit:junit:4.13.2") {

--- a/src/main/kotlin/snyk/container/DockerAdapter.kt
+++ b/src/main/kotlin/snyk/container/DockerAdapter.kt
@@ -1,0 +1,7 @@
+package snyk.container
+
+import org.testcontainers.DockerClientFactory
+
+class DockerAdapter {
+    fun isDockerRunning(): Boolean = DockerClientFactory.instance().isDockerAvailable
+}


### PR DESCRIPTION
snyk container test <image-name> command requires running Docker daemon. The scope of this ticket is finding the way to identify running Docker daemon (maybe with optional IntelliJ Docker plugin?)

Implemented using the testcontainers library that has that functionality already.