### PR TITLE
feat: ✨ detect Kubernetes files and extract image information from workload objects [ROAD-450]

### DIFF
--- a/.github/detekt/detekt-config.yml
+++ b/.github/detekt/detekt-config.yml
@@ -4,3 +4,11 @@
 formatting:
   Indentation:
     continuationIndentSize: 8
+
+complexity:
+  # don't count private & deprecated
+  # add integTest folder to excludes - we can't have too many tests
+  TooManyFunctions:
+    ignorePrivate: true
+    ignoreDeprecated: true
+    excludes: [ '**/integTest/**', '**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**' ]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,14 +26,13 @@ dependencies {
   implementation("com.atlassian.commonmark:commonmark:0.17.0")
   implementation("com.google.code.gson:gson:2.8.9")
   implementation("com.segment.analytics.java:analytics:3.1.3")
-  implementation("io.sentry:sentry:5.3.0")
+  implementation("io.sentry:sentry:5.4.0")
   implementation("io.snyk.code.sdk:snyk-code-client:2.2.0")
   implementation("ly.iterative.itly:plugin-iteratively:1.2.11")
   implementation("ly.iterative.itly:plugin-schema-validator:1.2.11") {
     exclude(group = "org.slf4j")
   }
   implementation("ly.iterative.itly:sdk-jvm:1.2.11")
-
   testImplementation("com.squareup.okhttp3:mockwebserver:4.9.2")
   testImplementation("junit:junit:4.13.2") {
     exclude(group = "org.hamcrest")

--- a/src/integTest/kotlin/snyk/container/KubernetesImageCacheIntegTest.kt
+++ b/src/integTest/kotlin/snyk/container/KubernetesImageCacheIntegTest.kt
@@ -1,0 +1,422 @@
+package snyk.container
+
+import com.intellij.openapi.components.service
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.testFramework.LightPlatform4TestCase
+import io.snyk.plugin.getKubernetesImageCache
+import org.junit.Test
+
+class KubernetesImageCacheIntegTest : LightPlatform4TestCase() {
+    private val fileName = "KubernetesImageExtractorIntegTest.yaml"
+
+    private lateinit var cut: KubernetesImageCache
+    override fun setUp() {
+        super.setUp()
+        cut = project.service()
+        getKubernetesImageCache(project).clear()
+    }
+
+    @Test
+    fun `extractFromFile should find yaml files and extract images`() {
+        val file = createFile(fileName, podYaml())
+        cut.extractFromFile(file.virtualFile)
+        val images = cut.getKubernetesWorkloadImages()
+
+        assertEquals(1, images.size)
+        assertTrue(images.contains(KubernetesWorkloadImage("nginx:1.14.2", file)))
+    }
+
+    @Test
+    fun `should extract images from multi-container pod yaml`() {
+        val images = executeExtract(multiContainerPodYaml())
+
+        assertTrue(images.contains("nginx:1.14.2"))
+        assertTrue(images.contains("busybox"))
+        assertEquals(2, images.size)
+    }
+
+    @Test
+    fun `should extract images from jobs`() {
+        val images = executeExtract(jobYaml())
+
+        assertEquals(1, images.size)
+        assertTrue(images.contains("perl"))
+    }
+
+    private fun jobYaml(): String =
+        """
+        apiVersion: batch/v1
+        kind: Job
+        metadata:
+          name: pi
+        spec:
+          template:
+            spec:
+              containers:
+              - name: pi
+                image: perl
+                command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+              restartPolicy: Never
+          backoffLimit: 4
+        """.trimIndent()
+
+    @Test
+    fun `should extract images from cronjobs`() {
+        val images = executeExtract(cronJobYaml())
+
+        assertEquals(1, images.size)
+        assertTrue(images.contains("busybox"))
+    }
+
+    private fun cronJobYaml(): String =
+        """
+        apiVersion: batch/v1
+        kind: CronJob
+        metadata:
+          name: hello
+        spec:
+          schedule: "*/1 * * * *"
+          jobTemplate:
+            spec:
+              template:
+                spec:
+                  containers:
+                  - name: hello
+                    image: busybox
+                    imagePullPolicy: IfNotPresent
+                    command:
+                    - /bin/sh
+                    - -c
+                    - date; echo Hello from the Kubernetes cluster
+                  restartPolicy: OnFailure
+        """.trimIndent()
+
+    @Test
+    fun `should extract via fallback`() {
+        val images = executeExtract(fallbackTest())
+
+        assertEquals(1, images.size)
+        assertTrue(images.contains("busybox"))
+    }
+
+    private fun fallbackTest(): String =
+        """
+        apiVersion: fallbacktest/v1
+        kind: CronJob
+        metadata:
+          name: hello
+        spec:
+          schedule: "*/1 * * * *"
+          jobTemplate:
+            spec:
+              template:
+                spec:
+                  containers:
+                  - name: hello
+                    image: busybox
+                    imagePullPolicy: IfNotPresent
+                    command:
+                    - /bin/sh
+                    - -c
+                    - date; echo Hello from the Kubernetes cluster
+                  restartPolicy: OnFailure
+        """.trimIndent()
+
+    @Test
+    fun `should extract from stateful set`() {
+        val images = executeExtract(statefulSetYaml())
+
+        assertEquals(1, images.size)
+        assertTrue(images.contains("k8s.gcr.io/nginx-slim:0.8"))
+    }
+
+    private fun statefulSetYaml(): String =
+        """
+        apiVersion: apps/v1
+        kind: StatefulSet
+        metadata:
+          name: web
+        spec:
+          selector:
+            matchLabels:
+              app: nginx # has to match .spec.template.metadata.labels
+          serviceName: "nginx"
+          replicas: 3 # by default is 1
+          template:
+            metadata:
+              labels:
+                app: nginx # has to match .spec.selector.matchLabels
+            spec:
+              terminationGracePeriodSeconds: 10
+              containers:
+              - name: nginx
+                image: k8s.gcr.io/nginx-slim:0.8
+                ports:
+                - containerPort: 80
+                  name: web
+                volumeMounts:
+                - name: www
+                  mountPath: /usr/share/nginx/html
+          volumeClaimTemplates:
+          - metadata:
+              name: www
+            spec:
+              accessModes: [ "ReadWriteOnce" ]
+              storageClassName: "my-storage-class"
+              resources:
+                requests:
+                  storage: 1Gi
+        """.trimIndent()
+
+    @Test
+    fun `should extract from daemon set`() {
+        val images = executeExtract(daemonSetYaml())
+
+        assertEquals(1, images.size)
+        assertTrue(images.contains("quay.io/fluentd_elasticsearch/fluentd:v2.5.2"))
+    }
+
+    private fun daemonSetYaml(): String =
+        """
+        apiVersion: apps/v1
+        kind: DaemonSet
+        metadata:
+          name: fluentd-elasticsearch
+          namespace: kube-system
+          labels:
+            k8s-app: fluentd-logging
+        spec:
+          selector:
+            matchLabels:
+              name: fluentd-elasticsearch
+          template:
+            metadata:
+              labels:
+                name: fluentd-elasticsearch
+            spec:
+              tolerations:
+              # this toleration is to have the daemonset runnable on master nodes
+              # remove it if your masters can't run pods
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+                effect: NoSchedule
+              containers:
+              - name: fluentd-elasticsearch
+                image: quay.io/fluentd_elasticsearch/fluentd:v2.5.2
+                resources:
+                  limits:
+                    memory: 200Mi
+                  requests:
+                    cpu: 100m
+                    memory: 200Mi
+                volumeMounts:
+                - name: varlog
+                  mountPath: /var/log
+                - name: varlibdockercontainers
+                  mountPath: /var/lib/docker/containers
+                  readOnly: true
+              terminationGracePeriodSeconds: 30
+              volumes:
+              - name: varlog
+                hostPath:
+                  path: /var/log
+              - name: varlibdockercontainers
+                hostPath:
+                  path: /var/lib/docker/containers
+              """.trimIndent()
+
+    private fun multiContainerPodYaml(): String =
+        """
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: nginx
+        spec:
+          containers:
+          - name: nginx
+            image: nginx:1.14.2
+          - name: busybox
+            image: busybox
+            ports:
+            - containerPort: 80
+        """.trimIndent()
+
+    @Test
+    fun `should extract from deployment`() {
+        val images = executeExtract(deploymentYaml())
+
+        assertEquals(1, images.size)
+        assertTrue(images.contains("nginx:1.14.2"))
+    }
+
+    private fun deploymentYaml(): String =
+        """
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: nginx-deployment
+        spec:
+          selector:
+            matchLabels:
+              app: nginx
+          replicas: 2 # tells deployment to run 2 pods matching the template
+          template:
+            metadata:
+              labels:
+                app: nginx
+            spec:
+              containers:
+              - name: nginx
+                image: nginx:1.14.2
+                ports:
+                - containerPort: 80
+        """.trimIndent()
+
+    @Test
+    fun `should extract from replicaset`() {
+        val images = executeExtract(replicaSetYaml())
+
+        assertEquals(1, images.size)
+        assertTrue(images.contains("gcr.io/google_samples/gb-frontend:v3"))
+    }
+
+    @Test
+    fun `should not extract from replicaset without apiVersion`() {
+        val images = executeExtract(replicaSetWithoutApiVersionYaml())
+
+        assertEquals(0, images.size)
+    }
+
+    private fun replicaSetYaml(): String =
+        """
+        apiVersion: apps/v1
+        kind: ReplicaSet
+        metadata:
+          name: frontend
+          labels:
+            app: guestbook
+            tier: frontend
+        spec:
+          # modify replicas according to your case
+          replicas: 3
+          selector:
+            matchLabels:
+              tier: frontend
+          template:
+            metadata:
+              labels:
+                tier: frontend
+            spec:
+              containers:
+              - name: php-redis
+                image: gcr.io/google_samples/gb-frontend:v3
+        """.trimIndent()
+
+    private fun replicaSetWithoutApiVersionYaml(): String =
+        """
+        kind: ReplicaSet
+        metadata:
+          name: frontend
+          labels:
+            app: guestbook
+            tier: frontend
+        spec:
+          # modify replicas according to your case
+          replicas: 3
+          selector:
+            matchLabels:
+              tier: frontend
+          template:
+            metadata:
+              labels:
+                tier: frontend
+            spec:
+              containers:
+              - name: php-redis
+                image: gcr.io/google_samples/gb-frontend:v3
+        """.trimIndent()
+
+    @Test
+    fun `should extract from replication controller`() {
+        val images = executeExtract(replicationControllerYaml())
+
+        assertEquals(1, images.size)
+        assertTrue(images.contains("nginx"))
+    }
+
+    private fun replicationControllerYaml(): String =
+        """
+        apiVersion: v1
+        kind: ReplicationController
+        metadata:
+          name: nginx
+        spec:
+          replicas: 3
+          selector:
+            app: nginx
+          template:
+            metadata:
+              name: nginx
+              labels:
+                app: nginx
+            spec:
+              containers:
+              - name: nginx
+                image: nginx
+                ports:
+                - containerPort: 80
+        """.trimIndent()
+
+    private fun executeExtract(yaml: String): Set<String> {
+        val file = createFile(fileName, yaml).virtualFile
+
+        cut.extractFromFile(file)
+        return cut.getKubernetesWorkloadImageNamesFromCache()
+    }
+
+    @Test
+    fun `should return Kubernetes Workload Files`() {
+        val file = createFile(fileName, podYaml()).virtualFile
+
+        cut.extractFromFile(file)
+        val files: Set<VirtualFile> = cut.getKubernetesWorkloadFilesFromCache()
+
+        assertEquals(1, files.size)
+        assertTrue(files.contains(file))
+    }
+
+    @Test
+    fun `should not parse non yaml files`() {
+        val file = createFile("not-a-yaml-file.zaml", podYaml()).virtualFile
+
+        cut.extractFromFile(file)
+        val files: Set<VirtualFile> = cut.getKubernetesWorkloadFilesFromCache()
+
+        assertEmpty(files)
+    }
+
+    @Test
+    fun `should return Kubernetes Workload Image Names`() {
+        val file = createFile(fileName, podYaml()).virtualFile
+
+        cut.extractFromFile(file)
+        val images: Set<String> = cut.getKubernetesWorkloadImageNamesFromCache()
+
+        assertEquals(1, images.size)
+        assertTrue(images.contains("nginx:1.14.2"))
+    }
+
+    fun podYaml(): String =
+        """
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: nginx
+        spec:
+          containers:
+          - name: nginx
+            image: nginx:1.14.2
+            ports:
+            - containerPort: 80
+        """.trimIndent()
+}

--- a/src/main/kotlin/io/snyk/plugin/SnykBulkFileListener.kt
+++ b/src/main/kotlin/io/snyk/plugin/SnykBulkFileListener.kt
@@ -35,6 +35,12 @@ class SnykBulkFileListener : BulkFileListener {
                 VFileCopyEvent::class.java
             )
         )
+
+        if (isContainerEnabled()) {
+            for (project in ProjectUtil.getOpenProjects()) {
+                getKubernetesImageCache(project).extractFromEvents(events)
+            }
+        }
     }
 
     override fun before(events: MutableList<out VFileEvent>) {

--- a/src/main/kotlin/io/snyk/plugin/SnykPostStartupActivity.kt
+++ b/src/main/kotlin/io/snyk/plugin/SnykPostStartupActivity.kt
@@ -21,6 +21,7 @@ import snyk.amplitude.AmplitudeExperimentService
 import snyk.amplitude.api.ExperimentUser
 import snyk.analytics.PluginIsInstalled
 import snyk.analytics.PluginIsUninstalled
+import snyk.container.KubernetesImageCache
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.Date
@@ -78,6 +79,10 @@ class SnykPostStartupActivity : StartupActivity.DumbAware {
         LOG.info("Loading variants for all amplitude experiments")
         val experimentUser = ExperimentUser(publicUserId)
         service<AmplitudeExperimentService>().fetch(experimentUser)
+
+        if (isContainerEnabled()) {
+            getKubernetesImageCache(project).scanProjectForKubernetesFiles()
+        }
     }
 }
 

