### PR TITLE
fix: remove unclaimed malicious package

### DIFF
--- a/src/integTest/resources/advisor-build-files/package.json
+++ b/src/integTest/resources/advisor-build-files/package.json
@@ -38,7 +38,6 @@
     "mongoose": "4.2.4",
     "morgan": "latest",
     "ms": "^0.7.1",
-    "fake_pa": "^0.7.1",
     "mysql": "^2.18.1",
     "npmconf": "0.0.24",
     "optional": "^0.1.3",


### PR DESCRIPTION
A security researcher found the "fake_pa" pkg was unclaimed.
They claimed the pkg and demoed RCE when npm install consumed the modified
package.json.