### PR TITLE
feat: ✨ only mark iac files obsolete if they have been changed [ROAD-570]

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,9 @@ dependencies {
     exclude(group = "org.hamcrest")
   }
   testImplementation("org.hamcrest:hamcrest:2.2")
-  testImplementation("io.mockk:mockk:1.12.0")
+  testImplementation("io.mockk:mockk:1.12.1")
+  testImplementation("org.awaitility:awaitility:4.1.1")
+  runtimeOnly("org.jetbrains.kotlin:kotlin-reflect:1.4.32")
 
   detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.19.0")
 }

--- a/src/integTest/kotlin/io/snyk/plugin/services/download/CliDownloaderErrorHandlerIntegTest.kt
+++ b/src/integTest/kotlin/io/snyk/plugin/services/download/CliDownloaderErrorHandlerIntegTest.kt
@@ -11,6 +11,7 @@ import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.spyk
+import io.mockk.unmockkAll
 import io.mockk.verify
 import io.snyk.plugin.getCliFile
 import io.snyk.plugin.resetSettings
@@ -45,7 +46,7 @@ class CliDownloaderErrorHandlerIntegTest : LightPlatformTestCase() {
     }
 
     override fun tearDown() {
-        clearAllMocks()
+        unmockkAll()
         resetSettings(project)
         super.tearDown()
     }