--- a/src/main/kotlin/io/snyk/plugin/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/Utils.kt
@@ -21,6 +21,7 @@ import io.snyk.plugin.services.download.SnykCliDownloaderService
 import io.snyk.plugin.snykcode.core.AnalysisData
 import io.snyk.plugin.snykcode.core.RunUtils
 import io.snyk.plugin.ui.toolwindow.SnykToolWindowFactory
+import snyk.container.KubernetesImageCache
 import snyk.iac.IacScanService
 import snyk.oss.OssService
 import java.io.File
@@ -38,6 +39,8 @@ fun getOssService(project: Project): OssService = project.service()
 fun getIacService(project: Project): IacScanService = project.service()
 
 fun getSnykCode(project: Project): SnykCodeService = project.service()
+
+fun getKubernetesImageCache(project: Project): KubernetesImageCache = project.service()
 
 fun getCliFile() = File(getPluginPath(), Platform.current().snykWrapperFileName)
 
@@ -168,6 +171,8 @@ fun controlExternalProcessWithProgressIndicator(
 }
 
 fun isIacEnabled(): Boolean = Registry.`is`("snyk.preview.iac.enabled", false)
+
+fun isContainerEnabled(): Boolean = Registry.`is`("snyk.preview.container.enabled", false)
 
 fun isNewRefactoredTreeEnabled(): Boolean = Registry.`is`("snyk.preview.new.refactored.tree.enabled", false)
 

