### PR TITLE
fix: chore: ⬆️ upgrade Snyk Code Client to 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Snyk Vulnerability Scanner Changelog
 
+## [2.4.8]
+### Fixed
+- use Snyk Code API 2.2.1
+- updated dependencies
+
 ## [2.4.7]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [2.4.8]
 ### Fixed
-- use Snyk Code API 2.2.1
+- don't show an error, when no supported package manager was found for Snyk OSS
+- use Snyk Code API 2.2.1, gives support to automatically handling empty files
 - updated dependencies
 
 ## [2.4.7]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
   implementation("com.google.code.gson:gson:2.8.9")
   implementation("com.segment.analytics.java:analytics:3.1.3")
   implementation("io.sentry:sentry:5.4.3")
-  implementation("io.snyk.code.sdk:snyk-code-client:2.2.0")
+  implementation("io.snyk.code.sdk:snyk-code-client:2.2.1")
   implementation("ly.iterative.itly:plugin-iteratively:1.2.11")
   implementation("ly.iterative.itly:plugin-schema-validator:1.2.11") {
     exclude(group = "org.slf4j")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=io.snyk.intellij
 pluginName=Snyk Vulnerability Scanner
-pluginVersion=2.4.7
+pluginVersion=2.4.8
 
 # for insight into build numbers and IntelliJ Platform versions
 # see https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html


### PR DESCRIPTION
This pulls in the latest code-api and prepares the 2.4.8 release as a bugfix release. The build will only succeed after the new version 2.2.1 is available in maven central (see https://github.com/snyk/code-sdk-java/pull/29).