### PR TITLE
feat: ✨ use http proxy host and proxy port settings from IntelliJ proxy configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [2.4.13]
 
+### Changed
+- Use IntelliJ http(s) proxy settings for all remote connections
+
 ### Fixed
 
 - Caches update and cleaning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,13 @@
 
 ### Changed
 - Use IntelliJ http(s) proxy settings for all remote connections
+- Ignoring issues in Snyk IaC now ignores the instance of the issue instead of all instances of the issue type.
 
 ### Fixed
 
 - Caches update and cleaning
 - InvocationTargetException on project-less authentication
 - Memory leak in Authentication panel
-
-### Changed
-- Ignoring issues in Snyk IaC now ignores the instance of the issue instead of all instances of the issue type.
 
 ## [2.4.12]
 

--- a/README.md
+++ b/README.md
@@ -17,19 +17,19 @@ fix advice:
 
 **Snyk detects the critical vulnerability Log4Shell, which was found in the open source Java library log4j-core - a component of one of the most popular Java logging frameworks, Log4J. The vulnerability was categorized as Critical with a CVSS score of 10, and with a mature exploit level.**
 
-### Proxy Setup
-If you are a behind a proxy, please configure the proxy in the IDE. Currently, http and https proxies are supported by the plugin.
-
-### Environment setup
-The plugin uses the Snyk CLI to perform vulnerability scans. In order for this to function correctly, 
-certain environment variables need to be set.
-
-1. `JAVA_HOME` to analyse Java JVM-based projects via Snyk CLI
-2. `PATH` to find maven when analysing Maven projects, to find python for python projects, etc
-
 ### Useful links
 
 - This plugin works with projects written in Java, JavaScript, .NET and many more languages. See the [full list of languages and package managers Snyk supports](https://snyk.co/ucWSd)
 - [Bug tracker](https://github.com/snyk/snyk-intellij-plugin/issues)
 
 <!-- Plugin description end -->
+
+### Proxy Setup
+If you are a behind a proxy, please configure the proxy in the IDE. Currently, http and https proxies are supported by the plugin.
+
+### Environment setup
+The plugin uses the Snyk CLI to perform vulnerability scans. In order for this to function correctly,
+certain environment variables need to be set.
+
+1. `JAVA_HOME` to analyse Java JVM-based projects via Snyk CLI
+2. `PATH` to find maven when analysing Maven projects, to find python for python projects, etc

--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ fix advice:
 
 **Snyk detects the critical vulnerability Log4Shell, which was found in the open source Java library log4j-core - a component of one of the most popular Java logging frameworks, Log4J. The vulnerability was categorized as Critical with a CVSS score of 10, and with a mature exploit level.**
 
+### Proxy Setup
+If you are a behind a proxy, please configure the proxy in the IDE. Currently, http and https proxies are supported by the plugin.
+
+### Environment setup
+The plugin uses the Snyk CLI to perform vulnerability scans. In order for this to function correctly, 
+certain environment variables need to be set.
+
+1. `JAVA_HOME` to analyse Java JVM-based projects via Snyk CLI
+2. `PATH` to find maven when analysing Maven projects, to find python for python projects, etc
+
 ### Useful links
 
 - This plugin works with projects written in Java, JavaScript, .NET and many more languages. See the [full list of languages and package managers Snyk supports](https://snyk.co/ucWSd)

--- a/src/integTest/kotlin/io/snyk/plugin/cli/ConsoleCommandRunnerTest.kt
+++ b/src/integTest/kotlin/io/snyk/plugin/cli/ConsoleCommandRunnerTest.kt
@@ -75,7 +75,7 @@ class ConsoleCommandRunnerTest : LightPlatformTestCase() {
     }
 
     @Test
-    fun testSetupCliEnvironmentVariablesWithProxy() {
+    fun testSetupCliEnvironmentVariablesWithProxyWithoutAuth() {
         val httpConfigurable = HttpConfigurable.getInstance()
         val originalProxyHost = httpConfigurable.PROXY_HOST
         val originalProxyPort = httpConfigurable.PROXY_PORT
@@ -95,6 +95,40 @@ class ConsoleCommandRunnerTest : LightPlatformTestCase() {
             httpConfigurable.USE_HTTP_PROXY = originalUseProxy
             httpConfigurable.PROXY_HOST = originalProxyHost
             httpConfigurable.PROXY_PORT = originalProxyPort
+        }
+    }
+
+    @Test
+    fun testSetupCliEnvironmentVariablesWithProxyWithAuth() {
+        val httpConfigurable = HttpConfigurable.getInstance()
+        val originalProxyHost = httpConfigurable.PROXY_HOST
+        val originalProxyPort = httpConfigurable.PROXY_PORT
+        val originalUseProxy = httpConfigurable.USE_HTTP_PROXY
+        val originalProxyAuthentication = httpConfigurable.PROXY_AUTHENTICATION
+        val originalLogin = httpConfigurable.proxyLogin
+        val originalPassword = httpConfigurable.plainProxyPassword
+        try {
+            httpConfigurable.PROXY_PORT = 3128
+            httpConfigurable.PROXY_HOST = "testProxy"
+            httpConfigurable.USE_HTTP_PROXY = true
+            httpConfigurable.PROXY_AUTHENTICATION = true
+            httpConfigurable.proxyLogin = "testLogin"
+            httpConfigurable.plainProxyPassword = "testPassword"
+
+            val generalCommandLine = GeneralCommandLine("")
+            val expectedProxy = "http://${httpConfigurable.proxyLogin}:${httpConfigurable.plainProxyPassword}@" +
+                "${httpConfigurable.PROXY_HOST}:${httpConfigurable.PROXY_PORT}"
+
+            ConsoleCommandRunner().setupCliEnvironmentVariables(generalCommandLine, "")
+
+            assertEquals(expectedProxy, generalCommandLine.environment["https_proxy"])
+        } finally {
+            httpConfigurable.USE_HTTP_PROXY = originalUseProxy
+            httpConfigurable.PROXY_HOST = originalProxyHost
+            httpConfigurable.PROXY_PORT = originalProxyPort
+            httpConfigurable.PROXY_AUTHENTICATION = originalProxyAuthentication
+            httpConfigurable.proxyLogin = originalLogin
+            httpConfigurable.plainProxyPassword = originalPassword
         }
     }
 

--- a/src/main/kotlin/io/snyk/plugin/cli/ConsoleCommandRunner.kt
+++ b/src/main/kotlin/io/snyk/plugin/cli/ConsoleCommandRunner.kt
@@ -108,8 +108,8 @@ open class ConsoleCommandRunner {
                     proxySettings.getPromptedAuthentication(proxyHost, "Snyk: Please enter your proxy password")
                 authentication = auth.userName + ":" + String(auth.password) + "@"
             }
+            commandLine.environment["http_proxy"] = "http://$authentication$proxyHost:${proxySettings.PROXY_PORT}"
             commandLine.environment["https_proxy"] = "http://$authentication$proxyHost:${proxySettings.PROXY_PORT}"
-
         }
     }
 

--- a/src/main/kotlin/io/snyk/plugin/cli/ConsoleCommandRunner.kt
+++ b/src/main/kotlin/io/snyk/plugin/cli/ConsoleCommandRunner.kt
@@ -100,8 +100,16 @@ open class ConsoleCommandRunner {
         commandLine.environment["SNYK_INTEGRATION_ENVIRONMENT"] = pluginInfo.integrationEnvironment
         commandLine.environment["SNYK_INTEGRATION_ENVIRONMENT_VERSION"] = pluginInfo.integrationEnvironmentVersion
         val proxySettings = HttpConfigurable.getInstance()
-        if (proxySettings != null && proxySettings.USE_HTTP_PROXY && proxySettings.PROXY_HOST.isNotEmpty()) {
-            commandLine.environment["https_proxy"] = "http://${proxySettings.PROXY_HOST}:${proxySettings.PROXY_PORT}"
+        val proxyHost = proxySettings.PROXY_HOST
+        if (proxySettings != null && proxySettings.USE_HTTP_PROXY && proxyHost.isNotEmpty()) {
+            var authentication = ""
+            if (proxySettings.PROXY_AUTHENTICATION) {
+                val auth =
+                    proxySettings.getPromptedAuthentication(proxyHost, "Snyk: Please enter your proxy password")
+                authentication = auth.userName + ":" + String(auth.password) + "@"
+            }
+            commandLine.environment["https_proxy"] = "http://$authentication$proxyHost:${proxySettings.PROXY_PORT}"
+
         }
     }
 

--- a/src/main/kotlin/io/snyk/plugin/cli/ConsoleCommandRunner.kt
+++ b/src/main/kotlin/io/snyk/plugin/cli/ConsoleCommandRunner.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Key
+import com.intellij.util.net.HttpConfigurable
 import io.snyk.plugin.controlExternalProcessWithProgressIndicator
 import io.snyk.plugin.getWaitForResultsTimeout
 import io.snyk.plugin.pluginSettings
@@ -98,6 +99,10 @@ open class ConsoleCommandRunner {
         commandLine.environment["SNYK_INTEGRATION_VERSION"] = pluginInfo.integrationVersion
         commandLine.environment["SNYK_INTEGRATION_ENVIRONMENT"] = pluginInfo.integrationEnvironment
         commandLine.environment["SNYK_INTEGRATION_ENVIRONMENT_VERSION"] = pluginInfo.integrationEnvironmentVersion
+        val proxySettings = HttpConfigurable.getInstance()
+        if (proxySettings != null && proxySettings.USE_HTTP_PROXY && proxySettings.PROXY_HOST.isNotEmpty()) {
+            commandLine.environment["https_proxy"] = "http://${proxySettings.PROXY_HOST}:${proxySettings.PROXY_PORT}"
+        }
     }
 
     companion object {

--- a/src/main/kotlin/io/snyk/plugin/services/download/CliDownloader.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/download/CliDownloader.kt
@@ -80,7 +80,7 @@ class CliDownloader {
     }
 
     fun expectedSha(): String {
-        val shaUrl = URL(String.format(SHA256_DOWNLOAD_URL, Platform.current().snykWrapperFileName))
-        return shaUrl.readText(Charsets.UTF_8).split(" ")[0]
+        val url = String.format(SHA256_DOWNLOAD_URL, Platform.current().snykWrapperFileName)
+        return HttpRequests.request(url).forceHttps(true).readString().split(" ")[0]
     }
 }

--- a/src/main/kotlin/io/snyk/plugin/services/download/CliDownloaderService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/download/CliDownloaderService.kt
@@ -43,7 +43,8 @@ class SnykCliDownloaderService {
 
     fun requestLatestReleasesInformation(): LatestReleaseInfo? {
         try {
-            val response = "v" + URL(CliDownloader.LATEST_RELEASES_URL).readText().removeSuffix("\n")
+            val result = HttpRequests.request(CliDownloader.LATEST_RELEASES_URL).readString()
+            val response = "v" + result.removeSuffix("\n")
             latestReleaseInfo = LatestReleaseInfo(
                 tagName = response,
                 url = "https://static.snyk.io/cli/latest/${Platform.current().snykWrapperFileName}",


### PR DESCRIPTION
Takes configuration from IntelliJ http proxy settings and uses it for CLI download, API calls, scans and authentication.

![image](https://user-images.githubusercontent.com/20150761/152572249-c1ea6e0e-de58-4230-a71c-793b30cac9b2.png)

Can be verified using the VM:

https://github.com/bastiandoetsch/jvm-development-environment