--- a/src/main/kotlin/snyk/container/KubernetesImageCache.kt
+++ b/src/main/kotlin/snyk/container/KubernetesImageCache.kt
@@ -1,0 +1,83 @@
+package snyk.container
+
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.progress.runBackgroundableTask
+import com.intellij.openapi.project.DumbService
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.newvfs.events.VFileContentChangeEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileCopyEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileCreateEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileDeleteEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileEvent
+import com.jetbrains.rd.util.concurrentMapOf
+
+@Service
+class KubernetesImageCache(val project: Project) {
+    private val images = concurrentMapOf<VirtualFile, Set<KubernetesWorkloadImage>>()
+    private val logger = Logger.getInstance(javaClass.name)
+
+    fun clear() {
+        images.clear()
+    }
+
+    fun scanProjectForKubernetesFiles() {
+        val title = "Snyk: Scanning For Kubernetes Files..."
+        runBackgroundableTask(title, project, true) { progress ->
+            DumbService.getInstance(project).runReadActionInSmartMode {
+                ProjectRootManager.getInstance(project).fileIndex.iterateContent { virtualFile ->
+                    this.extractFromFile(virtualFile)
+                    !progress.isCanceled
+                }
+            }
+        }
+    }
+
+    fun getKubernetesWorkloadFilesFromCache(): Set<VirtualFile> = images.keys
+
+    fun getKubernetesWorkloadImages(): Set<KubernetesWorkloadImage> = images.values.flatten().toSet()
+
+    fun getKubernetesWorkloadImageNamesFromCache(): Set<String> =
+        getKubernetesWorkloadImages().map { v -> v.image }.toSet()
+
+    private fun fileDeleted(event: VFileEvent): Boolean = event is VFileDeleteEvent
+
+    private fun fileContentChanged(event: VFileEvent): Boolean {
+        return when (event) {
+            is VFileContentChangeEvent -> true
+            is VFileCreateEvent -> true
+            is VFileCopyEvent -> true
+            else -> false
+        }
+    }
+
+    fun extractFromEvents(events: MutableList<out VFileEvent>) {
+        for (e in events) {
+            val file = e.file ?: continue
+
+            if (fileDeleted(e)) {
+                images.remove(file)
+                logger.debug("removed $file from cache")
+            }
+            if (fileContentChanged(e)) {
+                fileContentChanged(file)
+            }
+        }
+    }
+
+    private fun fileContentChanged(file: VirtualFile) {
+        if (file.isValid) {
+            extractFromFile(file)
+        }
+    }
+
+    /** public for Tests only */
+    fun extractFromFile(file: VirtualFile) {
+        val extractFromFile = YAMLImageExtractor.extractFromFile(file, project)
+        if (extractFromFile.isNotEmpty()) {
+            images[file] = extractFromFile
+        }
+    }
+}

