### PR TITLE
chore: enable sentry releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,11 +69,10 @@ jobs:
           ORG_GRADLE_PROJECT_segmentWriteKey: ${{ secrets.SEGMENT_WRITE_KEY }}
         run: ./gradlew publishPlugin
 
-# disabled for now as the token does not work
-#      - name: Create Sentry release
-#        uses: getsentry/action-release@v1
-#        if: ${{ !env.ACT }}
-#        env:
-#          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-#          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-#          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+      - name: Create Sentry release
+        uses: getsentry/action-release@v1
+        if: ${{ !env.ACT }}
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}


### PR DESCRIPTION
Enabled once more in release workflow, after having updated the token. 

Right now, I haven't found a way to create an org-token or service account, so it is using a personal token tied to my account, limited to `project:releases` scope (according to https://docs.sentry.io/api/releases/create-a-new-release-for-an-organization/ that's enough).