### PR TITLE
fix: exceptions from PsiManager.findFile()

### DIFF
--- a/src/main/kotlin/io/snyk/plugin/SnykBulkFileListener.kt
+++ b/src/main/kotlin/io/snyk/plugin/SnykBulkFileListener.kt
@@ -16,7 +16,6 @@ import com.intellij.openapi.vfs.newvfs.events.VFileDeleteEvent
 import com.intellij.openapi.vfs.newvfs.events.VFileEvent
 import com.intellij.openapi.vfs.newvfs.events.VFileMoveEvent
 import com.intellij.psi.PsiFile
-import com.intellij.psi.PsiManager
 import io.snyk.plugin.snykcode.core.AnalysisData
 import io.snyk.plugin.snykcode.core.RunUtils
 import io.snyk.plugin.snykcode.core.SnykCodeIgnoreInfoHolder
@@ -90,10 +89,9 @@ class SnykBulkFileListener : BulkFileListener {
             }
 
             // if SnykCode analysis is running then re-run it (with updated files)
-            val manager = PsiManager.getInstance(project)
             val supportedFileChanged = virtualFilesAffected
                 .filter { it.isValid }
-                .mapNotNull { manager.findFile(it) }
+                .mapNotNull { findPsiFileIgnoringExceptions(it, project) }
                 .any { SnykCodeUtils.instance.isSupportedFileFormat(it) }
             val isSnykCodeRunning = AnalysisData.instance.isUpdateAnalysisInProgress(project)
 

--- a/src/main/kotlin/io/snyk/plugin/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/Utils.kt
@@ -8,8 +8,11 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.registry.Registry
+import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowManager
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiManager
 import com.intellij.util.Alarm
 import com.intellij.util.messages.Topic
 import io.snyk.plugin.cli.Platform
@@ -226,3 +229,10 @@ fun getX509TrustManager(): X509TrustManager {
     }
     return trustManagers[0] as X509TrustManager
 }
+
+fun findPsiFileIgnoringExceptions(virtualFile: VirtualFile, project: Project): PsiFile? =
+    try {
+        PsiManager.getInstance(project).findFile(virtualFile)
+    } catch (ignored: Throwable) {
+        null
+    }

--- a/src/main/kotlin/io/snyk/plugin/snykcode/core/PDU.kt
+++ b/src/main/kotlin/io/snyk/plugin/snykcode/core/PDU.kt
@@ -13,8 +13,8 @@ import com.intellij.openapi.util.Computable
 import com.intellij.openapi.util.TextRange
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.psi.PsiFile
-import com.intellij.psi.PsiManager
 import io.snyk.plugin.events.SnykScanListener
+import io.snyk.plugin.findPsiFileIgnoringExceptions
 import io.snyk.plugin.getSyncPublisher
 import io.snyk.plugin.ui.SnykBalloonNotificationHelper
 import io.snyk.plugin.ui.toolwindow.SnykToolWindowPanel
@@ -55,7 +55,7 @@ class PDU private constructor() : PlatformDependentUtilsBase() {
         return RunUtils.computeInReadActionInSmartMode(
             prj,
             Computable {
-                if (virtualFile.isValid) PsiManager.getInstance(prj).findFile(virtualFile) else null
+                if (virtualFile.isValid) findPsiFileIgnoringExceptions(virtualFile, prj) else null
             }
         )
     }

--- a/src/main/kotlin/io/snyk/plugin/snykcode/core/SnykCodeIgnoreInfoHolder.kt
+++ b/src/main/kotlin/io/snyk/plugin/snykcode/core/SnykCodeIgnoreInfoHolder.kt
@@ -3,7 +3,7 @@ package io.snyk.plugin.snykcode.core
 import ai.deepcode.javaclient.core.DeepCodeIgnoreInfoHolderBase
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.psi.PsiManager
+import io.snyk.plugin.findPsiFileIgnoringExceptions
 import io.snyk.plugin.getSnykTaskQueueService
 import io.snyk.plugin.ui.SnykBalloonNotificationHelper
 import java.io.File
@@ -53,7 +53,7 @@ class SnykCodeIgnoreInfoHolder private constructor() : DeepCodeIgnoreInfoHolderB
             .filter { it.name == ".dcignore" || it.name == ".gitignore" }
             .filter { it.isValid }
             .distinct()
-            .mapNotNull { PsiManager.getInstance(project).findFile(it) }
+            .mapNotNull { findPsiFileIgnoringExceptions(it, project) }
 
     companion object{
         val instance = SnykCodeIgnoreInfoHolder()

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
@@ -14,7 +14,6 @@ import com.intellij.openapi.ui.SimpleToolWindowPanel
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.psi.PsiFile
-import com.intellij.psi.PsiManager
 import com.intellij.ui.OnePixelSplitter
 import com.intellij.ui.ScrollPaneFactory
 import com.intellij.ui.TreeSpeedSearch
@@ -31,6 +30,7 @@ import io.snyk.plugin.events.SnykResultsFilteringListener
 import io.snyk.plugin.events.SnykScanListener
 import io.snyk.plugin.events.SnykSettingsListener
 import io.snyk.plugin.events.SnykTaskQueueListener
+import io.snyk.plugin.findPsiFileIgnoringExceptions
 import io.snyk.plugin.getAmplitudeExperimentService
 import io.snyk.plugin.getSnykTaskQueueService
 import io.snyk.plugin.getSyncPublisher
@@ -388,7 +388,7 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
                         ?: throw IllegalArgumentException(node.toString())
                     val fileName = iacIssuesForFile.targetFilePath
                     val virtualFile = VirtualFileManager.getInstance().findFileByNioPath(Paths.get(fileName))
-                    val psiFile = virtualFile?.let { PsiManager.getInstance(project).findFile(it) }
+                    val psiFile = virtualFile?.let { findPsiFileIgnoringExceptions(it, project) }
 
                     val iacIssue = node.userObject as IacIssue
                     val scrollPane = wrapWithScrollPane(

--- a/src/main/kotlin/snyk/container/YAMLImageExtractor.kt
+++ b/src/main/kotlin/snyk/container/YAMLImageExtractor.kt
@@ -4,7 +4,7 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiFile
-import com.intellij.psi.PsiManager
+import io.snyk.plugin.findPsiFileIgnoringExceptions
 import java.util.stream.Collectors
 import kotlin.streams.toList
 
@@ -27,7 +27,7 @@ object YAMLImageExtractor {
             }.toList()
 
     fun extractFromFile(file: VirtualFile, project: Project): Set<KubernetesWorkloadImage> {
-        val psiFile = PsiManager.getInstance(project).findFile(file)
+        val psiFile = findPsiFileIgnoringExceptions(file, project)
         if (psiFile == null || file.isDirectory || !file.isValid) return emptySet()
 
         return extractImages(psiFile)


### PR DESCRIPTION
fix: exceptions in PsiManager.findFile() should be ignored (`null` returned as if PsiFile just not found) and not break the flow.
PS See Sentry's exception reports for examples.