--- a/src/main/kotlin/snyk/container/KubernetesWorkloadImage.kt
+++ b/src/main/kotlin/snyk/container/KubernetesWorkloadImage.kt
@@ -1,0 +1,5 @@
+package snyk.container
+
+import com.intellij.psi.PsiFile
+
+data class KubernetesWorkloadImage(val image: String, val psiFile: PsiFile)

--- a/src/main/kotlin/snyk/container/YAMLImageExtractor.kt
+++ b/src/main/kotlin/snyk/container/YAMLImageExtractor.kt
@@ -1,0 +1,58 @@
+package snyk.container
+
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiManager
+import java.util.stream.Collectors
+import kotlin.streams.toList
+
+object YAMLImageExtractor {
+    private val logger = Logger.getInstance(javaClass.name)
+
+    private fun extractImages(file: PsiFile): List<String> {
+        return if (!isKubernetes(file)) emptyList() else extractImagesFromText(file)
+    }
+
+    private fun extractImagesFromText(psiFile: PsiFile) =
+        getFileLines(psiFile).stream()
+            .filter { s -> s.trim().startsWith("image:") }
+            .map { s ->
+                s.trim()
+                    .split(":")
+                    .stream().filter { e -> e.trim() != "image" }
+                    .map { image -> image.trim() }
+                    .collect(Collectors.joining(":"))
+            }.toList()
+
+    fun extractFromFile(file: VirtualFile, project: Project): Set<KubernetesWorkloadImage> {
+        val psiFile = PsiManager.getInstance(project).findFile(file)
+        if (psiFile == null || file.isDirectory || !file.isValid) return emptySet()
+
+        return extractImages(psiFile)
+            .map { image ->
+                logger.debug("added $image to cache.")
+                KubernetesWorkloadImage(image, psiFile)
+            }.toSet()
+    }
+
+    private fun getFileLines(psiFile: PsiFile) =
+        psiFile.viewProvider.document?.text?.split("\n") ?: emptyList()
+
+    private fun isKubernetes(psiFile: PsiFile): Boolean = isKubernetes(getFileLines(psiFile))
+
+    internal fun isKubernetes(lines: List<String>): Boolean {
+        val normalizedLines =
+            lines
+                .map { line -> line.trim() }
+                .filter { line -> line.isNotBlank() }
+                .filter { line -> !line.startsWith("#") }
+
+        if (normalizedLines.size > 1) {
+            return normalizedLines[0].startsWith("apiVersion:") &&
+                normalizedLines[1].startsWith("kind:")
+        }
+        return false
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -38,6 +38,11 @@
                  description="Preview: Enable Snyk Infrastructure as Code product."
                  restartRequired="true"/>
 
+    <registryKey key="snyk.preview.container.enabled"
+                 defaultValue="false"
+                 description="Preview: Enable Snyk Container product."
+                 restartRequired="true"/>
+
     <registryKey key="snyk.preview.new.refactored.tree.enabled"
                  defaultValue="false"
                  description="Preview: Enable new refactored issues tree."

--- a/src/test/kotlin/snyk/container/YAMLImageExtractorTest.kt
+++ b/src/test/kotlin/snyk/container/YAMLImageExtractorTest.kt
@@ -1,0 +1,50 @@
+package snyk.container
+
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertTrue
+import org.junit.Test
+
+class YAMLImageExtractorTest {
+    val yaml =
+        """
+        apiVersion: asdf
+        kind: CronJob
+        metadata:
+          name: hello
+        spec:
+          schedule: "*/1 * * * *"
+          jobTemplate:
+            spec:
+              template:
+                spec:
+                  containers:
+                  - name: hello
+                    image: busybox
+                    imagePullPolicy: IfNotPresent
+                    command:
+                    - /bin/sh
+                    - -c
+                    - date; echo Hello from the Kubernetes cluster
+                  restartPolicy: OnFailure
+        """.trimIndent()
+    private val yamlList = yaml.split("\n")
+
+    @Test
+    fun `isKubernetesFile should return false if apiVersion and kind not set`() {
+        var fakeYamlList = yamlList.toMutableList()
+        fakeYamlList.removeAt(0)
+        assertFalse(YAMLImageExtractor.isKubernetes(fakeYamlList))
+
+        fakeYamlList = yamlList.toMutableList()
+        fakeYamlList.removeAt(1)
+        assertFalse(YAMLImageExtractor.isKubernetes(fakeYamlList))
+
+        fakeYamlList.removeAt(0)
+        assertFalse(YAMLImageExtractor.isKubernetes(fakeYamlList))
+    }
+
+    @Test
+    fun `isKubernetesFile should return true if apiVersion and kind are set`() {
+        assertTrue(YAMLImageExtractor.isKubernetes(yamlList))
+    }
+}


### PR DESCRIPTION
- uses BulkFileListener to listen to file events
- uses Kubernetes Java Client to parse into Kubernetes Objects
- provides several functions in KubernetesImageCache.kt to access found files and image information
- interpolation of variables is not supported by Kubernetes, so we do not need to handle it

feat: ✨ add kubernetes java api dependency