--- a/src/integTest/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanelIntegTest.kt
+++ b/src/integTest/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanelIntegTest.kt
@@ -152,7 +152,7 @@ class SnykToolWindowPanelIntegTest : HeavyPlatformTestCase() {
 
         val errorMessageTextArea =
             UIComponentFinder.getComponentByName(errorPanel!!, JTextArea::class, "errorMessageTextArea")
-        val pathTextArea = UIComponentFinder.getComponentByName(errorPanel!!, JTextArea::class, "pathTextArea")
+        val pathTextArea = UIComponentFinder.getComponentByName(errorPanel, JTextArea::class, "pathTextArea")
 
         assertTrue(errorMessageTextArea?.text == iacError.message)
         assertTrue(pathTextArea?.text == iacError.path)

--- a/src/integTest/kotlin/snyk/iac/annotator/IacBaseAnnotatorCase.kt
+++ b/src/integTest/kotlin/snyk/iac/annotator/IacBaseAnnotatorCase.kt
@@ -2,8 +2,8 @@ package snyk.iac.annotator
 
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.intellij.testFramework.replaceService
-import io.mockk.clearAllMocks
 import io.mockk.mockk
+import io.mockk.unmockkAll
 import io.snyk.plugin.ui.toolwindow.SnykToolWindowPanel
 import org.junit.Before
 import java.nio.file.Paths
@@ -23,7 +23,18 @@ abstract class IacBaseAnnotatorCase : BasePlatformTestCase() {
     @Before
     override fun setUp() {
         super.setUp()
+        unmockkAll()
         project.replaceService(SnykToolWindowPanel::class.java, toolWindowPanel, project)
-        clearAllMocks()
+    }
+
+    @Suppress("SwallowedException", "TooGenericExceptionCaught")
+    override fun tearDown() {
+        unmockkAll()
+        try {
+            super.tearDown()
+        } catch (e: Exception) {
+            // when tearing down the test case, our File Listener is trying to react on the deletion of the test
+            // files and tries to access the file index that isn't there anymore
+        }
     }
 }

--- a/src/integTest/kotlin/snyk/iac/annotator/IacHclAnnotatorTest.kt
+++ b/src/integTest/kotlin/snyk/iac/annotator/IacHclAnnotatorTest.kt
@@ -22,7 +22,7 @@ class IacHclAnnotatorTest : IacBaseAnnotatorCase() {
     private val annotationHolderMock = mockk<AnnotationHolder>(relaxed = true)
     private val terraformManifestFile = "terraform-main.tf"
     lateinit var file: VirtualFile
-    lateinit var psiFile: PsiFile
+    private lateinit var psiFile: PsiFile
 
     @Before
     override fun setUp() {
@@ -104,11 +104,8 @@ class IacHclAnnotatorTest : IacBaseAnnotatorCase() {
             lineNumber = 1,
             severity = "", publicId = "", documentation = "", issue = "", impact = ""
         )
-        val iacIssuesForFile = IacIssuesForFile()
-        iacIssuesForFile.targetFile = terraformManifestFile
-        iacIssuesForFile.targetFilePath = file.path
-        iacIssuesForFile.infrastructureAsCodeIssues = arrayOf(iacIssue)
-        return IacResult(arrayOf(iacIssuesForFile), null)
+        val iacIssuesForFile = IacIssuesForFile(listOf(iacIssue), terraformManifestFile, file.path, "terraform")
+        return IacResult(listOf(iacIssuesForFile), null)
     }
 
     private fun createIacResultWithIssueOnLine8(): IacResult {
@@ -118,10 +115,8 @@ class IacHclAnnotatorTest : IacBaseAnnotatorCase() {
             lineNumber = 8,
             severity = "", publicId = "", documentation = "", issue = "", impact = ""
         )
-        val iacIssuesForFile = IacIssuesForFile()
-        iacIssuesForFile.targetFile = terraformManifestFile
-        iacIssuesForFile.infrastructureAsCodeIssues = arrayOf(iacIssue)
-        return IacResult(arrayOf(iacIssuesForFile), null)
+        val iacIssuesForFile = IacIssuesForFile(listOf(iacIssue), terraformManifestFile, file.path, "terraform")
+        return IacResult(listOf(iacIssuesForFile), null)
     }
 
     private fun createIacResultWithIssueOnLine18(): IacResult {
@@ -131,9 +126,7 @@ class IacHclAnnotatorTest : IacBaseAnnotatorCase() {
             lineNumber = 18,
             severity = "", publicId = "", documentation = "", issue = "", impact = ""
         )
-        val iacIssuesForFile = IacIssuesForFile()
-        iacIssuesForFile.targetFile = terraformManifestFile
-        iacIssuesForFile.infrastructureAsCodeIssues = arrayOf(iacIssue)
-        return IacResult(arrayOf(iacIssuesForFile), null)
+        val iacIssuesForFile = IacIssuesForFile(listOf(iacIssue), terraformManifestFile, file.path, "terraform")
+        return IacResult(listOf(iacIssuesForFile), null)
     }
 }

--- a/src/integTest/kotlin/snyk/iac/annotator/IacJsonAnnotatorTest.kt
+++ b/src/integTest/kotlin/snyk/iac/annotator/IacJsonAnnotatorTest.kt
@@ -20,7 +20,7 @@ class IacJsonAnnotatorTest : IacBaseAnnotatorCase() {
     private val annotationHolderMock = mockk<AnnotationHolder>(relaxed = true)
     private val cloudformationManifestFile = "cloudformation-deployment.yaml"
     lateinit var file: VirtualFile
-    lateinit var psiFile: PsiFile
+    private lateinit var psiFile: PsiFile
 
     @Before
     override fun setUp() {
@@ -63,11 +63,8 @@ class IacJsonAnnotatorTest : IacBaseAnnotatorCase() {
             lineNumber = 2,
             severity = "", publicId = "", documentation = "", issue = "", impact = ""
         )
-        val iacIssuesForFile = IacIssuesForFile()
-        iacIssuesForFile.targetFile = cloudformationManifestFile
-        iacIssuesForFile.targetFilePath = file.path
-        iacIssuesForFile.infrastructureAsCodeIssues = arrayOf(iacIssue)
-        return IacResult(arrayOf(iacIssuesForFile), null)
+        val iacIssuesForFile =
+            IacIssuesForFile(listOf(iacIssue), cloudformationManifestFile, file.path, "cloudformation")
+        return IacResult(listOf(iacIssuesForFile), null)
     }
-
 }

--- a/src/integTest/kotlin/snyk/iac/annotator/IacYamlAnnotatorTest.kt
+++ b/src/integTest/kotlin/snyk/iac/annotator/IacYamlAnnotatorTest.kt
@@ -22,7 +22,7 @@ class IacYamlAnnotatorTest : IacBaseAnnotatorCase() {
     private val annotationHolderMock = mockk<AnnotationHolder>(relaxed = true)
     private val kubernetesManifestFile = "kubernetes-deployment.yaml"
     lateinit var file: VirtualFile
-    lateinit var psiFile: PsiFile
+    private lateinit var psiFile: PsiFile
 
     @Before
     override fun setUp() {
@@ -91,11 +91,9 @@ class IacYamlAnnotatorTest : IacBaseAnnotatorCase() {
             lineNumber = 18,
             severity = "", publicId = "", documentation = "", issue = "", impact = ""
         )
-        val iacIssuesForFile = IacIssuesForFile()
-        iacIssuesForFile.targetFile = kubernetesManifestFile
-        iacIssuesForFile.targetFilePath = file.path
-        iacIssuesForFile.infrastructureAsCodeIssues = arrayOf(iacIssue)
-        return IacResult(arrayOf(iacIssuesForFile), null)
+        val iacIssuesForFile =
+            IacIssuesForFile(listOf(iacIssue), kubernetesManifestFile, file.path, "Kubernetes")
+        return IacResult(listOf(iacIssuesForFile), null)
     }
 
     private fun createIacResultWithIssueOnLine20(): IacResult {
@@ -105,9 +103,8 @@ class IacYamlAnnotatorTest : IacBaseAnnotatorCase() {
             lineNumber = 20,
             severity = "", publicId = "", documentation = "", issue = "", impact = ""
         )
-        val iacIssuesForFile = IacIssuesForFile()
-        iacIssuesForFile.targetFile = kubernetesManifestFile
-        iacIssuesForFile.infrastructureAsCodeIssues = arrayOf(iacIssue)
-        return IacResult(arrayOf(iacIssuesForFile), null)
+        val iacIssuesForFile =
+            IacIssuesForFile(listOf(iacIssue), kubernetesManifestFile, file.path, "Kubernetes")
+        return IacResult(listOf(iacIssuesForFile), null)
     }
 }

--- a/src/main/kotlin/io/snyk/plugin/cli/CliResult.kt
+++ b/src/main/kotlin/io/snyk/plugin/cli/CliResult.kt
@@ -1,11 +1,11 @@
 package io.snyk.plugin.cli
 
 import io.snyk.plugin.Severity
-import snyk.common.SnykError
 import java.time.Instant
+import snyk.common.SnykError
 
 abstract class CliResult<CliIssuesForFile>(
-    var allCliIssues: Array<CliIssuesForFile>?,
+    var allCliIssues: List<CliIssuesForFile>?,
     var error: SnykError?
 ) {
 

--- a/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
@@ -156,8 +156,7 @@ class SnykTaskQueueService(val project: Project) {
         ) {
             override fun run(indicator: ProgressIndicator) {
                 val toolWindowPanel = project.service<SnykToolWindowPanel>()
-                if (toolWindowPanel.currentIacResult != null) return
-
+                if (toolWindowPanel.currentIacResult != null && !toolWindowPanel.iacScanNeeded) return
                 LOG.debug("Starting IaC scan")
                 iacScanProgressIndicator = indicator
                 scanPublisher?.scanningStarted()

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
@@ -86,6 +86,7 @@ import javax.swing.tree.TreePath
 @Service
 class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
 
+    var iacScanNeeded: Boolean = false
     private val scrollPaneAlarm = Alarm()
 
     private var descriptionPanel = SimpleToolWindowPanel(true, true).apply { name = "descriptionPanel" }
@@ -173,6 +174,7 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
 
                 override fun scanningIacFinished(iacResult: IacResult) {
                     currentIacResult = iacResult
+                    iacScanNeeded = false
                     ApplicationManager.getApplication().invokeLater {
                         displayIacResults(iacResult)
                     }
@@ -228,6 +230,7 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
 
                 override fun scanningIacError(snykError: SnykError) {
                     currentIacResult = null
+                    iacScanNeeded = false
                     ApplicationManager.getApplication().invokeLater {
                         SnykBalloonNotificationHelper.showError(snykError.message, project)
                         currentIacError = snykError
@@ -459,6 +462,7 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
         currentSnykCodeError = null
         currentIacResult = null
         currentIacError = null
+        iacScanNeeded = true
         AnalysisData.instance.resetCachesAndTasks(project)
         SnykCodeIgnoreInfoHolder.instance.removeProject(project)
         DaemonCodeAnalyzer.getInstance(project).restart()
@@ -809,7 +813,7 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
         smartReloadRootNode(rootQualityIssuesTreeNode, userObjectsForExpandedQualityNodes, selectedNodeUserObject)
     }
 
-    private fun displayIacResults(iacResult: IacResult) {
+    fun displayIacResults(iacResult: IacResult) {
         val userObjectsForExpandedChildren = userObjectsForExpandedNodes(rootIacIssuesTreeNode)
         val selectedNodeUserObject = TreeUtil.findObjectInPath(vulnerabilitiesTree.selectionPath, Any::class.java)
 
@@ -966,7 +970,6 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
         (vulnerabilitiesTree.model as DefaultTreeModel).reload()
     }
 
-    @TestOnly
     fun getRootIacIssuesTreeNode() = rootIacIssuesTreeNode
 
     @TestOnly

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/VulnerabilityTreeCellRenderer.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/VulnerabilityTreeCellRenderer.kt
@@ -9,8 +9,6 @@ import com.intellij.ui.SimpleTextAttributes
 import com.intellij.util.IconUtil
 import com.intellij.util.ui.UIUtil
 import icons.SnykIcons
-import snyk.oss.OssVulnerabilitiesForFile
-import snyk.oss.Vulnerability
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.snykcode.core.AnalysisData
 import io.snyk.plugin.snykcode.severityAsString
@@ -20,6 +18,8 @@ import snyk.iac.IacIssue
 import snyk.iac.IacIssuesForFile
 import snyk.iac.ui.toolwindow.IacFileTreeNode
 import snyk.iac.ui.toolwindow.IacIssueTreeNode
+import snyk.oss.OssVulnerabilitiesForFile
+import snyk.oss.Vulnerability
 import java.awt.Color
 import javax.swing.Icon
 import javax.swing.JTree
@@ -58,7 +58,7 @@ class VulnerabilityTreeCellRenderer : ColoredTreeCellRenderer() {
                 val toolWindowPanel = value.project.service<SnykToolWindowPanel>()
                 if (toolWindowPanel.currentOssResults == null) {
                     attributes = SimpleTextAttributes.GRAYED_ATTRIBUTES
-                    text += " (obsolete)"
+                    text += obsoleteSuffix
                     nodeIcon = getDisabledIcon(nodeIcon)
                 }
             }
@@ -81,7 +81,7 @@ class VulnerabilityTreeCellRenderer : ColoredTreeCellRenderer() {
                 text = file.name
                 if (!AnalysisData.instance.isFileInCache(file)) {
                     attributes = SimpleTextAttributes.GRAYED_ATTRIBUTES
-                    text += " (obsolete)"
+                    text += obsoleteSuffix
                     nodeIcon = getDisabledIcon(nodeIcon)
                 }
             }
@@ -91,10 +91,10 @@ class VulnerabilityTreeCellRenderer : ColoredTreeCellRenderer() {
                 text = iacVulnerabilitiesForFile.targetFile
 
                 val toolWindowPanel = value.project.service<SnykToolWindowPanel>()
-                if (toolWindowPanel.currentIacResult == null) {
+                if (toolWindowPanel.currentIacResult == null || iacVulnerabilitiesForFile.obsolete) {
                     attributes = SimpleTextAttributes.GRAYED_ATTRIBUTES
-                    text += " (obsolete)"
                     nodeIcon = getDisabledIcon(nodeIcon)
+                    text += obsoleteSuffix
                 }
             }
             is IacIssueTreeNode -> {
@@ -106,8 +106,17 @@ class VulnerabilityTreeCellRenderer : ColoredTreeCellRenderer() {
                     issue.title
                 } + if (issue.ignored) " (ignored)" else ""
 
+                var obsolete = false
+                if (value.parent is IacFileTreeNode) {
+                    val parentTreeNode = value.parent as IacFileTreeNode
+                    val iacIssuesForFile = parentTreeNode.userObject as IacIssuesForFile
+                    if (iacIssuesForFile.obsolete) {
+                        obsolete = true
+                    }
+                }
+
                 val toolWindowPanel = value.project.service<SnykToolWindowPanel>()
-                if (toolWindowPanel.currentIacResult == null || issue.ignored) {
+                if (toolWindowPanel.currentIacResult == null || issue.ignored || obsolete) {
                     attributes = SimpleTextAttributes.GRAYED_ATTRIBUTES
                     nodeIcon = getDisabledIcon(nodeIcon)
                 }
@@ -142,7 +151,8 @@ class VulnerabilityTreeCellRenderer : ColoredTreeCellRenderer() {
                 if (!settings.snykCodeQualityIssuesScanEnable) {
                     nodeIcon = SnykIcons.SNYK_CODE_DISABLED
                     val availabilityPostfix = snykCodeAvailabilityPostfix()
-                    text = SnykToolWindowPanel.SNYKCODE_QUALITY_ISSUES_ROOT_TEXT + availabilityPostfix.ifEmpty { " (disabled)" }
+                    text = SnykToolWindowPanel.SNYKCODE_QUALITY_ISSUES_ROOT_TEXT +
+                        availabilityPostfix.ifEmpty { " (disabled)" }
                     attributes = SimpleTextAttributes.GRAYED_ATTRIBUTES
                 } else {
                     nodeIcon = SnykIcons.SNYK_CODE
@@ -173,7 +183,6 @@ class VulnerabilityTreeCellRenderer : ColoredTreeCellRenderer() {
         originalIcon?.let { IconUtil.colorize(it, Color.LIGHT_GRAY) }
 
     companion object {
-        private val GRAYED_STRIKEOUT_ATTRIBUTES =
-            SimpleTextAttributes(SimpleTextAttributes.STYLE_STRIKEOUT, UIUtil.getInactiveTextColor())
+        const val obsoleteSuffix = " (obsolete)"
     }
 }

--- a/src/main/kotlin/snyk/iac/IacIssue.kt
+++ b/src/main/kotlin/snyk/iac/IacIssue.kt
@@ -1,5 +1,7 @@
 package snyk.iac
 
+import com.google.gson.annotations.Expose
+
 data class IacIssue(
     val id: String,
     val title: String,
@@ -11,7 +13,46 @@ data class IacIssue(
     val impact: String,
     val resolve: String? = null,
     val references: List<String> = emptyList(),
-    val path: List<String> = emptyList()
+    val path: List<String> = emptyList(),
+    @Expose val obsolete: Boolean = false
 ) {
     var ignored = false
+
+    // We need the equals / hashcode methods as we don't want to include `obsolete` in our equality checks
+    @Suppress("DuplicatedCode") // false positive for generated code
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as IacIssue
+
+        if (id != other.id) return false
+        if (title != other.title) return false
+        if (severity != other.severity) return false
+        if (publicId != other.publicId) return false
+        if (documentation != other.documentation) return false
+        if (lineNumber != other.lineNumber) return false
+        if (issue != other.issue) return false
+        if (impact != other.impact) return false
+        if (resolve != other.resolve) return false
+        if (references != other.references) return false
+        if (path != other.path) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = id.hashCode()
+        result = 31 * result + title.hashCode()
+        result = 31 * result + severity.hashCode()
+        result = 31 * result + publicId.hashCode()
+        result = 31 * result + documentation.hashCode()
+        result = 31 * result + lineNumber
+        result = 31 * result + issue.hashCode()
+        result = 31 * result + impact.hashCode()
+        result = 31 * result + (resolve?.hashCode() ?: 0)
+        result = 31 * result + references.hashCode()
+        result = 31 * result + path.hashCode()
+        return result
+    }
 }

--- a/src/main/kotlin/snyk/iac/IacIssuesForFile.kt
+++ b/src/main/kotlin/snyk/iac/IacIssuesForFile.kt
@@ -1,12 +1,39 @@
 package snyk.iac
 
-class IacIssuesForFile {
-    lateinit var infrastructureAsCodeIssues: Array<IacIssue>
-    lateinit var targetFile: String
-    lateinit var targetFilePath: String
-    lateinit var packageManager: String
+import com.google.gson.annotations.Expose
 
+data class IacIssuesForFile(
+    val infrastructureAsCodeIssues: List<IacIssue>,
+    val targetFile: String,
+    val targetFilePath: String,
+    val packageManager: String,
+    @Expose val obsolete: Boolean = false
+) {
     val uniqueCount: Int get() = infrastructureAsCodeIssues.groupBy { it.id }.size
+
+    @Suppress("DuplicatedCode")
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as IacIssuesForFile
+
+        if (infrastructureAsCodeIssues != other.infrastructureAsCodeIssues) return false
+        if (targetFile != other.targetFile) return false
+        if (targetFilePath != other.targetFilePath) return false
+        if (packageManager != other.packageManager) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = infrastructureAsCodeIssues.hashCode()
+        result = 31 * result + targetFile.hashCode()
+        result = 31 * result + targetFilePath.hashCode()
+        result = 31 * result + packageManager.hashCode()
+        return result
+    }
+
 }
 
 /* Real json Example: src/integTest/resources/iac-test-results/infrastructure-as-code-goof.json */

--- a/src/main/kotlin/snyk/iac/IacResult.kt
+++ b/src/main/kotlin/snyk/iac/IacResult.kt
@@ -1,14 +1,14 @@
 package snyk.iac
 
-import snyk.common.SnykError
 import io.snyk.plugin.cli.CliResult
+import snyk.common.SnykError
 
 class IacResult(
-    allIacVulnerabilities: Array<IacIssuesForFile>?,
+    allIacVulnerabilities: List<IacIssuesForFile>?,
     error: SnykError?
 ) : CliResult<IacIssuesForFile>(allIacVulnerabilities, error) {
 
-    override val issuesCount = allCliIssues?.sumBy { it.uniqueCount }
+    override val issuesCount get() = allCliIssues?.sumBy { it.uniqueCount }
 
     override fun countBySeverity(severity: String): Int? {
         return allCliIssues?.sumBy { issuesForFile ->

--- a/src/main/kotlin/snyk/iac/annotator/IacBaseAnnotator.kt
+++ b/src/main/kotlin/snyk/iac/annotator/IacBaseAnnotator.kt
@@ -37,11 +37,11 @@ abstract class IacBaseAnnotator : ExternalAnnotator<PsiFile, Unit>() {
         val issues = getIssues(psiFile)
 
         LOG.debug("Call apply on ${psiFile.name}")
-        if (issues == null || issues.isEmpty()) return
+        if (issues.isEmpty()) return
 
         LOG.debug("Received ${issues.size} IacIssue annotations for ${psiFile.virtualFile.name}")
         issues.forEach { iacIssue ->
-            if (iacIssue.ignored) return@forEach
+            if (iacIssue.ignored || iacIssue.obsolete) return@forEach
 
             LOG.debug("-> ${iacIssue.id}: ${iacIssue.title}: ${iacIssue.lineNumber}")
             val severity = when (iacIssue.severity) {

--- a/src/main/kotlin/snyk/oss/OssResult.kt
+++ b/src/main/kotlin/snyk/oss/OssResult.kt
@@ -1,10 +1,10 @@
 package snyk.oss
 
-import snyk.common.SnykError
 import io.snyk.plugin.cli.CliResult
+import snyk.common.SnykError
 
 class OssResult(
-    allOssVulnerabilities: Array<OssVulnerabilitiesForFile>?,
+    allOssVulnerabilities: List<OssVulnerabilitiesForFile>?,
     error: SnykError?
 ) : CliResult<OssVulnerabilitiesForFile>(allOssVulnerabilities, error) {
 

--- a/src/main/kotlin/snyk/oss/OssService.kt
+++ b/src/main/kotlin/snyk/oss/OssService.kt
@@ -2,6 +2,7 @@ package snyk.oss
 
 import com.google.gson.Gson
 import com.google.gson.JsonSyntaxException
+import com.google.gson.reflect.TypeToken
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.project.Project
 import io.snyk.plugin.cli.CliError
@@ -9,6 +10,7 @@ import io.snyk.plugin.cli.ConsoleCommandRunner
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.services.CliAdapter
 import snyk.common.SnykError
+import java.lang.reflect.Type
 
 /**
  * Wrap work with Snyk CLI for OSS (`test` command).
@@ -29,6 +31,8 @@ class OssService(project: Project) : CliAdapter<OssResult>(project) {
      */
     override fun convertRawCliStringToCliResult(rawStr: String): OssResult =
         try {
+            val ossVulnerabilitiesForFileListType: Type =
+                object : TypeToken<ArrayList<OssVulnerabilitiesForFile>>() {}.type
             when {
                 rawStr == ConsoleCommandRunner.PROCESS_CANCELLED_BY_USER -> {
                     OssResult(null, null)
@@ -37,11 +41,11 @@ class OssService(project: Project) : CliAdapter<OssResult>(project) {
                     OssResult(null, SnykError("CLI fail to produce any output", projectPath))
                 }
                 rawStr.first() == '[' -> {
-                    OssResult(Gson().fromJson(rawStr, Array<OssVulnerabilitiesForFile>::class.java), null)
+                    OssResult(Gson().fromJson(rawStr, ossVulnerabilitiesForFileListType), null)
                 }
                 rawStr.first() == '{' -> {
                     if (isSuccessCliJsonString(rawStr)) {
-                        OssResult(arrayOf(Gson().fromJson(rawStr, OssVulnerabilitiesForFile::class.java)), null)
+                        OssResult(listOf(Gson().fromJson(rawStr, OssVulnerabilitiesForFile::class.java)), null)
                     } else {
                         val cliError = Gson().fromJson(rawStr, CliError::class.java)
                         OssResult(null, SnykError(cliError.message, cliError.path))

--- a/src/test/kotlin/io/snyk/plugin/ui/toolwindow/LabelProviderTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/toolwindow/LabelProviderTest.kt
@@ -1,12 +1,13 @@
 package io.snyk.plugin.ui.toolwindow
 
 import com.intellij.ui.components.labels.LinkLabel
-import io.mockk.clearAllMocks
 import io.mockk.mockkStatic
 import io.mockk.slot
+import io.mockk.unmockkAll
 import io.mockk.verify
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertTrue
+import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import javax.swing.JLabel
@@ -14,10 +15,15 @@ import javax.swing.JLabel
 class LabelProviderTest {
     @Before
     fun setUp() {
-        clearAllMocks()
+        unmockkAll()
         // test URL - unfortunately, LinkLabel does not provide an easy way to verify
         // the link action, so we're using a static mock of the create method to check the action
         mockkStatic(LinkLabel::class)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
     }
 
     @Test

--- a/src/test/kotlin/snyk/amplitude/api/AmplitudeExperimentApiClientTest.kt
+++ b/src/test/kotlin/snyk/amplitude/api/AmplitudeExperimentApiClientTest.kt
@@ -1,5 +1,9 @@
 package snyk.amplitude.api
 
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.snyk.plugin.pluginSettings
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okio.buffer
@@ -8,12 +12,14 @@ import org.hamcrest.collection.IsMapWithSize.aMapWithSize
 import org.hamcrest.collection.IsMapWithSize.anEmptyMap
 import org.hamcrest.core.IsEqual.equalTo
 import org.hamcrest.core.IsNull.notNullValue
+import org.junit.After
 import org.junit.Assert.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import snyk.net.HttpClient
 import java.nio.charset.StandardCharsets
+import java.util.UUID
 
 class AmplitudeExperimentApiClientTest {
     @JvmField
@@ -34,6 +40,14 @@ class AmplitudeExperimentApiClientTest {
             apiKey = "",
             httpClient = mockHttpClient
         )
+        unmockkAll()
+        mockkStatic("io.snyk.plugin.UtilsKt")
+        every { pluginSettings().userAnonymousId } returns UUID.randomUUID().toString()
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
     }
 
     @Test

--- a/src/test/kotlin/snyk/errorHandler/SentryErrorReporterTest.kt
+++ b/src/test/kotlin/snyk/errorHandler/SentryErrorReporterTest.kt
@@ -2,10 +2,10 @@ package snyk.errorHandler
 
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
-import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import io.mockk.unmockkAll
 import io.mockk.verify
 import io.sentry.Sentry
 import io.sentry.protocol.SentryId
@@ -20,7 +20,7 @@ import snyk.pluginInfo
 class SentryErrorReporterTest {
     @Before
     fun setUp() {
-        clearAllMocks()
+        unmockkAll()
         mockkStatic(Sentry::class)
         // never send to Sentry
         every { Sentry.captureException(any()) } returns SentryId()
@@ -28,7 +28,7 @@ class SentryErrorReporterTest {
 
     @After
     fun tearDown() {
-        clearAllMocks()
+        unmockkAll()
     }
 
     @Test

--- a/src/test/kotlin/snyk/iac/IgnoreButtonActionListenerTest.kt
+++ b/src/test/kotlin/snyk/iac/IgnoreButtonActionListenerTest.kt
@@ -1,6 +1,6 @@
 package snyk.iac
 
-import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
 import io.mockk.every
@@ -82,9 +82,8 @@ class IgnoreButtonActionListenerTest {
         justRun { service.ignore(issue.id) }
         every { event.source } returns button
 
-        val daemonCodeAnalyzer = mockk<DaemonCodeAnalyzer>()
-        every { DaemonCodeAnalyzer.getInstance(project) } returns daemonCodeAnalyzer
-        justRun { daemonCodeAnalyzer.restart() }
+        mockkStatic(ApplicationManager::class)
+        justRun { ApplicationManager.getApplication().invokeLater(any()) }
 
         task.run(mockk())
 

--- a/src/test/kotlin/snyk/net/HttpClientTest.kt
+++ b/src/test/kotlin/snyk/net/HttpClientTest.kt
@@ -1,6 +1,5 @@
 package snyk.net
 
-import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
@@ -19,7 +18,7 @@ class HttpClientTest {
 
     @Before
     fun setUp() {
-        clearAllMocks()
+        unmockkAll()
     }
 
     @After


### PR DESCRIPTION
- changed FileListener to only update the node

- changed scan trigger to not check for description == null (please explain if this had a reason). When a user explicitly triggers a scan, we should not ignore it, I think.