### PR TITLE
fix: 🐛 don't delete / replace CLI file before download of new version is successful [ROAD-645]

### DIFF
--- a/src/integTest/kotlin/io/snyk/plugin/cli/ConsoleCommandRunnerTest.kt
+++ b/src/integTest/kotlin/io/snyk/plugin/cli/ConsoleCommandRunnerTest.kt
@@ -37,6 +37,25 @@ class ConsoleCommandRunnerTest : LightPlatformTestCase() {
     private val ossService: OssService
         get() = getOssService(project) ?: throw IllegalStateException("OSS service should be available")
 
+    @Before
+    override fun setUp() {
+        super.setUp()
+        unmockkAll()
+        resetSettings(project)
+        setupDummyCliFile()
+        // don't report to Sentry when running this test
+        mockkObject(SentryErrorReporter)
+        every { SentryErrorReporter.captureException(any()) } returns SentryId()
+    }
+
+    @After
+    override fun tearDown() {
+        unmockkAll()
+        resetSettings(project)
+        removeDummyCliFile()
+        super.tearDown()
+    }
+
     @Test
     fun testSetupCliEnvironmentVariables() {
         val generalCommandLine = GeneralCommandLine("")
@@ -51,6 +70,7 @@ class ConsoleCommandRunnerTest : LightPlatformTestCase() {
         assertEquals("2020.2", generalCommandLine.environment["SNYK_INTEGRATION_ENVIRONMENT_VERSION"])
     }
 
+    @Suppress("SwallowedException")
     @Test
     fun testCommandExecutionRequestWhileCliIsDownloading() {
         val cliFile = getCliFile()
@@ -76,20 +96,22 @@ class ConsoleCommandRunnerTest : LightPlatformTestCase() {
         val testRunFuture = progressManager.runProcessWithProgressAsynchronously(
             object : Task.Backgroundable(project, "Test CLI command invocation", true) {
                 override fun run(indicator: ProgressIndicator) {
-                    while (!cliFile.exists()) {
+                    while (!snykCliDownloaderService.isCliDownloading()) {
                         Thread.sleep(10) // lets wait till actual download begin
                     }
                     assertTrue(
                         "Downloading of CLI should be in progress at this stage.",
                         snykCliDownloaderService.isCliDownloading()
                     )
-                    // No exception should happened while CLI is downloading and any CLI command is invoked
-                    val commands = ossService.buildCliCommandsList_TEST_ONLY(listOf("test"))
-                    val output = ConsoleCommandRunner().execute(commands, getPluginPath(), "", project)
-                    assertTrue(
-                        "Should be NO output for CLI command while CLI is downloading, but received:\n$output",
-                        output.isEmpty()
-                    )
+                    // CLINotExistsException should happen while CLI is not there,
+                    // but downloading and any CLI command is invoked
+                    try {
+                        val commands = ossService.buildCliCommandsList_TEST_ONLY(listOf("test"))
+                        ConsoleCommandRunner().execute(commands, getPluginPath(), "", project)
+                        fail("Should have thrown CliNotExistsException, as the CLI is still downloading.")
+                    } catch (e: CliNotExistsException) {
+                        // this is expected and actually desired
+                    }
                 }
             },
             EmptyProgressIndicator(),
@@ -112,7 +134,7 @@ class ConsoleCommandRunnerTest : LightPlatformTestCase() {
         val registryValue = Registry.get("snyk.timeout.results.waiting")
         val defaultValue = registryValue.asInteger()
         assertEquals(DEFAULT_TIMEOUT_FOR_SCAN_WAITING_MS, defaultValue)
-        registryValue.setValue(100)
+        registryValue.setValue(10)
 
         val commands = ossService.buildCliCommandsList_TEST_ONLY(listOf("test"))
         val progressManager = ProgressManager.getInstance() as CoreProgressManager
@@ -136,24 +158,5 @@ class ConsoleCommandRunnerTest : LightPlatformTestCase() {
         // clean up
         registryValue.setValue(DEFAULT_TIMEOUT_FOR_SCAN_WAITING_MS)
         getCliFile().delete()
-    }
-
-    @Before
-    override fun setUp() {
-        super.setUp()
-        unmockkAll()
-        resetSettings(project)
-        setupDummyCliFile()
-        // don't report to Sentry when running this test
-        mockkObject(SentryErrorReporter)
-        every { SentryErrorReporter.captureException(any()) } returns SentryId()
-    }
-
-    @After
-    override fun tearDown() {
-        unmockkAll()
-        resetSettings(project)
-        removeDummyCliFile()
-        super.tearDown()
     }
 }

--- a/src/integTest/kotlin/io/snyk/plugin/services/download/CliDownloaderErrorHandlerIntegTest.kt
+++ b/src/integTest/kotlin/io/snyk/plugin/services/download/CliDownloaderErrorHandlerIntegTest.kt
@@ -53,11 +53,12 @@ class CliDownloaderErrorHandlerIntegTest : LightPlatformTestCase() {
 
     fun testHandleIOExceptionShouldRetryDownloadAndShowBalloonIfItFails() {
         val e = IOException("Expected Test Exception, don't panic")
-        every { cliDownloaderMock.downloadFile(any(), any()) } throws e
+        every { cliDownloaderMock.expectedSha() } returns "test"
+        every { cliDownloaderMock.downloadFile(any(), any(), any()) } throws e
 
         cut.handleIOException(e, indicator, projectSpy)
 
-        verify(exactly = 1) { cliDownloaderMock.downloadFile(getCliFile(), indicator) }
+        verify(exactly = 1) { cliDownloaderMock.downloadFile(getCliFile(), any(), indicator) }
         verify(exactly = 1) { progressManager.run(any<Task.Backgroundable>()) }
         verify(exactly = 1) {
             SnykBalloonNotificationHelper.showError(
@@ -68,11 +69,12 @@ class CliDownloaderErrorHandlerIntegTest : LightPlatformTestCase() {
 
     fun testHandleChecksumVerificationExceptionShouldRetryDownloadAndShowBalloonIfItFails() {
         val e = ChecksumVerificationException("Expected Test Exception, don't panic")
-        every { cliDownloaderMock.downloadFile(any(), any()) } throws e
+        every { cliDownloaderMock.expectedSha() } returns "test"
+        every { cliDownloaderMock.downloadFile(any(), any(), any()) } throws e
 
         cut.handleChecksumVerificationException(e, indicator, projectSpy)
 
-        verify(exactly = 1) { cliDownloaderMock.downloadFile(getCliFile(), indicator) }
+        verify(exactly = 1) { cliDownloaderMock.downloadFile(getCliFile(), any(), indicator) }
         verify(exactly = 1) { progressManager.run(any<Task.Backgroundable>()) }
         verify(exactly = 1) {
             SnykBalloonNotificationHelper.showError(

--- a/src/integTest/kotlin/io/snyk/plugin/services/download/CliDownloaderServiceIntegTest.kt
+++ b/src/integTest/kotlin/io/snyk/plugin/services/download/CliDownloaderServiceIntegTest.kt
@@ -72,7 +72,7 @@ class CliDownloaderServiceIntegTest : LightPlatformTestCase() {
         assertTrue(downloadedFile.exists())
         assertEquals(cutSpy.getLatestReleaseInfo()!!.tagName, "v" + pluginSettings().cliVersion)
 
-        verify { downloader.downloadFile(cliFile, indicator) }
+        verify { downloader.downloadFile(cliFile, any(), indicator) }
         verify { downloader.verifyChecksum(any(), any()) }
         downloadedFile.delete()
     }
@@ -101,13 +101,13 @@ class CliDownloaderServiceIntegTest : LightPlatformTestCase() {
         val exceptionMessage = "Read Timed Out"
         val ioException = SocketTimeoutException(exceptionMessage)
 
-        every { downloader.downloadFile(any(), any()) } throws ioException
+        every { downloader.downloadFile(any(), any(), any()) } throws ioException
         justRun { errorHandler.handleIOException(ioException, indicator, project) }
 
         cutSpy.downloadLatestRelease(indicator, project)
 
         verify {
-            downloader.downloadFile(any(), any())
+            downloader.downloadFile(any(), any(), any())
             errorHandler.handleIOException(ioException, indicator, project)
         }
     }
@@ -116,13 +116,13 @@ class CliDownloaderServiceIntegTest : LightPlatformTestCase() {
     fun testDownloadLatestCliReleaseShouldHandleHttpStatusException() {
         val httpStatusException = HttpRequests.HttpStatusException("status bad", HttpStatus.SC_GATEWAY_TIMEOUT, "url")
 
-        every { downloader.downloadFile(any(), any()) } throws httpStatusException
+        every { downloader.downloadFile(any(), any(), any()) } throws httpStatusException
         justRun { errorHandler.handleHttpStatusException(httpStatusException, project) }
 
         cutSpy.downloadLatestRelease(indicator, project)
 
         verify {
-            downloader.downloadFile(any(), any())
+            downloader.downloadFile(any(), any(), any())
             errorHandler.handleHttpStatusException(httpStatusException, project)
         }
     }

--- a/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
@@ -255,8 +255,8 @@ class SnykTaskQueueService(val project: Project) {
         taskQueue.run(object : Task.Backgroundable(project, "Check Snyk CLI presence", true) {
             override fun run(indicator: ProgressIndicator) {
                 cliDownloadPublisher.checkCliExistsStarted()
-                val cliDownloader = service<SnykCliDownloaderService>()
                 if (project.isDisposed) return
+                val cliDownloader = service<SnykCliDownloaderService>()
 
                 if (!isCliInstalled()) {
                     cliDownloader.downloadLatestRelease(indicator, project)

--- a/src/main/kotlin/io/snyk/plugin/services/download/CliDownloaderErrorHandler.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/download/CliDownloaderErrorHandler.kt
@@ -34,7 +34,7 @@ class CliDownloaderErrorHandler {
             try {
                 // not using the service here to not causing an endless recursion (the service triggers a retry)
                 val downloader = project.getService(SnykCliDownloaderService::class.java).downloader
-                downloader.downloadFile(getCliFile(), indicator)
+                downloader.downloadFile(getCliFile(), downloader.expectedSha(), indicator)
             } catch (throwable: Throwable) { // we must catch throwable as IntelliJ could throw AssertionError
                 // IntelliJ throws an exception if we log an error, and in this case it is just the retry that failed
                 logger<CliDownloaderErrorHandler>().warn("Retry of downloading the Snyk CLI failed.", throwable)

--- a/src/test/kotlin/io/snyk/plugin/services/download/CliDownloaderTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/services/download/CliDownloaderTest.kt
@@ -1,11 +1,31 @@
 package io.snyk.plugin.services.download
 
+import com.intellij.util.Url
+import com.intellij.util.io.HttpRequests
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
 import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertTrue
+import junit.framework.TestCase.fail
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
 import java.io.File
 import java.nio.file.Files
 
 class CliDownloaderTest {
+    @Before
+    fun setUp() {
+        unmockkAll()
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
     @Test
     fun `calculateSha256 should verify the SHA of a given file and return false if no match`() {
         val filePath = "src/test/resources/dummy-binary"
@@ -33,5 +53,28 @@ class CliDownloaderTest {
     @Test
     fun `should download sha256 from base url`() {
         assertEquals("${CliDownloader.BASE_URL}/cli/latest/%s.sha256", CliDownloader.SHA256_DOWNLOAD_URL)
+    }
+
+    @Test
+    fun `should not delete file if download fails`() {
+        val testFile = createTempFile()
+        testFile.deleteOnExit()
+        val dummyContent = "test test test".toByteArray()
+        Files.write(testFile.toPath(), dummyContent)
+        val cut = CliDownloader()
+        val expectedSha = cut.calculateSha256("wrong sha".toByteArray())
+        mockkStatic(HttpRequests::class)
+        justRun {
+            HttpRequests.request(any<Url>()).productNameAsUserAgent().saveToFile(any(), any())
+        }
+
+        try {
+            cut.downloadFile(testFile, expectedSha, mockk(relaxed = true))
+            fail("Should have thrown ChecksumVerificationException")
+        } catch (e: ChecksumVerificationException) {
+            assertTrue("testFile should still exist, as $e was thrown", testFile.exists())
+        } finally {
+            testFile.delete()
+        }
     }
 }


### PR DESCRIPTION
A client does not allow installation of executables/download into the plugin directory. Thus, we should not assume that a download of the CLI file can be successful, and only delete the executable after successfully saving the newly downloaded file and after having verified the checksum.