### PR TITLE
Facilitate Release Process

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,7 @@ trim_trailing_whitespace = true
 [*.md]
 trim_trailing_whitespace = false
 
-[*.kt]
+[*.{kt,kts}]
 indent_size = 4
 wildcard_import_limit = 999
 ij_kotlin_packages_to_use_import_on_demand = ^

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,15 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name }}
 
+      - name: Create Github release
+        uses: "marvinpinto/action-automatic-releases@latest"
+        if: ${{ !env.ACT }}
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          prerelease: false
+
       - name: Publish Plugin
+        if: ${{ !env.ACT }}
         env:
           PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
           ORG_GRADLE_PROJECT_amplitudeExperimentApiKey: ${{ secrets.AMPLITUDE_EXPERIMENT_API_KEY }}

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -2,7 +2,7 @@ name: Weekly Release
 
 on:
   schedule:
-    - cron: '0 10 * * 3'  # every wednesday at 10 am
+    - cron: '0 10 * * 1'  # every Monday at 10 am UTC
 
 jobs:
   create-release-tag:

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -1,0 +1,41 @@
+name: Weekly Release
+
+on:
+  schedule:
+    - cron: '0 10 * * 3'  # every wednesday at 10 am
+
+jobs:
+  create-release-tag:
+    name: create release tag
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fetch Sources
+        uses: actions/checkout@v2
+
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Setup Gradle Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+
+      - name: Release
+        if: ${{ !env.ACT }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git checkout master
+          ./gradlew release
+
+      - name: Release - Dry Run
+        if: ${{ env.ACT }}
+        run: ./gradlew release -Prelease.dryRun
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,170 +8,171 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 fun properties(key: String) = project.findProperty(key).toString()
 
 plugins {
-  id("org.jetbrains.changelog") version "1.2.1"
-  id("org.jetbrains.intellij") version "1.1.2"
-  id("org.jetbrains.kotlin.jvm") version "1.5.10"
-  id("io.gitlab.arturbosch.detekt") version ("1.17.1")
+    id("org.jetbrains.changelog") version "1.2.1"
+    id("org.jetbrains.intellij") version "1.1.2"
+    id("org.jetbrains.kotlin.jvm") version "1.5.10"
+    id("io.gitlab.arturbosch.detekt") version ("1.17.1")
+    id("pl.allegro.tech.build.axion-release") version "1.13.6"
 }
+
+version = scmVersion.version
 
 group = properties("pluginGroup")
 description = properties("pluginName")
-version = properties("pluginVersion")
 
 repositories {
-  mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-  implementation("org.commonmark:commonmark:0.18.1")
-  implementation("com.google.code.gson:gson:2.8.9")
-  implementation("com.segment.analytics.java:analytics:3.1.3")
-  implementation("io.sentry:sentry:5.4.3")
-  implementation("io.snyk.code.sdk:snyk-code-client:2.2.1")
-  implementation("ly.iterative.itly:plugin-iteratively:1.2.11")
-  implementation("ly.iterative.itly:plugin-schema-validator:1.2.11") {
-    exclude(group = "org.slf4j")
-  }
-  implementation("ly.iterative.itly:sdk-jvm:1.2.11")
-  testImplementation("com.squareup.okhttp3:mockwebserver:4.9.3")
-  testImplementation("junit:junit:4.13.2") {
-    exclude(group = "org.hamcrest")
-  }
-  testImplementation("org.hamcrest:hamcrest:2.2")
-  testImplementation("io.mockk:mockk:1.12.1")
-  testImplementation("org.awaitility:awaitility:4.1.1")
-  runtimeOnly("org.jetbrains.kotlin:kotlin-reflect:1.4.32")
+    implementation("org.commonmark:commonmark:0.18.1")
+    implementation("com.google.code.gson:gson:2.8.9")
+    implementation("com.segment.analytics.java:analytics:3.1.3")
+    implementation("io.sentry:sentry:5.4.3")
+    implementation("io.snyk.code.sdk:snyk-code-client:2.2.1")
+    implementation("ly.iterative.itly:plugin-iteratively:1.2.11")
+    implementation("ly.iterative.itly:plugin-schema-validator:1.2.11") {
+        exclude(group = "org.slf4j")
+    }
+    implementation("ly.iterative.itly:sdk-jvm:1.2.11")
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.9.3")
+    testImplementation("junit:junit:4.13.2") {
+        exclude(group = "org.hamcrest")
+    }
+    testImplementation("org.hamcrest:hamcrest:2.2")
+    testImplementation("io.mockk:mockk:1.12.1")
+    testImplementation("org.awaitility:awaitility:4.1.1")
+    runtimeOnly("org.jetbrains.kotlin:kotlin-reflect:1.4.32")
 
-  detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.19.0")
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.19.0")
 }
 
 // configuration for gradle-intellij-plugin plugin.
 // read more: https://github.com/JetBrains/gradle-intellij-plugin
 intellij {
-  version.set(properties("platformVersion"))
+    version.set(properties("platformVersion"))
 
-  downloadSources.set(properties("platformDownloadSources").toBoolean())
+    downloadSources.set(properties("platformDownloadSources").toBoolean())
 
-  // plugin dependencies: uses `platformPlugins` property from the gradle.properties file.
-  plugins.set(properties("platformPlugins").split(',').map(String::trim).filter(String::isNotEmpty))
+    // plugin dependencies: uses `platformPlugins` property from the gradle.properties file.
+    plugins.set(properties("platformPlugins").split(',').map(String::trim).filter(String::isNotEmpty))
 }
 
 // configure for detekt plugin.
 // read more: https://detekt.github.io/detekt/kotlindsl.html
 detekt {
-  config = files("$projectDir/.github/detekt/detekt-config.yml")
-  baseline = file("$projectDir/.github/detekt/detekt-baseline.xml")
-  buildUponDefaultConfig = true
+    config = files("$projectDir/.github/detekt/detekt-config.yml")
+    baseline = file("$projectDir/.github/detekt/detekt-baseline.xml")
+    buildUponDefaultConfig = true
 
-  reports {
-    sarif {
-      enabled = true
-      destination = file("$buildDir/detekt.sarif")
+    reports {
+        sarif {
+            enabled = true
+            destination = file("$buildDir/detekt.sarif")
+        }
+        html.enabled = false
+        xml.enabled = false
+        txt.enabled = false
     }
-    html.enabled = false
-    xml.enabled = false
-    txt.enabled = false
-  }
 }
 
 tasks {
-  withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "1.8"
-    kotlinOptions.languageVersion = "1.3"
-  }
-
-  withType<Detekt> {
-    jvmTarget = "1.8"
-  }
-
-  withType<ProcessResources> {
-    val environment = project.findProperty("environment") ?: "DEVELOPMENT"
-    filesMatching("application.properties") {
-      val amplitudeExperimentApiKey = project.findProperty("amplitudeExperimentApiKey") ?: ""
-      val segmentWriteKey = project.findProperty("segmentWriteKey") ?: ""
-      val sentryDsnKey = project.findProperty("sentryDsn") ?: ""
-      val tokens = mapOf(
-        "amplitude.experiment.api-key" to amplitudeExperimentApiKey,
-        "environment" to environment,
-        "segment.analytics.write-key" to segmentWriteKey,
-        "sentry.dsn" to sentryDsnKey
-      )
-      filter<ReplaceTokens>("tokens" to tokens)
+    withType<KotlinCompile> {
+        kotlinOptions.jvmTarget = "1.8"
+        kotlinOptions.languageVersion = "1.3"
     }
-  }
 
-  withType<Test> {
-    testLogging {
-      exceptionFormat = TestExceptionFormat.FULL
+    withType<Detekt> {
+        jvmTarget = "1.8"
     }
-  }
 
-  buildSearchableOptions {
-    enabled = false
-  }
-
-  patchPluginXml {
-    version.set(properties("pluginVersion"))
-    sinceBuild.set(properties("pluginSinceBuild"))
-    untilBuild.set(properties("pluginUntilBuild"))
-
-    pluginDescription.set(
-      File("$projectDir/README.md").readText().lines().run {
-        val start = "<!-- Plugin description start -->"
-        val end = "<!-- Plugin description end -->"
-
-        if (!containsAll(listOf(start, end))) {
-          throw GradleException("Plugin description section not found in README.md file:\n$start ... $end")
+    withType<ProcessResources> {
+        val environment = project.findProperty("environment") ?: "DEVELOPMENT"
+        filesMatching("application.properties") {
+            val amplitudeExperimentApiKey = project.findProperty("amplitudeExperimentApiKey") ?: ""
+            val segmentWriteKey = project.findProperty("segmentWriteKey") ?: ""
+            val sentryDsnKey = project.findProperty("sentryDsn") ?: ""
+            val tokens = mapOf(
+                "amplitude.experiment.api-key" to amplitudeExperimentApiKey,
+                "environment" to environment,
+                "segment.analytics.write-key" to segmentWriteKey,
+                "sentry.dsn" to sentryDsnKey
+            )
+            filter<ReplaceTokens>("tokens" to tokens)
         }
-        subList(indexOf(start) + 1, indexOf(end))
-      }.joinToString("\n").run { markdownToHTML(this) }
-    )
-
-    changeNotes.set(provider { changelog.getLatest().toHTML() })
-  }
-
-  publishPlugin {
-    token.set(System.getenv("PUBLISH_TOKEN"))
-    channels.set(listOf(properties("pluginVersion").split('-').getOrElse(1) { "default" }.split('.').first()))
-  }
-
-  runIde {
-    maxHeapSize = "2g"
-    autoReloadPlugins.set(false)
-    if (properties("localIdeDirectory").isNotEmpty()) {
-      ideDir.set(File(properties("localIdeDirectory")))
     }
-  }
 
-  runPluginVerifier {
-    ideVersions.set(properties("pluginVerifierIdeVersions").split(',').map(String::trim).filter(String::isNotEmpty))
-    failureLevel.set(
-      listOf(
-        org.jetbrains.intellij.tasks.RunPluginVerifierTask.FailureLevel.COMPATIBILITY_PROBLEMS,
-        org.jetbrains.intellij.tasks.RunPluginVerifierTask.FailureLevel.INVALID_PLUGIN
-      )
-    )
-    verificationReportsDir.set("$rootDir.path/reports/pluginVerifier")
-  }
+    withType<Test> {
+        testLogging {
+            exceptionFormat = TestExceptionFormat.FULL
+        }
+    }
+
+    buildSearchableOptions {
+        enabled = false
+    }
+
+    patchPluginXml {
+        sinceBuild.set(properties("pluginSinceBuild"))
+        untilBuild.set(properties("pluginUntilBuild"))
+
+        pluginDescription.set(
+            File("$projectDir/README.md").readText().lines().run {
+                val start = "<!-- Plugin description start -->"
+                val end = "<!-- Plugin description end -->"
+
+                if (!containsAll(listOf(start, end))) {
+                    throw GradleException("Plugin description section not found in README.md file:\n$start ... $end")
+                }
+                subList(indexOf(start) + 1, indexOf(end))
+            }.joinToString("\n").run { markdownToHTML(this) }
+        )
+
+        changeNotes.set(provider { changelog.getLatest().toHTML() })
+    }
+
+    publishPlugin {
+        token.set(System.getenv("PUBLISH_TOKEN"))
+        channels.set(listOf(properties("pluginVersion").split('-').getOrElse(1) { "default" }.split('.').first()))
+    }
+
+    runIde {
+        maxHeapSize = "2g"
+        autoReloadPlugins.set(false)
+        if (properties("localIdeDirectory").isNotEmpty()) {
+            ideDir.set(File(properties("localIdeDirectory")))
+        }
+    }
+
+    runPluginVerifier {
+        ideVersions.set(properties("pluginVerifierIdeVersions").split(',').map(String::trim).filter(String::isNotEmpty))
+        failureLevel.set(
+            listOf(
+                org.jetbrains.intellij.tasks.RunPluginVerifierTask.FailureLevel.COMPATIBILITY_PROBLEMS,
+                org.jetbrains.intellij.tasks.RunPluginVerifierTask.FailureLevel.INVALID_PLUGIN
+            )
+        )
+        verificationReportsDir.set("$rootDir.path/reports/pluginVerifier")
+    }
 }
 
 sourceSets {
-  create("integTest") {
-    compileClasspath += sourceSets.main.get().output
-    runtimeClasspath += sourceSets.main.get().output
-  }
+    create("integTest") {
+        compileClasspath += sourceSets.main.get().output
+        runtimeClasspath += sourceSets.main.get().output
+    }
 }
 val integTestImplementation: Configuration by configurations.getting {
-  extendsFrom(configurations.implementation.get(), configurations.testImplementation.get())
+    extendsFrom(configurations.implementation.get(), configurations.testImplementation.get())
 }
 configurations["integTestRuntimeOnly"].extendsFrom(configurations.runtimeOnly.get())
 
 val integTest = task<Test>("integTest") {
-  description = "Runs the integration tests."
-  group = "verification"
+    description = "Runs the integration tests."
+    group = "verification"
 
-  testClassesDirs = sourceSets["integTest"].output.classesDirs
-  classpath = sourceSets["integTest"].runtimeClasspath
-  shouldRunAfter("test")
+    testClassesDirs = sourceSets["integTest"].output.classesDirs
+    classpath = sourceSets["integTest"].runtimeClasspath
+    shouldRunAfter("test")
 }
 tasks.check { dependsOn(integTest) }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,5 @@
 pluginGroup=io.snyk.intellij
 pluginName=Snyk Vulnerability Scanner
-pluginVersion=2.4.10
 
 # for insight into build numbers and IntelliJ Platform versions
 # see https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html


### PR DESCRIPTION
Automatically determine the right semantic version from git history, create a tag and push to origin with the next version when e.g. `./gradlew release -Prelease.versionIncrementer=incrementMajor` is executed. Executing just `./gradlew release` will increase patch level, using `./gradlew release -Prelease.versionIncrementer=incrementMinor` will [increment](https://axion-release-plugin.readthedocs.io/en/latest/configuration/version/) the middle number. This all is done using the [axion release plugin](https://github.com/allegro/axion-release-plugin). This way, we do not need to manually set the version in gradle.properties. Developer releases on branches use `-SNAPSHOT` convention, e.g. `2.4.9-SNAPSHOT`.

Automatically create github release when release workflow is triggered, done using the [automatic release action](https://github.com/marvinpinto/action-automatic-releases) recommended by github.

Updated editorconfig to recognise *.kts files and reformat build.gradle.kts. Now detekt plugin is not complaining anymore.