### PR TITLE
fix: AlreadyDisposedException due to Project disposal before using project's service [ROAD-606]

### DIFF
--- a/src/integTest/kotlin/io/snyk/SnykBulkFileListenerTest.kt
+++ b/src/integTest/kotlin/io/snyk/SnykBulkFileListenerTest.kt
@@ -13,12 +13,12 @@ import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.intellij.util.io.createDirectories
 import com.intellij.util.io.delete
 import com.intellij.util.io.exists
-import io.snyk.plugin.getKubernetesImageCache
 import io.snyk.plugin.removeDummyCliFile
 import io.snyk.plugin.resetSettings
 import io.snyk.plugin.ui.toolwindow.SnykToolWindowPanel
 import org.awaitility.Awaitility.await
 import org.junit.Test
+import snyk.container.KubernetesImageCache
 import snyk.container.KubernetesImageCacheIntegTest
 import snyk.iac.IacIssuesForFile
 import snyk.iac.IacResult
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeUnit
 @Suppress("FunctionName")
 class SnykBulkFileListenerTest : BasePlatformTestCase() {
 
-    private val imageCache get() = getKubernetesImageCache(project)
+    private val imageCache get() = project.service<KubernetesImageCache>()
 
     override fun setUp() {
         super.setUp()

--- a/src/integTest/kotlin/io/snyk/plugin/cli/ConsoleCommandRunnerTest.kt
+++ b/src/integTest/kotlin/io/snyk/plugin/cli/ConsoleCommandRunnerTest.kt
@@ -29,9 +29,13 @@ import org.junit.Before
 import org.junit.Test
 import snyk.PLUGIN_ID
 import snyk.errorHandler.SentryErrorReporter
+import snyk.oss.OssService
 import java.util.concurrent.TimeUnit
 
 class ConsoleCommandRunnerTest : LightPlatformTestCase() {
+
+    private val ossService: OssService
+        get() = getOssService(project) ?: throw IllegalStateException("OSS service should be available")
 
     @Test
     fun testSetupCliEnvironmentVariables() {
@@ -80,7 +84,7 @@ class ConsoleCommandRunnerTest : LightPlatformTestCase() {
                         snykCliDownloaderService.isCliDownloading()
                     )
                     // No exception should happened while CLI is downloading and any CLI command is invoked
-                    val commands = getOssService(project).buildCliCommandsList(listOf("test"))
+                    val commands = ossService.buildCliCommandsList(listOf("test"))
                     val output = ConsoleCommandRunner().execute(commands, getPluginPath(), "", project)
                     assertTrue(
                         "Should be NO output for CLI command while CLI is downloading, but received:\n$output",
@@ -110,7 +114,7 @@ class ConsoleCommandRunnerTest : LightPlatformTestCase() {
         assertEquals(DEFAULT_TIMEOUT_FOR_SCAN_WAITING_MS, defaultValue)
         registryValue.setValue(100)
 
-        val commands = getOssService(project).buildCliCommandsList(listOf("test"))
+        val commands = ossService.buildCliCommandsList(listOf("test"))
         val progressManager = ProgressManager.getInstance() as CoreProgressManager
         val testRunFuture = progressManager.runProcessWithProgressAsynchronously(
             object : Task.Backgroundable(project, "Test CLI command invocation", true) {

--- a/src/integTest/kotlin/io/snyk/plugin/services/SnykTaskQueueServiceHeavyTest.kt
+++ b/src/integTest/kotlin/io/snyk/plugin/services/SnykTaskQueueServiceHeavyTest.kt
@@ -1,0 +1,38 @@
+package io.snyk.plugin.services
+
+import com.intellij.testFramework.HeavyPlatformTestCase
+import com.intellij.testFramework.PlatformTestUtil
+import io.mockk.unmockkAll
+import io.snyk.plugin.getSnykTaskQueueService
+import io.snyk.plugin.removeDummyCliFile
+import io.snyk.plugin.resetSettings
+import org.junit.Test
+
+@Suppress("FunctionName")
+class SnykTaskQueueServiceHeavyTest : HeavyPlatformTestCase() {
+
+    override fun setUp() {
+        super.setUp()
+        unmockkAll()
+        resetSettings(project)
+    }
+
+    override fun tearDown() {
+        unmockkAll()
+        resetSettings(project)
+        removeDummyCliFile()
+        super.tearDown()
+    }
+
+    @Test
+    fun `test service request for disposed project`() {
+        PlatformTestUtil.forceCloseProjectWithoutSaving(project)
+
+        // project.service<>() for disposed project
+        // will fail with AlreadyDisposedException under Idea at least 213 and up
+        val service = getSnykTaskQueueService(project)
+
+        assertNull("Project Service request should return NULL for disposed project", service)
+        myProject = null // to avoid double disposing effort in tearDown
+    }
+}

--- a/src/integTest/kotlin/io/snyk/plugin/services/SnykTaskQueueServiceTest.kt
+++ b/src/integTest/kotlin/io/snyk/plugin/services/SnykTaskQueueServiceTest.kt
@@ -38,7 +38,7 @@ class SnykTaskQueueServiceTest : LightPlatformTestCase() {
     fun testSnykTaskQueueService() {
         setupDummyCliFile()
 
-        val snykTaskQueueService = project!!.service<SnykTaskQueueService>()
+        val snykTaskQueueService = project.service<SnykTaskQueueService>()
 
         snykTaskQueueService.scan()
         // needed due to luck of disposing services by Idea test framework (bug?)
@@ -59,7 +59,7 @@ class SnykTaskQueueServiceTest : LightPlatformTestCase() {
         if (cliFile.exists()) cliFile.delete()
         assertFalse(cliFile.exists())
 
-        val snykTaskQueueService = project!!.service<SnykTaskQueueService>()
+        val snykTaskQueueService = project.service<SnykTaskQueueService>()
 
         val settings = pluginSettings()
         settings.ossScanEnable = true
@@ -115,8 +115,8 @@ class SnykTaskQueueServiceTest : LightPlatformTestCase() {
 
         mockkStatic("io.snyk.plugin.UtilsKt")
         every { isIacEnabled() } returns true
-        every { getIacService(project).isCliInstalled() } returns true
-        every { getIacService(project).scan() } returns fakeIacResult
+        every { getIacService(project)?.isCliInstalled() } returns true
+        every { getIacService(project)?.scan() } returns fakeIacResult
 
         snykTaskQueueService.scan()
 

--- a/src/integTest/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanelIntegTest.kt
+++ b/src/integTest/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanelIntegTest.kt
@@ -90,7 +90,7 @@ class SnykToolWindowPanelIntegTest : HeavyPlatformTestCase() {
             )
         } returns (iacGoofJson)
 
-        getIacService(project).setConsoleCommandRunner(mockRunner)
+        getIacService(project)?.setConsoleCommandRunner(mockRunner)
 
         project.service<SnykTaskQueueService>().scan()
     }
@@ -188,8 +188,8 @@ class SnykToolWindowPanelIntegTest : HeavyPlatformTestCase() {
         val iacResultWithError = IacResult(null, iacError)
 
         mockkStatic("io.snyk.plugin.UtilsKt")
-        every { getIacService(project).isCliInstalled() } returns true
-        every { getIacService(project).scan() } returns iacResultWithError
+        every { getIacService(project)?.isCliInstalled() } returns true
+        every { getIacService(project)?.scan() } returns iacResultWithError
 
         // actual test run
         project.service<SnykTaskQueueService>().scan()

--- a/src/integTest/kotlin/io/snyk/plugin/ui/toolwindow/settings/ScanTypesPanelTest.kt
+++ b/src/integTest/kotlin/io/snyk/plugin/ui/toolwindow/settings/ScanTypesPanelTest.kt
@@ -2,6 +2,7 @@ package io.snyk.plugin.ui.toolwindow.settings
 
 import UIComponentFinder.getComponentByName
 import com.intellij.openapi.Disposable
+import com.intellij.openapi.components.service
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.util.registry.Registry
 import com.intellij.testFramework.LightPlatform4TestCase
@@ -16,6 +17,7 @@ import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.resetSettings
 import io.snyk.plugin.ui.settings.ScanTypesPanel
 import org.junit.Test
+import snyk.container.KubernetesImageCache
 
 @Suppress("FunctionName")
 class ScanTypesPanelTest : LightPlatform4TestCase() {
@@ -37,6 +39,8 @@ class ScanTypesPanelTest : LightPlatform4TestCase() {
         isContainerEnabledRegistryValue.setValue(isContainerEnabledDefaultValue)
         super.tearDown()
     }
+
+    private val imageCache get() = project.service<KubernetesImageCache>()
 
     private lateinit var disposable: Disposable
 
@@ -106,7 +110,7 @@ class ScanTypesPanelTest : LightPlatform4TestCase() {
     @Test
     fun `KubernetesImageCache rescan after container enablement`() {
         mockkStatic("io.snyk.plugin.UtilsKt")
-        val spyk = spyk(getKubernetesImageCache(project))
+        val spyk = spyk(imageCache)
         every { getKubernetesImageCache(project) } returns spyk
         getContainerCheckBox(initialValue = false, switchSelection = true)
 
@@ -116,7 +120,7 @@ class ScanTypesPanelTest : LightPlatform4TestCase() {
     @Test
     fun `KubernetesImageCache clean up after container disablement`() {
         mockkStatic("io.snyk.plugin.UtilsKt")
-        val spyk = spyk(getKubernetesImageCache(project))
+        val spyk = spyk(imageCache)
         every { getKubernetesImageCache(project) } returns spyk
         getContainerCheckBox(initialValue = true, switchSelection = true)
 

--- a/src/integTest/kotlin/snyk/container/KubernetesImageCacheIntegTest.kt
+++ b/src/integTest/kotlin/snyk/container/KubernetesImageCacheIntegTest.kt
@@ -13,7 +13,7 @@ class KubernetesImageCacheIntegTest : LightPlatform4TestCase() {
     override fun setUp() {
         super.setUp()
         cut = project.service()
-        getKubernetesImageCache(project).clear()
+        getKubernetesImageCache(project)?.clear()
     }
 
     @Test

--- a/src/integTest/kotlin/snyk/iac/IacServiceTest.kt
+++ b/src/integTest/kotlin/snyk/iac/IacServiceTest.kt
@@ -47,11 +47,14 @@ class IacServiceTest : LightPlatformTestCase() {
         super.tearDown()
     }
 
+    private val iacService: IacScanService
+        get() = getIacService(project) ?: throw IllegalStateException("IaC service should be available")
+
     @Test
     fun testBuildCliCommandsListWithDefaults() {
         setupDummyCliFile()
 
-        val cliCommands = getIacService(project).buildCliCommandsList(listOf("fake_cli_command"))
+        val cliCommands = iacService.buildCliCommandsList(listOf("fake_cli_command"))
 
         assertTrue(cliCommands.contains(getCliFile().absolutePath))
         assertTrue(cliCommands.contains("fake_cli_command"))
@@ -63,7 +66,7 @@ class IacServiceTest : LightPlatformTestCase() {
         setupDummyCliFile()
         pluginSettings().usageAnalyticsEnabled = false
 
-        val cliCommands = getIacService(project).buildCliCommandsList(listOf("fake_cli_command"))
+        val cliCommands = iacService.buildCliCommandsList(listOf("fake_cli_command"))
 
         assertFalse(cliCommands.contains("--DISABLE_ANALYTICS"))
     }
@@ -74,7 +77,7 @@ class IacServiceTest : LightPlatformTestCase() {
 
         project.service<SnykProjectSettingsStateService>().additionalParameters = "--file=package.json"
 
-        val cliCommands = getIacService(project).buildCliCommandsList(listOf("fake_cli_command"))
+        val cliCommands = iacService.buildCliCommandsList(listOf("fake_cli_command"))
 
         assertFalse(cliCommands.contains("--file=package.json"))
     }
@@ -101,9 +104,9 @@ class IacServiceTest : LightPlatformTestCase() {
             }
         """.trimIndent()
 
-        getIacService(project).setConsoleCommandRunner(mockRunner)
+        iacService.setConsoleCommandRunner(mockRunner)
 
-        val iacResult = getIacService(project).scan()
+        val iacResult = iacService.scan()
 
         assertFalse(iacResult.isSuccessful())
         assertEquals(errorMsg, iacResult.error!!.message)
@@ -124,9 +127,9 @@ class IacServiceTest : LightPlatformTestCase() {
             )
         } returns (wholeProjectJson)
 
-        getIacService(project).setConsoleCommandRunner(mockRunner)
+        iacService.setConsoleCommandRunner(mockRunner)
 
-        val iacResult = getIacService(project).scan()
+        val iacResult = iacService.scan()
 
         assertTrue(iacResult.isSuccessful())
 
@@ -140,8 +143,6 @@ class IacServiceTest : LightPlatformTestCase() {
 
     @Test
     fun testConvertRawCliStringToIacResult() {
-        val iacService = getIacService(project)
-
         val singleObjectIacResult = iacService.convertRawCliStringToCliResult(singleFileJson)
         assertTrue(singleObjectIacResult.isSuccessful())
 
@@ -168,17 +169,13 @@ class IacServiceTest : LightPlatformTestCase() {
 
     @Test
     fun testConvertRawCliStringToIacResultWithEmptyRawString() {
-        val cli = getIacService(project)
-
-        val cliResult = cli.convertRawCliStringToCliResult("")
+        val cliResult = iacService.convertRawCliStringToCliResult("")
         assertFalse(cliResult.isSuccessful())
     }
 
     @Test
     fun testConvertRawCliStringToIacResultWithMissformedJson() {
-        val cli = getIacService(project)
-
-        val cliResult = cli.convertRawCliStringToCliResult("""
+        val cliResult = iacService.convertRawCliStringToCliResult("""
                     {
                       "ok": false,
                       "error": ["could not be","array here"],
@@ -190,8 +187,6 @@ class IacServiceTest : LightPlatformTestCase() {
 
     @Test
     fun testConvertRawCliStringToIacResultFieldsInitialisation() {
-        val iacService = getIacService(project)
-
         val iacResult = iacService.convertRawCliStringToCliResult(wholeProjectJson)
         assertTrue(iacResult.isSuccessful())
 

--- a/src/main/kotlin/io/snyk/plugin/SnykBulkFileListener.kt
+++ b/src/main/kotlin/io/snyk/plugin/SnykBulkFileListener.kt
@@ -111,7 +111,7 @@ class SnykBulkFileListener : BulkFileListener {
                         virtualFilesAffected.any { it.isDirectory && vFile.path.startsWith(it.path) }
                 }
 
-            if (filesToRemoveFromCache.isNotEmpty())
+            if (filesToRemoveFromCache.isNotEmpty()) {
                 getSnykTaskQueueService(project)?.scheduleRunnable("Snyk Code is updating caches...") {
                     if (filesToRemoveFromCache.size > 10) {
                         // bulk files change event (like `git checkout`) - better to drop cache and perform full rescan later
@@ -120,7 +120,7 @@ class SnykBulkFileListener : BulkFileListener {
                         AnalysisData.instance.removeFilesFromCache(filesToRemoveFromCache)
                     }
                 }
-
+            }
             // clean .dcignore caches if needed
             SnykCodeIgnoreInfoHolder.instance.cleanIgnoreFileCachesIfAffected(project, virtualFilesAffected)
         }

--- a/src/main/kotlin/io/snyk/plugin/SnykBulkFileListener.kt
+++ b/src/main/kotlin/io/snyk/plugin/SnykBulkFileListener.kt
@@ -2,7 +2,6 @@ package io.snyk.plugin
 
 import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
 import com.intellij.ide.impl.ProjectUtil
-import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.progress.runBackgroundableTask
 import com.intellij.openapi.project.DumbService
@@ -18,7 +17,6 @@ import com.intellij.openapi.vfs.newvfs.events.VFileEvent
 import com.intellij.openapi.vfs.newvfs.events.VFileMoveEvent
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
-import io.snyk.plugin.services.SnykTaskQueueService
 import io.snyk.plugin.snykcode.core.AnalysisData
 import io.snyk.plugin.snykcode.core.RunUtils
 import io.snyk.plugin.snykcode.core.SnykCodeIgnoreInfoHolder
@@ -47,7 +45,7 @@ class SnykBulkFileListener : BulkFileListener {
 
             if (isContainerEnabled()) {
                 for (project in ProjectUtil.getOpenProjects()) {
-                    getKubernetesImageCache(project).extractFromEvents(events)
+                    getKubernetesImageCache(project)?.extractFromEvents(events)
                 }
             }
         }
@@ -78,10 +76,10 @@ class SnykBulkFileListener : BulkFileListener {
                 classesOfEventsToFilter = classesOfEventsToFilter
             )
 
-            val toolWindowPanel = project.service<SnykToolWindowPanel>()
+            val toolWindowPanel = getSnykToolWindowPanel(project)
 
             // clean OSS cached results if needed
-            if (toolWindowPanel.currentOssResults != null) {
+            if (toolWindowPanel?.currentOssResults != null) {
                 val buildFileChanged = virtualFilesAffected
                     .filter { supportedBuildFiles.contains(it.name) }
                     .find { ProjectRootManager.getInstance(project).fileIndex.isInContent(it) }
@@ -114,7 +112,7 @@ class SnykBulkFileListener : BulkFileListener {
                 }
 
             if (filesToRemoveFromCache.isNotEmpty())
-                project.service<SnykTaskQueueService>().scheduleRunnable("Snyk Code is updating caches...") {
+                getSnykTaskQueueService(project)?.scheduleRunnable("Snyk Code is updating caches...") {
                     if (filesToRemoveFromCache.size > 10) {
                         // bulk files change event (like `git checkout`) - better to drop cache and perform full rescan later
                         AnalysisData.instance.removeProjectFromCaches(project)
@@ -182,8 +180,8 @@ class SnykBulkFileListener : BulkFileListener {
             )
 
             // update IaC cached results if needed
-            val toolWindowPanel = project.service<SnykToolWindowPanel>()
-            val allCliIssues = toolWindowPanel.currentIacResult?.allCliIssues
+            val toolWindowPanel = getSnykToolWindowPanel(project)
+            val allCliIssues = toolWindowPanel?.currentIacResult?.allCliIssues
             if (allCliIssues != null && allCliIssues.isNotEmpty()) {
                 updateIacCache(virtualFilesAffected, toolWindowPanel)
             }

--- a/src/main/kotlin/io/snyk/plugin/SnykPostStartupActivity.kt
+++ b/src/main/kotlin/io/snyk/plugin/SnykPostStartupActivity.kt
@@ -12,7 +12,6 @@ import com.intellij.openapi.startup.StartupActivity
 import com.intellij.openapi.vfs.VirtualFileManager
 import io.snyk.plugin.services.SnykAnalyticsService
 import io.snyk.plugin.services.SnykApiService
-import io.snyk.plugin.services.SnykTaskQueueService
 import io.snyk.plugin.snykcode.core.AnalysisData
 import io.snyk.plugin.snykcode.core.SnykCodeIgnoreInfoHolder
 import io.snyk.plugin.ui.SnykBalloonNotifications
@@ -21,7 +20,6 @@ import snyk.amplitude.AmplitudeExperimentService
 import snyk.amplitude.api.ExperimentUser
 import snyk.analytics.PluginIsInstalled
 import snyk.analytics.PluginIsUninstalled
-import snyk.container.KubernetesImageCache
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.Date
@@ -59,7 +57,7 @@ class SnykPostStartupActivity : StartupActivity.DumbAware {
         SnykCodeIgnoreInfoHolder.instance.createDcIgnoreIfNeeded(project)
 
         if (!ApplicationManager.getApplication().isUnitTestMode) {
-            project.service<SnykTaskQueueService>().downloadLatestRelease()
+            getSnykTaskQueueService(project)?.downloadLatestRelease()
         }
 
         val feedbackRequestShownMoreThenTwoWeeksAgo =
@@ -81,7 +79,7 @@ class SnykPostStartupActivity : StartupActivity.DumbAware {
         service<AmplitudeExperimentService>().fetch(experimentUser)
 
         if (isContainerEnabled()) {
-            getKubernetesImageCache(project).scanProjectForKubernetesFiles()
+            getKubernetesImageCache(project)?.scanProjectForKubernetesFiles()
         }
     }
 }

--- a/src/main/kotlin/io/snyk/plugin/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/Utils.kt
@@ -56,7 +56,7 @@ fun getSnykCliAuthenticationService(project: Project): SnykCliAuthenticationServ
 
 fun getSnykCliDownloaderService(project: Project): SnykCliDownloaderService? = project.serviceIfNotDisposed()
 
-fun getSnykProjectSettingsStateService(project: Project): SnykProjectSettingsStateService? = project.serviceIfNotDisposed()
+fun getSnykProjectSettingsService(project: Project): SnykProjectSettingsStateService? = project.serviceIfNotDisposed()
 
 fun getCliFile() = File(getPluginPath(), Platform.current().snykWrapperFileName)
 

--- a/src/main/kotlin/io/snyk/plugin/services/download/CliDownloaderErrorHandler.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/download/CliDownloaderErrorHandler.kt
@@ -2,13 +2,13 @@ package io.snyk.plugin.services.download
 
 import com.intellij.ide.BrowserUtil
 import com.intellij.notification.NotificationAction
-import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.runBackgroundableTask
 import com.intellij.openapi.project.Project
 import com.intellij.util.io.HttpRequests
 import io.snyk.plugin.getCliFile
+import io.snyk.plugin.getSnykCliDownloaderService
 import io.snyk.plugin.ui.SnykBalloonNotificationHelper
 import java.io.IOException
 
@@ -17,7 +17,7 @@ class CliDownloaderErrorHandler {
         SnykBalloonNotificationHelper.showError(message, project,
             NotificationAction.createSimple("Retry CLI download") {
                 runBackgroundableTask("Retry Snyk CLI Download", project, true) {
-                    project.service<SnykCliDownloaderService>().downloadLatestRelease(it, project)
+                    getSnykCliDownloaderService(project)?.downloadLatestRelease(it, project)
                 }
             },
             NotificationAction.createSimple("Contact support...") {

--- a/src/main/kotlin/io/snyk/plugin/settings/SnykProjectSettingsConfigurable.kt
+++ b/src/main/kotlin/io/snyk/plugin/settings/SnykProjectSettingsConfigurable.kt
@@ -4,6 +4,8 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.options.SearchableConfigurable
 import com.intellij.openapi.project.Project
 import io.snyk.plugin.events.SnykSettingsListener
+import io.snyk.plugin.getSnykProjectSettingsStateService
+import io.snyk.plugin.getSnykToolWindowPanel
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.getSyncPublisher
 import io.snyk.plugin.isProjectSettingsAvailable
@@ -59,10 +61,10 @@ class SnykProjectSettingsConfigurable(val project: Project) : SearchableConfigur
         snykSettingsDialog.saveScanTypeChanges()
 
         if (isProjectSettingsAvailable(project)) {
-            project.service<SnykProjectSettingsStateService>().additionalParameters = snykSettingsDialog.getAdditionalParameters()
+            getSnykProjectSettingsStateService(project)?.additionalParameters = snykSettingsDialog.getAdditionalParameters()
         }
 
-        project.service<SnykToolWindowPanel>().cleanUiAndCaches()
+        getSnykToolWindowPanel(project)?.cleanUiAndCaches()
         getSyncPublisher(project, SnykSettingsListener.SNYK_SETTINGS_TOPIC)?.settingsChanged()
     }
 
@@ -86,5 +88,5 @@ class SnykProjectSettingsConfigurable(val project: Project) : SearchableConfigur
 
     private fun isAdditionalParametersModified(): Boolean =
         isProjectSettingsAvailable(project)
-            && snykSettingsDialog.getAdditionalParameters() != project.service<SnykProjectSettingsStateService>().additionalParameters
+            && snykSettingsDialog.getAdditionalParameters() != getSnykProjectSettingsStateService(project)?.additionalParameters
 }

--- a/src/main/kotlin/io/snyk/plugin/settings/SnykProjectSettingsConfigurable.kt
+++ b/src/main/kotlin/io/snyk/plugin/settings/SnykProjectSettingsConfigurable.kt
@@ -1,20 +1,17 @@
 package io.snyk.plugin.settings
 
-import com.intellij.openapi.components.service
 import com.intellij.openapi.options.SearchableConfigurable
 import com.intellij.openapi.project.Project
 import io.snyk.plugin.events.SnykSettingsListener
-import io.snyk.plugin.getSnykProjectSettingsStateService
+import io.snyk.plugin.getSnykProjectSettingsService
 import io.snyk.plugin.getSnykToolWindowPanel
-import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.getSyncPublisher
 import io.snyk.plugin.isProjectSettingsAvailable
 import io.snyk.plugin.isUrlValid
-import io.snyk.plugin.services.SnykProjectSettingsStateService
+import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.snykcode.core.SnykCodeParams
 import io.snyk.plugin.toSnykCodeApiUrl
 import io.snyk.plugin.ui.SnykSettingsDialog
-import io.snyk.plugin.ui.toolwindow.SnykToolWindowPanel
 import javax.swing.JComponent
 
 class SnykProjectSettingsConfigurable(val project: Project) : SearchableConfigurable {
@@ -61,7 +58,7 @@ class SnykProjectSettingsConfigurable(val project: Project) : SearchableConfigur
         snykSettingsDialog.saveScanTypeChanges()
 
         if (isProjectSettingsAvailable(project)) {
-            getSnykProjectSettingsStateService(project)?.additionalParameters = snykSettingsDialog.getAdditionalParameters()
+            getSnykProjectSettingsService(project)?.additionalParameters = snykSettingsDialog.getAdditionalParameters()
         }
 
         getSnykToolWindowPanel(project)?.cleanUiAndCaches()
@@ -86,7 +83,6 @@ class SnykProjectSettingsConfigurable(val project: Project) : SearchableConfigur
     private fun isCrashReportingModified(): Boolean =
         snykSettingsDialog.isCrashReportingEnabled() != applicationSettingsStateService.crashReportingEnabled
 
-    private fun isAdditionalParametersModified(): Boolean =
-        isProjectSettingsAvailable(project)
-            && snykSettingsDialog.getAdditionalParameters() != getSnykProjectSettingsStateService(project)?.additionalParameters
+    private fun isAdditionalParametersModified(): Boolean = isProjectSettingsAvailable(project) &&
+        snykSettingsDialog.getAdditionalParameters() != getSnykProjectSettingsService(project)?.additionalParameters
 }

--- a/src/main/kotlin/io/snyk/plugin/snykcode/core/SnykCodeIgnoreInfoHolder.kt
+++ b/src/main/kotlin/io/snyk/plugin/snykcode/core/SnykCodeIgnoreInfoHolder.kt
@@ -1,11 +1,10 @@
 package io.snyk.plugin.snykcode.core
 
 import ai.deepcode.javaclient.core.DeepCodeIgnoreInfoHolderBase
-import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiManager
-import io.snyk.plugin.services.SnykTaskQueueService
+import io.snyk.plugin.getSnykTaskQueueService
 import io.snyk.plugin.ui.SnykBalloonNotificationHelper
 import java.io.File
 
@@ -26,7 +25,7 @@ class SnykCodeIgnoreInfoHolder private constructor() : DeepCodeIgnoreInfoHolderB
     fun updateIgnoreFileCachesIfAffected(project: Project, virtualFilesToCheck: Collection<VirtualFile>) {
         val ignoreFilesChanged = getIgnoreFiles(project, virtualFilesToCheck)
         for (ignoreFile in ignoreFilesChanged) {
-            project.service<SnykTaskQueueService>().scheduleRunnable(
+            getSnykTaskQueueService(project)?.scheduleRunnable(
                 "updating caches for: ${PDU.instance.getFilePath(ignoreFile)}"
             ) { progress ->
                 update_ignoreFileContent(ignoreFile, progress)

--- a/src/main/kotlin/io/snyk/plugin/ui/SnykSettingsDialog.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/SnykSettingsDialog.kt
@@ -12,11 +12,11 @@ import com.intellij.ui.components.JBPasswordField
 import com.intellij.ui.components.fields.ExpandableTextField
 import com.intellij.uiDesigner.core.Spacer
 import io.snyk.plugin.events.SnykCliDownloadListener
+import io.snyk.plugin.getSnykCliAuthenticationService
 import io.snyk.plugin.isProjectSettingsAvailable
 import io.snyk.plugin.isUrlValid
 import io.snyk.plugin.services.SnykAnalyticsService
 import io.snyk.plugin.services.SnykApplicationSettingsStateService
-import io.snyk.plugin.services.SnykCliAuthenticationService
 import io.snyk.plugin.services.download.SnykCliDownloaderService
 import io.snyk.plugin.settings.SnykProjectSettingsConfigurable
 import io.snyk.plugin.ui.settings.ScanTypesPanel
@@ -78,7 +78,7 @@ class SnykSettingsDialog(
         receiveTokenButton.addActionListener {
             ApplicationManager.getApplication().invokeLater {
                 snykProjectSettingsConfigurable.apply()
-                val token = project.service<SnykCliAuthenticationService>().authenticate()
+                val token = getSnykCliAuthenticationService(project)?.authenticate() ?: ""
                 tokenTextField.text = token
 
                 val analytics = service<SnykAnalyticsService>()

--- a/src/main/kotlin/io/snyk/plugin/ui/settings/ScanTypesPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/settings/ScanTypesPanel.kt
@@ -104,7 +104,7 @@ class ScanTypesPanel(
                         { enabled ->
                             settings.containerScanEnabled = enabled
                             val imagesCache = getKubernetesImageCache(project)
-                            if (enabled) imagesCache.scanProjectForKubernetesFiles() else imagesCache.clear()
+                            if (enabled) imagesCache?.scanProjectForKubernetesFiles() else imagesCache?.clear()
                         },
                         null
                     ).component.apply {

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/OnboardPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/OnboardPanel.kt
@@ -7,18 +7,16 @@ import com.intellij.ui.layout.panel
 import com.intellij.util.ui.JBUI
 import io.snyk.plugin.analytics.getSelectedProducts
 import io.snyk.plugin.events.SnykSettingsListener
+import io.snyk.plugin.getSnykTaskQueueService
 import io.snyk.plugin.getSyncPublisher
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.services.SnykAnalyticsService
-import io.snyk.plugin.services.SnykTaskQueueService
 import io.snyk.plugin.ui.settings.ScanTypesPanel
-import snyk.amplitude.AmplitudeExperimentService
 import snyk.analytics.AnalysisIsTriggered
 import javax.swing.SwingConstants
 
 class OnboardPanel(project: Project) {
     private val disposable = Disposer.newDisposable()
-    private val amplitudeExperimentService = project.service<AmplitudeExperimentService>()
 
     private val scanTypesPanel by lazy {
         return@lazy ScanTypesPanel(
@@ -65,6 +63,6 @@ class OnboardPanel(project: Project) {
                 .build()
         )
 
-        project.service<SnykTaskQueueService>().scan()
+        getSnykTaskQueueService(project)?.scan()
     }
 }

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindow.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindow.kt
@@ -5,15 +5,15 @@ import com.intellij.openapi.actionSystem.ActionGroup
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.ActionToolbar
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.SimpleToolWindowPanel
-import snyk.common.SnykError
-import snyk.oss.OssResult
 import io.snyk.plugin.events.SnykScanListener
 import io.snyk.plugin.events.SnykTaskQueueListener
+import io.snyk.plugin.getSnykToolWindowPanel
 import io.snyk.plugin.snykcode.SnykCodeResults
+import snyk.common.SnykError
 import snyk.iac.IacResult
+import snyk.oss.OssResult
 
 /**
  * IntelliJ ToolWindow for Snyk plugin.
@@ -23,15 +23,13 @@ class SnykToolWindow(private val project: Project) : SimpleToolWindowPanel(false
     private val actionToolbar: ActionToolbar
 
     init {
-        val toolWindowPanel = project.service<SnykToolWindowPanel>()
-
         val actionManager = ActionManager.getInstance()
         val actionGroup = actionManager.getAction("io.snyk.plugin.ActionBar") as ActionGroup
         actionToolbar = actionManager.createActionToolbar("Snyk Toolbar", actionGroup, false)
         initialiseToolbar()
         toolbar = actionToolbar.component
 
-        setContent(toolWindowPanel)
+        getSnykToolWindowPanel(project)?.let { setContent(it) }
     }
 
     private fun initialiseToolbar() {

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
@@ -31,6 +31,8 @@ import io.snyk.plugin.events.SnykResultsFilteringListener
 import io.snyk.plugin.events.SnykScanListener
 import io.snyk.plugin.events.SnykSettingsListener
 import io.snyk.plugin.events.SnykTaskQueueListener
+import io.snyk.plugin.getAmplitudeExperimentService
+import io.snyk.plugin.getSnykTaskQueueService
 import io.snyk.plugin.getSyncPublisher
 import io.snyk.plugin.head
 import io.snyk.plugin.isCliDownloading
@@ -515,7 +517,7 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
         when {
             settings.token.isNullOrEmpty() -> displayAuthPanel()
             settings.pluginFirstRun -> {
-                if (project.service<AmplitudeExperimentService>().isPartOfExperimentalWelcomeWorkflow()) {
+                if (getAmplitudeExperimentService(project)?.isPartOfExperimentalWelcomeWorkflow() == true) {
                     pluginSettings().pluginFirstRun = false
                     enableProductsAccordingToServerSetting()
                     getSyncPublisher(project, SnykSettingsListener.SNYK_SETTINGS_TOPIC)?.settingsChanged()
@@ -538,8 +540,7 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
                 .build()
         )
 
-        val taskQueueService = project.service<SnykTaskQueueService>()
-        taskQueueService.scan()
+        getSnykTaskQueueService(project)?.scan()
     }
 
     fun displayAuthPanel() {
@@ -720,7 +721,7 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
         val statePanel = StatePanel(
             "Scanning project for vulnerabilities...",
             "Stop Scanning",
-            Runnable { project.service<SnykTaskQueueService>().stopScan() }
+            Runnable { getSnykTaskQueueService(project)?.stopScan() }
         )
 
         descriptionPanel.add(CenterOneComponentPanel(statePanel), BorderLayout.CENTER)

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
@@ -45,7 +45,6 @@ import io.snyk.plugin.isSnykCodeRunning
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.services.SnykAnalyticsService
 import io.snyk.plugin.services.SnykApiService
-import io.snyk.plugin.services.SnykTaskQueueService
 import io.snyk.plugin.services.download.SnykCliDownloaderService
 import io.snyk.plugin.snykcode.SnykCodeResults
 import io.snyk.plugin.snykcode.core.AnalysisData

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/VulnerabilityTreeCellRenderer.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/VulnerabilityTreeCellRenderer.kt
@@ -1,7 +1,6 @@
 package io.snyk.plugin.ui.toolwindow
 
 import ai.deepcode.javaclient.core.SuggestionForFile
-import com.intellij.openapi.components.service
 import com.intellij.openapi.util.Iconable
 import com.intellij.psi.PsiFile
 import com.intellij.ui.ColoredTreeCellRenderer
@@ -9,6 +8,7 @@ import com.intellij.ui.SimpleTextAttributes
 import com.intellij.util.IconUtil
 import com.intellij.util.ui.UIUtil
 import icons.SnykIcons
+import io.snyk.plugin.getSnykToolWindowPanel
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.snykcode.core.AnalysisData
 import io.snyk.plugin.snykcode.severityAsString
@@ -44,8 +44,8 @@ class VulnerabilityTreeCellRenderer : ColoredTreeCellRenderer() {
                 nodeIcon = SnykIcons.getSeverityIcon(vulnerability.severity)
                 text = vulnerability.getPackageNameTitle()
 
-                val toolWindowPanel = value.project.service<SnykToolWindowPanel>()
-                if (toolWindowPanel.currentOssResults == null) {
+                val toolWindowPanel = getSnykToolWindowPanel(value.project)
+                if (toolWindowPanel?.currentOssResults == null) {
                     attributes = SimpleTextAttributes.GRAYED_ATTRIBUTES
                     nodeIcon = getDisabledIcon(nodeIcon)
                 }
@@ -55,8 +55,8 @@ class VulnerabilityTreeCellRenderer : ColoredTreeCellRenderer() {
                 nodeIcon = PackageManagerIconProvider.getIcon(ossVulnerabilitiesForFile.packageManager.toLowerCase())
                 text = ossVulnerabilitiesForFile.displayTargetFile
 
-                val toolWindowPanel = value.project.service<SnykToolWindowPanel>()
-                if (toolWindowPanel.currentOssResults == null) {
+                val toolWindowPanel = getSnykToolWindowPanel(value.project)
+                if (toolWindowPanel?.currentOssResults == null) {
                     attributes = SimpleTextAttributes.GRAYED_ATTRIBUTES
                     text += obsoleteSuffix
                     nodeIcon = getDisabledIcon(nodeIcon)
@@ -90,8 +90,8 @@ class VulnerabilityTreeCellRenderer : ColoredTreeCellRenderer() {
                 nodeIcon = PackageManagerIconProvider.getIcon(iacVulnerabilitiesForFile.packageManager.toLowerCase())
                 text = iacVulnerabilitiesForFile.targetFile
 
-                val toolWindowPanel = value.project.service<SnykToolWindowPanel>()
-                if (toolWindowPanel.currentIacResult == null || iacVulnerabilitiesForFile.obsolete) {
+                val toolWindowPanel = getSnykToolWindowPanel(value.project)
+                if (toolWindowPanel?.currentIacResult == null || iacVulnerabilitiesForFile.obsolete) {
                     attributes = SimpleTextAttributes.GRAYED_ATTRIBUTES
                     nodeIcon = getDisabledIcon(nodeIcon)
                     text += obsoleteSuffix
@@ -115,8 +115,8 @@ class VulnerabilityTreeCellRenderer : ColoredTreeCellRenderer() {
                     }
                 }
 
-                val toolWindowPanel = value.project.service<SnykToolWindowPanel>()
-                if (toolWindowPanel.currentIacResult == null || issue.ignored || obsolete) {
+                val toolWindowPanel = getSnykToolWindowPanel(value.project)
+                if (toolWindowPanel?.currentIacResult == null || issue.ignored || obsolete) {
                     attributes = SimpleTextAttributes.GRAYED_ATTRIBUTES
                     nodeIcon = getDisabledIcon(nodeIcon)
                 }

--- a/src/main/kotlin/snyk/iac/annotator/IacBaseAnnotator.kt
+++ b/src/main/kotlin/snyk/iac/annotator/IacBaseAnnotator.kt
@@ -3,7 +3,6 @@ package snyk.iac.annotator
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.ExternalAnnotator
 import com.intellij.lang.annotation.HighlightSeverity
-import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.util.TextRange
@@ -13,7 +12,7 @@ import io.snyk.plugin.Severity.Companion.CRITICAL
 import io.snyk.plugin.Severity.Companion.HIGH
 import io.snyk.plugin.Severity.Companion.LOW
 import io.snyk.plugin.Severity.Companion.MEDIUM
-import io.snyk.plugin.ui.toolwindow.SnykToolWindowPanel
+import io.snyk.plugin.getSnykToolWindowPanel
 import snyk.iac.IacIssue
 import snyk.iac.IacResult
 
@@ -28,7 +27,7 @@ abstract class IacBaseAnnotator : ExternalAnnotator<PsiFile, Unit>() {
     fun getIssues(psiFile: PsiFile): List<IacIssue> {
         LOG.debug("Calling doAnnotate on ${psiFile.name}")
 
-        val iacResult = psiFile.project.service<SnykToolWindowPanel>().currentIacResult ?: return emptyList()
+        val iacResult = getSnykToolWindowPanel(psiFile.project)?.currentIacResult ?: return emptyList()
         ProgressManager.checkCanceled()
         return getIssuesForFile(psiFile, iacResult)
     }

--- a/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SnykAuthPanelTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SnykAuthPanelTest.kt
@@ -37,6 +37,7 @@ class SnykAuthPanelTest {
         val messageBus = mockk<MessageBus>(relaxed = true)
         every { application.messageBus } returns messageBus
         every { project.messageBus } returns messageBus
+        every { project.isDisposed } returns false
         every { messageBus.syncPublisher(SNYK_SETTINGS_TOPIC) } returns mockk(relaxed = true)
         every { messageBus.isDisposed } returns false
         every { application.getService(SnykApplicationSettingsStateService::class.java) } returns mockk(relaxed = true)


### PR DESCRIPTION
For all our project services create correspondent funs in Util and check there if project is disposed return Null otherwise the service instance.
Then we need to remember to use any such service from correspondent fun only. 
Also Null case need to be handled in each particular case (in most places it looks like just ?. usage needed).