### PR TITLE
fix: caches update and cleaning [ROAD-646]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Snyk Vulnerability Scanner Changelog
 
+## [2.4.13]
+
+### Fixed
+
+- caches update and cleaning
+
 ## [2.4.12]
 
 ### Fixed

--- a/src/integTest/kotlin/io/snyk/SnykBulkFileListenerTest.kt
+++ b/src/integTest/kotlin/io/snyk/SnykBulkFileListenerTest.kt
@@ -27,7 +27,6 @@ import snyk.oss.OssResult
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Paths
-import java.util.concurrent.Callable
 import java.util.concurrent.TimeUnit
 
 @Suppress("FunctionName")
@@ -101,6 +100,24 @@ class SnykBulkFileListenerTest : BasePlatformTestCase() {
     fun testCurrentIacResults_shouldDropCachedResult_whenIacSupportedFileChanged() {
         val file = "k8s-deployment.yaml"
         val filePath = "/src/$file"
+        createFakeIacResultInCache(file, filePath)
+
+        myFixture.configureByText(file, "some text")
+
+        await().atMost(2, TimeUnit.SECONDS).until { cacheUpdated(filePath) }
+    }
+
+    private fun cacheUpdated(filePath: String?): Boolean {
+        val iacCachedIssues = project.service<SnykToolWindowPanel>().currentIacResult!!.allCliIssues!!
+        return iacCachedIssues.any { iacFile ->
+            (filePath == null || iacFile.targetFilePath == filePath) && iacFile.obsolete
+        }
+    }
+
+    private fun isIacUpdateNeeded(): Boolean =
+        project.service<SnykToolWindowPanel>().currentIacResult?.iacScanNeeded ?: true
+
+    private fun createFakeIacResultInCache(file: String, filePath: String) {
         val iacIssuesForFile = IacIssuesForFile(emptyList(), file, filePath, "npm")
         val iacVulnerabilities = listOf(iacIssuesForFile)
         val fakeIacResult = IacResult(iacVulnerabilities, null)
@@ -108,20 +125,70 @@ class SnykBulkFileListenerTest : BasePlatformTestCase() {
         toolWindowPanel.currentIacResult = fakeIacResult
         val rootIacIssuesTreeNode = toolWindowPanel.getRootIacIssuesTreeNode()
         rootIacIssuesTreeNode.add(IacFileTreeNode(iacIssuesForFile, project))
-
-        myFixture.configureByText(file, "some text")
-
-        await().atMost(2, TimeUnit.SECONDS).until(cacheUpdated(toolWindowPanel, filePath))
     }
 
-    private fun cacheUpdated(toolWindowPanel: SnykToolWindowPanel, filePath: String): Callable<Boolean> {
-        return Callable {
-            val iacCache = toolWindowPanel.currentIacResult
-            val found =
-                iacCache!!.allCliIssues!!
-                    .firstOrNull { iacFile -> iacFile.targetFilePath == filePath && iacFile.obsolete }
-            return@Callable found != null
+    @Test
+    fun `test current IacResults should mark IacScanNeeded when IaC supported file CREATED`() {
+        val existingFile = "existing.yaml"
+        createFakeIacResultInCache(existingFile, "/src/$existingFile")
+
+        assertFalse(isIacUpdateNeeded())
+
+        myFixture.addFileToProject("new.yaml", "some text")
+
+        assertTrue(isIacUpdateNeeded())
+        assertFalse(cacheUpdated(null))
+    }
+
+    @Test
+    fun `test current IacResults should mark IacScanNeeded when IaC supported file COPIED`() {
+        val originalFileName = "existing.yaml"
+        val originalFile = myFixture.addFileToProject(originalFileName, "some text")
+        createFakeIacResultInCache(originalFileName, originalFile.virtualFile.path)
+
+        assertFalse(isIacUpdateNeeded())
+
+        ApplicationManager.getApplication().runWriteAction {
+            originalFile.virtualFile.copy(null, originalFile.virtualFile.parent, "copied.yaml")
         }
+
+        assertTrue(isIacUpdateNeeded())
+        assertFalse(cacheUpdated(null))
+    }
+
+    @Test
+    fun `test current IacResults should drop cache and mark IacScanNeeded when IaC supported file MOVED`() {
+        val originalFileName = "existing.yaml"
+        val originalFile = myFixture.addFileToProject(originalFileName, "some text")
+        val originalFilePath = originalFile.virtualFile.path
+        createFakeIacResultInCache(originalFileName, originalFilePath)
+
+        assertFalse(isIacUpdateNeeded())
+
+        ApplicationManager.getApplication().runWriteAction {
+            val moveToDirVirtualFile = originalFile.virtualFile.parent.createChildDirectory(null, "subdir")
+            require(moveToDirVirtualFile != null)
+            originalFile.virtualFile.move(null, moveToDirVirtualFile)
+        }
+
+        assertTrue(isIacUpdateNeeded())
+        assertTrue(cacheUpdated(originalFilePath))
+    }
+
+    @Test
+    fun `test current IacResults should drop cache and mark IacScanNeeded when IaC supported file DELETED`() {
+        val originalFileName = "existing.yaml"
+        val originalFile = myFixture.addFileToProject(originalFileName, "some text")
+        createFakeIacResultInCache(originalFileName, originalFile.virtualFile.path)
+
+        assertFalse(isIacUpdateNeeded())
+
+        ApplicationManager.getApplication().runWriteAction {
+            originalFile.virtualFile.delete(null)
+        }
+
+        assertTrue(isIacUpdateNeeded())
+        assertTrue(cacheUpdated(originalFile.virtualFile.path))
     }
 
     @Test
@@ -151,15 +218,18 @@ class SnykBulkFileListenerTest : BasePlatformTestCase() {
         )
     }
 
-    @Test
-    fun `test should update image cache when yaml file is changed`() {
-        setUpContainerTest()
+    private fun createNewFileInProjectRoot(name: String): File {
         val projectPath = Paths.get(project.basePath!!)
         if (!projectPath.exists()) {
             projectPath.createDirectories()
         }
-        val path = Paths.get(project.basePath + File.separator + "kubernetes-test.yaml")
-        path.toFile().createNewFile()
+        return File(project.basePath + File.separator + name).apply { createNewFile() }
+    }
+
+    @Test
+    fun `test should update image cache when yaml file is changed`() {
+        setUpContainerTest()
+        val path = createNewFileInProjectRoot("kubernetes-test.yaml").toPath()
         Files.write(path, "\n".toByteArray(Charsets.UTF_8))
         val virtualFile = VirtualFileManager.getInstance().findFileByNioPath(path)
         require(virtualFile != null)
@@ -183,7 +253,7 @@ class SnykBulkFileListenerTest : BasePlatformTestCase() {
     }
 
     @Test
-    fun `test should delete from cache when yaml file is deleted`() {
+    fun `test Container should delete images from cache when yaml file is deleted`() {
         setUpContainerTest()
         val file = myFixture.addFileToProject("kubernetes-test.yaml", "")
 

--- a/src/main/kotlin/io/snyk/plugin/SnykBulkFileListener.kt
+++ b/src/main/kotlin/io/snyk/plugin/SnykBulkFileListener.kt
@@ -165,8 +165,7 @@ class SnykBulkFileListener : BulkFileListener {
     ) {
         if (virtualFilesAffected.isEmpty()) return
         val toolWindowPanel = getSnykToolWindowPanel(project)
-        val iacFiles = toolWindowPanel?.currentIacResult?.allCliIssues
-        if (iacFiles == null || iacFiles.isEmpty()) return
+        val iacFiles = toolWindowPanel?.currentIacResult?.allCliIssues ?: return
 
         var changed = false
 
@@ -186,8 +185,8 @@ class SnykBulkFileListener : BulkFileListener {
 
         if (changed) {
             val newIacCache = IacResult(newIacFileList.toImmutableList(), null)
+            newIacCache.iacScanNeeded = true
             toolWindowPanel.currentIacResult = newIacCache
-            toolWindowPanel.iacScanNeeded = true
             ApplicationManager.getApplication().invokeLater {
                 toolWindowPanel.displayIacResults(newIacCache)
             }

--- a/src/main/kotlin/io/snyk/plugin/SnykBulkFileListener.kt
+++ b/src/main/kotlin/io/snyk/plugin/SnykBulkFileListener.kt
@@ -2,9 +2,9 @@ package io.snyk.plugin
 
 import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
 import com.intellij.ide.impl.ProjectUtil
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.logger
-import com.intellij.openapi.progress.runBackgroundableTask
-import com.intellij.openapi.project.DumbService
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.util.io.FileUtil.pathsEqual
 import com.intellij.openapi.vfs.VirtualFile
@@ -20,7 +20,6 @@ import io.snyk.plugin.snykcode.core.AnalysisData
 import io.snyk.plugin.snykcode.core.RunUtils
 import io.snyk.plugin.snykcode.core.SnykCodeIgnoreInfoHolder
 import io.snyk.plugin.snykcode.core.SnykCodeUtils
-import io.snyk.plugin.ui.toolwindow.SnykToolWindowPanel
 import okhttp3.internal.toImmutableList
 import snyk.iac.IacIssuesForFile
 import snyk.iac.IacResult
@@ -28,6 +27,32 @@ import java.util.function.Predicate
 
 private val LOG = logger<SnykBulkFileListener>()
 
+/**
+ * For our caches we need following events for file: Create, Change, Delete
+ * Also in our caches we need next type of actions: _add_ _update_ _clean_
+ * Note: Current implementation meaning:
+ *  add - mark results as invalid anymore (i.e. next scan attempt should run scan and not use cache)
+ *  update - mark item(file) result as obsolete (i.e. next scan attempt should run scan and not use cache)
+ *  clean - mark item(file) result as obsolete (i.e. next scan attempt should run scan and not use cache)
+ *
+ * BulkFileListener provide next events: Create, ContentChange, Move, Copy, Delete
+ * Also in `before` state we have access to old files.
+ * While in `after` state we have access for new/updated files too (but old might not exist anymore)
+ *
+ * Next mapping/interpretation for BulkFileListener type of events should be used:
+ * Create
+ *  - addressed at `after` state, new file processed to _add_ caches
+ * ContentChange
+ *  - addressed at `after` state, new file processed to _update_ caches
+ * Move
+ *  - addressed at `before` state, old file processed to _clean_ caches
+ *  - addressed at `after` state, new file processed to _add_ caches
+ * Copy
+ *  - addressed at `after` state, new file processed to _add_ caches
+ * Delete
+ *  - addressed at `before` state, old file processed to _clean_ caches
+ *
+ */
 class SnykBulkFileListener : BulkFileListener {
 
     override fun after(events: MutableList<out VFileEvent>) {
@@ -69,11 +94,8 @@ class SnykBulkFileListener : BulkFileListener {
         for (project in ProjectUtil.getOpenProjects()) {
             if (project.isDisposed) continue
 
-            // todo: clean Container cached results
-
             val virtualFilesAffected = getAffectedVirtualFiles(
                 events,
-                fileFilter = Predicate { true },
                 classesOfEventsToFilter = classesOfEventsToFilter
             )
 
@@ -123,43 +145,53 @@ class SnykBulkFileListener : BulkFileListener {
             }
             // clean .dcignore caches if needed
             SnykCodeIgnoreInfoHolder.instance.cleanIgnoreFileCachesIfAffected(project, virtualFilesAffected)
+
+            // clean IaC cached results for deleted/moved files
+            updateIacCache(
+                getAffectedVirtualFiles(
+                    events,
+                    classesOfEventsToFilter = listOf(VFileDeleteEvent::class.java, VFileMoveEvent::class.java)
+                ),
+                project
+            )
+
+            // todo: clean Container cached results for deleted/moved files
         }
     }
 
     private fun updateIacCache(
         virtualFilesAffected: Set<VirtualFile>,
-        toolWindowPanel: SnykToolWindowPanel
+        project: Project
     ) {
-        val iacCache = toolWindowPanel.currentIacResult
-        val iacFiles = iacCache?.allCliIssues ?: return
-        val project = toolWindowPanel.project
+        if (virtualFilesAffected.isEmpty()) return
+        val toolWindowPanel = getSnykToolWindowPanel(project)
+        val iacFiles = toolWindowPanel?.currentIacResult?.allCliIssues
+        if (iacFiles == null || iacFiles.isEmpty()) return
 
-        runBackgroundableTask("Updating Snyk Infrastructure As Code Cache...", project, true) {
-            DumbService.getInstance(project).runReadActionInSmartMode {
-                var changed = false
+        var changed = false
 
-                val newIacFileList = iacFiles.toMutableList()
-                virtualFilesAffected
-                    .filter { iacFileExtensions.contains(it.extension) }
-                    .filter { ProjectRootManager.getInstance(project).fileIndex.isInContent(it) }
-                    .forEach {
-                        changed = true // for new files we need to "dirty" the cache, too
-                        newIacFileList.forEachIndexed { i, iacIssuesForFile ->
-                            if (pathsEqual(it.path, iacIssuesForFile.targetFilePath)) {
-                                val obsoleteIacFile = makeObsolete(iacIssuesForFile)
-                                newIacFileList[i] = obsoleteIacFile
-                            }
-                        }
+        val newIacFileList = iacFiles.toMutableList()
+        virtualFilesAffected
+            .filter { iacFileExtensions.contains(it.extension) }
+            .filter { ProjectRootManager.getInstance(project).fileIndex.isInContent(it) }
+            .forEach {
+                changed = true // for new files we need to "dirty" the cache, too
+                newIacFileList.forEachIndexed { i, iacIssuesForFile ->
+                    if (pathsEqual(it.path, iacIssuesForFile.targetFilePath)) {
+                        val obsoleteIacFile = makeObsolete(iacIssuesForFile)
+                        newIacFileList[i] = obsoleteIacFile
                     }
-
-                if (changed) {
-                    val newIacCache = IacResult(newIacFileList.toImmutableList(), null)
-                    toolWindowPanel.currentIacResult = newIacCache
-                    toolWindowPanel.displayIacResults(newIacCache)
-                    toolWindowPanel.iacScanNeeded = true
-                    DaemonCodeAnalyzer.getInstance(toolWindowPanel.project).restart()
                 }
             }
+
+        if (changed) {
+            val newIacCache = IacResult(newIacFileList.toImmutableList(), null)
+            toolWindowPanel.currentIacResult = newIacCache
+            toolWindowPanel.iacScanNeeded = true
+            ApplicationManager.getApplication().invokeLater {
+                toolWindowPanel.displayIacResults(newIacCache)
+            }
+            DaemonCodeAnalyzer.getInstance(toolWindowPanel.project).restart()
         }
     }
 
@@ -175,30 +207,35 @@ class SnykBulkFileListener : BulkFileListener {
 
             val virtualFilesAffected = getAffectedVirtualFiles(
                 events,
-                fileFilter = Predicate { true },
+                eventToVirtualFileTransformer = {
+                    when (it) {
+                        is VFileCopyEvent -> it.findCreatedFile()
+                        is VFileMoveEvent -> if (it.newParent.isValid) it.newParent.findChild(it.file.name) else null
+                        else -> it.file
+                    }
+                },
                 classesOfEventsToFilter = classesOfEventsToFilter
             )
 
             // update IaC cached results if needed
-            val toolWindowPanel = getSnykToolWindowPanel(project)
-            val allCliIssues = toolWindowPanel?.currentIacResult?.allCliIssues
-            if (allCliIssues != null && allCliIssues.isNotEmpty()) {
-                updateIacCache(virtualFilesAffected, toolWindowPanel)
-            }
+            updateIacCache(virtualFilesAffected, project)
 
             // update .dcignore caches if needed
             SnykCodeIgnoreInfoHolder.instance.updateIgnoreFileCachesIfAffected(project, virtualFilesAffected)
+
+            //todo: update Container cached results if needed
         }
     }
 
     private fun getAffectedVirtualFiles(
         events: List<VFileEvent>,
-        fileFilter: Predicate<VirtualFile>,
+        eventToVirtualFileTransformer: (VFileEvent) -> VirtualFile? = { it.file },
+        fileFilter: Predicate<VirtualFile> = Predicate { true },
         classesOfEventsToFilter: Collection<Class<*>>
     ): Set<VirtualFile> {
         return events.asSequence()
             .filter { event -> instanceOf(event, classesOfEventsToFilter) }
-            .mapNotNull(VFileEvent::getFile)
+            .mapNotNull(eventToVirtualFileTransformer)
             .filter(fileFilter::test)
             .toSet()
     }

--- a/src/main/kotlin/io/snyk/plugin/cli/ConsoleCommandRunner.kt
+++ b/src/main/kotlin/io/snyk/plugin/cli/ConsoleCommandRunner.kt
@@ -52,7 +52,7 @@ open class ConsoleCommandRunner {
         processHandler.addProcessListener(object : ProcessAdapter() {
             override fun onTextAvailable(event: ProcessEvent, outputType: Key<*>) {
                 if (firstLine) {
-                    logger.debug("Executing: \"${event.text}\"")
+                    logger.debug("Executing:\n${event.text}")
                     firstLine = false
                 }
                 outputConsumer(event.text)

--- a/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
@@ -218,7 +218,7 @@ class SnykTaskQueueService(val project: Project) {
             override fun run(indicator: ProgressIndicator) {
                 if (!isCliInstalled()) return
                 val toolWindowPanel = getSnykToolWindowPanel(project) ?: return
-                if (toolWindowPanel.currentIacResult != null && !toolWindowPanel.iacScanNeeded) return
+                if (toolWindowPanel.currentIacResult?.iacScanNeeded == false) return
                 logger.debug("Starting IaC scan")
                 iacScanProgressIndicator = indicator
                 scanPublisher?.scanningStarted()

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
@@ -94,7 +94,6 @@ import javax.swing.tree.TreePath
  */
 @Service
 class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
-    var iacScanNeeded: Boolean = false
     var snykScanListener: SnykScanListener
     private val scrollPaneAlarm = Alarm()
     private var descriptionPanel = SimpleToolWindowPanel(true, true).apply { name = "descriptionPanel" }
@@ -174,7 +173,6 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
 
             override fun scanningIacFinished(iacResult: IacResult) {
                 currentIacResult = iacResult
-                iacScanNeeded = false
                 ApplicationManager.getApplication().invokeLater {
                     displayIacResults(iacResult)
                 }
@@ -254,7 +252,6 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
 
             override fun scanningIacError(snykError: SnykError) {
                 currentIacResult = null
-                iacScanNeeded = false
                 var iacResultsCount: Int? = null
                 ApplicationManager.getApplication().invokeLater {
                     currentIacError = if (snykError.message.startsWith(NO_IAC_FILES)) {
@@ -556,7 +553,6 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
         currentSnykCodeError = null
         currentIacResult = null
         currentIacError = null
-        iacScanNeeded = true
         currentContainerResult = null
         currentContainerError = null
         AnalysisData.instance.resetCachesAndTasks(project)

--- a/src/main/kotlin/snyk/iac/IacResult.kt
+++ b/src/main/kotlin/snyk/iac/IacResult.kt
@@ -8,6 +8,8 @@ class IacResult(
     error: SnykError?
 ) : CliResult<IacIssuesForFile>(allIacVulnerabilities, error) {
 
+    var iacScanNeeded: Boolean = false
+
     override val issuesCount get() = allCliIssues?.sumBy { it.uniqueCount }
 
     override fun countBySeverity(severity: String): Int? {


### PR DESCRIPTION
For our caches we need following events for file: Create, Change, Delete                               
Also in our caches we need next type of actions: _add_ _update_ _clean_                                
Note: Current implementation meaning:                                                                  
 add - mark results as invalid anymore (i.e. next scan attempt should run scan and not use cache)      
 update - mark item(file) result as obsolete (i.e. next scan attempt should run scan and not use cache)
 clean - mark item(file) result as obsolete (i.e. next scan attempt should run scan and not use cache) 
                                                                                                       
BulkFileListener provide next events: Create, ContentChange, Move, Copy, Delete                        
Also in `before` state we have access to old files.                                                    
While in `after` state we have access for new/updated files too (but old might not exist anymore)      
                                                                                                       
Next mapping/interpretation for BulkFileListener type of events should be used:                        
* Create                                                                                                 
   - addressed at `after` state, new file processed to _add_ caches                                      
* ContentChange                                                                                          
   - addressed at `after` state, new file processed to _update_ caches                                   
* Move                                                                                                   
   - addressed at `before` state, old file processed to _clean_ caches                                   
   - addressed at `after` state, new file processed to _add_ caches                                      
* Copy                                                                                                   
   - addressed at `after` state, new file processed to _add_ caches                                      
* Delete                                                                                                 
   - addressed at `before` state, old file processed to _clean_ caches                                   