### PR TITLE
fix: IaC ignored issue mark in the tree and ignore button enablemnt [ROAD-502]

### DIFF
--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
@@ -14,6 +14,7 @@ import com.intellij.openapi.ui.SimpleToolWindowPanel
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiManager
 import com.intellij.ui.OnePixelSplitter
 import com.intellij.ui.ScrollPaneFactory
 import com.intellij.ui.TreeSpeedSearch
@@ -362,16 +363,18 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
                     )
                 }
                 is IacIssueTreeNode -> {
-                    val iacIssue = node.userObject as IacIssue
-                    val scrollPane = wrapWithScrollPane(
-                        IacSuggestionDescriptionPanel(iacIssue, project)
-                    )
-                    descriptionPanel.add(scrollPane, BorderLayout.CENTER)
-
                     val iacIssuesForFile = (node.parent as? IacFileTreeNode)?.userObject as? IacIssuesForFile
                         ?: throw IllegalArgumentException(node.toString())
                     val fileName = iacIssuesForFile.targetFilePath
                     val virtualFile = VirtualFileManager.getInstance().findFileByNioPath(Paths.get(fileName))
+                    val psiFile = virtualFile?.let { PsiManager.getInstance(project).findFile(it) }
+
+                    val iacIssue = node.userObject as IacIssue
+                    val scrollPane = wrapWithScrollPane(
+                        IacSuggestionDescriptionPanel(iacIssue, psiFile, project)
+                    )
+                    descriptionPanel.add(scrollPane, BorderLayout.CENTER)
+
                     if (virtualFile != null && virtualFile.isValid) {
                         val document = FileDocumentManager.getInstance().getDocument(virtualFile)
                         if (document != null) {

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/VulnerabilityTreeCellRenderer.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/VulnerabilityTreeCellRenderer.kt
@@ -104,10 +104,10 @@ class VulnerabilityTreeCellRenderer : ColoredTreeCellRenderer() {
                     "line ${issue.lineNumber}: ${issue.title}"
                 } else {
                     issue.title
-                }
+                } + if (issue.ignored) " (ignored)" else ""
 
                 val toolWindowPanel = value.project.service<SnykToolWindowPanel>()
-                if (toolWindowPanel.currentIacResult == null) {
+                if (toolWindowPanel.currentIacResult == null || issue.ignored) {
                     attributes = SimpleTextAttributes.GRAYED_ATTRIBUTES
                     nodeIcon = getDisabledIcon(nodeIcon)
                 }

--- a/src/main/kotlin/snyk/iac/IacIssue.kt
+++ b/src/main/kotlin/snyk/iac/IacIssue.kt
@@ -12,4 +12,6 @@ data class IacIssue(
     val resolve: String? = null,
     val references: List<String> = emptyList(),
     val path: List<String> = emptyList()
-)
+) {
+    var ignored = false
+}

--- a/src/main/kotlin/snyk/iac/IacSuggestionDescriptionPanel.kt
+++ b/src/main/kotlin/snyk/iac/IacSuggestionDescriptionPanel.kt
@@ -2,6 +2,7 @@ package snyk.iac
 
 import com.intellij.ide.BrowserUtil
 import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiFile
 import com.intellij.ui.HyperlinkLabel
 import com.intellij.uiDesigner.core.GridConstraints
 import com.intellij.uiDesigner.core.GridLayoutManager
@@ -27,6 +28,7 @@ import javax.swing.event.HyperlinkEvent
 
 class IacSuggestionDescriptionPanel(
     val issue: IacIssue,
+    val psiFile: PsiFile?,
     val project: Project
 ) : JPanel() {
 
@@ -61,6 +63,7 @@ class IacSuggestionDescriptionPanel(
     )
 
     init {
+        this.name = "IacSuggestionDescriptionPanel"
         this.layout = GridLayoutManager(10, 1, Insets(20, 10, 20, 20), -1, 10)
 
         this.add(
@@ -175,8 +178,16 @@ class IacSuggestionDescriptionPanel(
     }
 
     private fun createIgnoreButton(panel: JPanel) {
-        val ignoreButton = JButton("Ignore This Issue")
-        ignoreButton.addActionListener(IgnoreButtonActionListener(IgnoreService(project), issue.id, project))
+        val ignoreButton = JButton().apply {
+            if (issue.ignored) {
+                text = IgnoreButtonActionListener.IGNORED_ISSUE_BUTTON_TEXT
+                isEnabled = false
+            } else {
+                text = "Ignore This Issue"
+                addActionListener(IgnoreButtonActionListener(IgnoreService(project), issue, psiFile, project))
+            }
+            name = "ignoreButton"
+        }
         panel.add(
             ignoreButton,
             baseGridConstraints(0)

--- a/src/main/kotlin/snyk/iac/IgnoreButtonActionListener.kt
+++ b/src/main/kotlin/snyk/iac/IgnoreButtonActionListener.kt
@@ -1,9 +1,12 @@
 package snyk.iac
 
+import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiFile
 import io.snyk.plugin.ui.SnykBalloonNotificationHelper
 import org.jetbrains.annotations.NotNull
 import snyk.common.IgnoreException
@@ -14,22 +17,36 @@ import javax.swing.JButton
 
 class IgnoreButtonActionListener(
     private val ignoreService: IgnoreService,
-    val issueId: String,
+    val issue: IacIssue,
+    private val psiFile: PsiFile?,
     private val project: Project
-) :
-    ActionListener {
+) : ActionListener {
+
     override fun actionPerformed(e: ActionEvent?) {
-        ProgressManager.getInstance().run(IgnoreTask(project, ignoreService, issueId, e))
+        ProgressManager.getInstance().run(IgnoreTask(project, ignoreService, issue, psiFile, e))
     }
 
-    class IgnoreTask(project: Project, val ignoreService: IgnoreService, val issueId: String, val e: ActionEvent?) :
-        Task.Backgroundable(project, "Ignoring issue...") {
+    class IgnoreTask(
+        project: Project,
+        val ignoreService: IgnoreService,
+        val issue: IacIssue,
+        private val psiFile: PsiFile?,
+        val e: ActionEvent?
+    ) : Task.Backgroundable(project, "Ignoring issue...") {
         override fun run(@NotNull progressIndicator: ProgressIndicator) {
             try {
-                ignoreService.ignore(issueId)
+                ignoreService.ignore(issue.id)
+                issue.ignored = true
                 (e?.source as? JButton)?.apply {
                     isEnabled = false
-                    text = "Issue now ignored"
+                    text = IGNORED_ISSUE_BUTTON_TEXT
+                }
+                ApplicationManager.getApplication().invokeLater {
+                    if (psiFile != null) {
+                        DaemonCodeAnalyzer.getInstance(project).restart(psiFile)
+                    } else {
+                        DaemonCodeAnalyzer.getInstance(project).restart()
+                    }
                 }
             } catch (e: IgnoreException) {
                 SnykBalloonNotificationHelper.showError(
@@ -38,5 +55,9 @@ class IgnoreButtonActionListener(
                 )
             }
         }
+    }
+
+    companion object {
+        const val IGNORED_ISSUE_BUTTON_TEXT = "Issue Is Ignored"
     }
 }

--- a/src/main/kotlin/snyk/iac/annotator/IacBaseAnnotator.kt
+++ b/src/main/kotlin/snyk/iac/annotator/IacBaseAnnotator.kt
@@ -41,8 +41,9 @@ abstract class IacBaseAnnotator : ExternalAnnotator<PsiFile, Unit>() {
 
         LOG.debug("Received ${issues.size} IacIssue annotations for ${psiFile.virtualFile.name}")
         issues.forEach { iacIssue ->
-            LOG.debug("-> ${iacIssue.id}: ${iacIssue.title}: ${iacIssue.lineNumber}")
+            if (iacIssue.ignored) return@forEach
 
+            LOG.debug("-> ${iacIssue.id}: ${iacIssue.title}: ${iacIssue.lineNumber}")
             val severity = when (iacIssue.severity) {
                 CRITICAL -> HighlightSeverity.ERROR
                 HIGH -> HighlightSeverity.WARNING

--- a/src/test/kotlin/snyk/iac/IacSuggestionDescriptionPanelTest.kt
+++ b/src/test/kotlin/snyk/iac/IacSuggestionDescriptionPanelTest.kt
@@ -38,7 +38,7 @@ class IacSuggestionDescriptionPanelTest {
     fun `IacSuggestionDescriptionPanel should have ignore button`() {
         val expectedButtonText = "Ignore This Issue"
 
-        cut = IacSuggestionDescriptionPanel(issue, project)
+        cut = IacSuggestionDescriptionPanel(issue, null, project)
 
         val actualButton = getJButtonByText(cut, expectedButtonText)
         assertNotNull("Didn't find button with text $expectedButtonText", actualButton)
@@ -48,12 +48,12 @@ class IacSuggestionDescriptionPanelTest {
     fun `IacSuggestionDescriptionPanel ignore button should call IacIgnoreService on click`() {
         val expectedButtonText = "Ignore This Issue"
 
-        cut = IacSuggestionDescriptionPanel(issue, project)
+        cut = IacSuggestionDescriptionPanel(issue, null, project)
 
         val actualButton = getJButtonByText(cut, expectedButtonText)
         assertNotNull("Didn't find Ignore Button", actualButton)
         val listener = actualButton!!.actionListeners.first() as IgnoreButtonActionListener
         assertEquals(IgnoreButtonActionListener::class, listener::class)
-        assertEquals(issue.id, listener.issueId)
+        assertEquals(issue.id, listener.issue.id)
     }
 }


### PR DESCRIPTION
IaC ignoring: 

- mark node as `ignored` in the tree and make `ignore` button remain disabled in the description panel after issue reselection
- remove ignored issue from annotator's highlighting
Before ignoring:
![image](https://user-images.githubusercontent.com/14268320/142780098-a4546bef-27bd-4fc3-b63b-53a7d0b85719.png)
After ignoring:
![image](https://user-images.githubusercontent.com/14268320/142780119-d953f264-8388-449e-a40e-f729573635ae.png)
