### PR TITLE
fix: write asynchronously in annotator, as it's might be a read action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Snyk Vulnerability Scanner Changelog
 
+## [2.4.16]
+
+### Fixed
+
+- Fix exception in IaC and Container annotators
+
 ## [2.4.15]
 
 ### Fixed

--- a/src/main/kotlin/snyk/container/annotator/ContainerYamlAnnotator.kt
+++ b/src/main/kotlin/snyk/container/annotator/ContainerYamlAnnotator.kt
@@ -16,7 +16,6 @@ class ContainerYamlAnnotator : ExternalAnnotator<PsiFile, Unit>() {
     // override needed for the Annotator to invoke apply(). We don't do anything here
     override fun collectInformation(file: PsiFile): PsiFile? = file
 
-    // save all changes on disk to update caches through SnykBulkFileListener
     override fun doAnnotate(collectedInfo: PsiFile?) {}
 
     fun getContainerIssuesForImages(psiFile: PsiFile): List<ContainerIssuesForImage> {

--- a/src/main/kotlin/snyk/container/annotator/ContainerYamlAnnotator.kt
+++ b/src/main/kotlin/snyk/container/annotator/ContainerYamlAnnotator.kt
@@ -3,12 +3,9 @@ package snyk.container.annotator
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.ExternalAnnotator
 import com.intellij.lang.annotation.HighlightSeverity
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.logger
-import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.util.TextRange
-import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiFile
 import io.snyk.plugin.getSnykToolWindowPanel
 import snyk.container.ContainerIssuesForImage
@@ -20,14 +17,7 @@ class ContainerYamlAnnotator : ExternalAnnotator<PsiFile, Unit>() {
     override fun collectInformation(file: PsiFile): PsiFile? = file
 
     // save all changes on disk to update caches through SnykBulkFileListener
-    override fun doAnnotate(collectedInfo: PsiFile?) {
-        logger.debug("doAnnotate on ${collectedInfo?.name}")
-        val psiFile = collectedInfo ?: return
-        val document = PsiDocumentManager.getInstance(psiFile.project).getDocument(psiFile) ?: return
-        ApplicationManager.getApplication().invokeAndWait {
-            FileDocumentManager.getInstance().saveDocument(document)
-        }
-    }
+    override fun doAnnotate(collectedInfo: PsiFile?) {}
 
     fun getContainerIssuesForImages(psiFile: PsiFile): List<ContainerIssuesForImage> {
         val containerResult = getSnykToolWindowPanel(psiFile.project)?.currentContainerResult

--- a/src/main/kotlin/snyk/iac/annotator/IacBaseAnnotator.kt
+++ b/src/main/kotlin/snyk/iac/annotator/IacBaseAnnotator.kt
@@ -3,10 +3,13 @@ package snyk.iac.annotator
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.ExternalAnnotator
 import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.util.TextRange
 import com.intellij.openapi.util.io.FileUtil
+import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiFile
 import io.snyk.plugin.Severity.Companion.CRITICAL
 import io.snyk.plugin.Severity.Companion.HIGH
@@ -23,7 +26,15 @@ abstract class IacBaseAnnotator : ExternalAnnotator<PsiFile, Unit>() {
     // override needed for the Annotator to invoke apply(). We don't do anything here
     override fun collectInformation(file: PsiFile): PsiFile? = file
 
-    override fun doAnnotate(collectedInfo: PsiFile?) {}
+    // save all changes on disk to update caches through SnykBulkFileListener
+    override fun doAnnotate(collectedInfo: PsiFile?) {
+        LOG.debug("Calling doAnnotate on ${collectedInfo?.name}")
+        val psiFile = collectedInfo ?: return
+        val document = PsiDocumentManager.getInstance(psiFile.project).getDocument(psiFile) ?: return
+        ApplicationManager.getApplication().invokeLater {
+            FileDocumentManager.getInstance().saveDocument(document)
+        }
+    }
 
     fun getIssues(psiFile: PsiFile): List<IacIssue> {
         val iacResult = getSnykToolWindowPanel(psiFile.project)?.currentIacResult ?: return emptyList()

--- a/src/main/kotlin/snyk/iac/annotator/IacBaseAnnotator.kt
+++ b/src/main/kotlin/snyk/iac/annotator/IacBaseAnnotator.kt
@@ -23,7 +23,6 @@ abstract class IacBaseAnnotator : ExternalAnnotator<PsiFile, Unit>() {
     // override needed for the Annotator to invoke apply(). We don't do anything here
     override fun collectInformation(file: PsiFile): PsiFile? = file
 
-    // save all changes on disk to update caches through SnykBulkFileListener
     override fun doAnnotate(collectedInfo: PsiFile?) {}
 
     fun getIssues(psiFile: PsiFile): List<IacIssue> {

--- a/src/main/kotlin/snyk/iac/annotator/IacBaseAnnotator.kt
+++ b/src/main/kotlin/snyk/iac/annotator/IacBaseAnnotator.kt
@@ -3,13 +3,10 @@ package snyk.iac.annotator
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.ExternalAnnotator
 import com.intellij.lang.annotation.HighlightSeverity
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.logger
-import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.util.TextRange
 import com.intellij.openapi.util.io.FileUtil
-import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiFile
 import io.snyk.plugin.Severity.Companion.CRITICAL
 import io.snyk.plugin.Severity.Companion.HIGH
@@ -27,14 +24,7 @@ abstract class IacBaseAnnotator : ExternalAnnotator<PsiFile, Unit>() {
     override fun collectInformation(file: PsiFile): PsiFile? = file
 
     // save all changes on disk to update caches through SnykBulkFileListener
-    override fun doAnnotate(collectedInfo: PsiFile?) {
-        LOG.debug("Calling doAnnotate on ${collectedInfo?.name}")
-        val psiFile = collectedInfo ?: return
-        val document = PsiDocumentManager.getInstance(psiFile.project).getDocument(psiFile) ?: return
-        ApplicationManager.getApplication().invokeAndWait {
-            FileDocumentManager.getInstance().saveDocument(document)
-        }
-    }
+    override fun doAnnotate(collectedInfo: PsiFile?) {}
 
     fun getIssues(psiFile: PsiFile): List<IacIssue> {
         val iacResult = getSnykToolWindowPanel(psiFile.project)?.currentIacResult ?: return emptyList()


### PR DESCRIPTION
original stacktrace:
```
ExternalToolPass: 

com.intellij.diagnostic.PluginException: annotator: snyk.iac.annotator.IacYamlAnnotator@75c76c6e (class snyk.iac.annotator.IacYamlAnnotator) [Plugin: io.snyk.snyk-intellij-plugin]
	at com.intellij.ide.plugins.PluginManagerCore.createPluginException(PluginManagerCore.java:270)
	at com.intellij.diagnostic.PluginProblemReporterImpl.createPluginExceptionByClass(PluginProblemReporterImpl.java:12)
	at com.intellij.diagnostic.PluginException.createByClass(PluginException.java:83)
	at com.intellij.codeInsight.daemon.impl.ExternalToolPass.processError(ExternalToolPass.java:272)
	at com.intellij.codeInsight.daemon.impl.ExternalToolPass.doAnnotate(ExternalToolPass.java:221)
	at com.intellij.codeInsight.daemon.impl.ExternalToolPass.doAnnotate(ExternalToolPass.java:212)
	at com.intellij.codeInsight.daemon.impl.ExternalToolPass.getInfos(ExternalToolPass.java:168)
	at com.intellij.codeInsight.daemon.impl.DaemonCodeAnalyzerImpl.runMainPasses(DaemonCodeAnalyzerImpl.java:285)
	at com.intellij.openapi.vcs.impl.CodeSmellDetectorImpl.lambda$runMainPasses$7(CodeSmellDetectorImpl.java:198)
	at com.intellij.openapi.project.DumbService.lambda$runReadActionInSmartMode$0(DumbService.java:113)
	at com.intellij.openapi.project.DumbService.lambda$runReadActionInSmartMode$1(DumbService.java:157)
	at com.intellij.openapi.application.impl.ApplicationImpl.runReadAction(ApplicationImpl.java:865)
	at com.intellij.openapi.application.ReadAction.compute(ReadAction.java:61)
	at com.intellij.openapi.project.DumbService.runReadActionInSmartMode(DumbService.java:150)
	at com.intellij.openapi.project.DumbService.runReadActionInSmartMode(DumbService.java:113)
	at com.intellij.openapi.vcs.impl.CodeSmellDetectorImpl.runMainPasses(CodeSmellDetectorImpl.java:198)
	at com.intellij.openapi.vcs.impl.CodeSmellDetectorImpl.lambda$findCodeSmells$5(CodeSmellDetectorImpl.java:167)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcess$2(CoreProgressManager.java:188)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$executeProcessUnderProgress$12(CoreProgressManager.java:624)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:698)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computeUnderProgress(CoreProgressManager.java:646)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:623)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:66)
	at com.intellij.openapi.progress.impl.CoreProgressManager.runProcess(CoreProgressManager.java:175)
	at com.intellij.openapi.vcs.impl.CodeSmellDetectorImpl.findCodeSmells(CodeSmellDetectorImpl.java:166)
	at com.intellij.openapi.vcs.impl.CodeSmellDetectorImpl.findCodeSmells(CodeSmellDetectorImpl.java:144)
	at com.intellij.openapi.vcs.impl.CodeSmellDetectorImpl$1.run(CodeSmellDetectorImpl.java:106)
	at com.intellij.openapi.progress.impl.CoreProgressManager.startTask(CoreProgressManager.java:436)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.startTask(ProgressManagerImpl.java:120)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcessWithProgressSynchronously$8(CoreProgressManager.java:542)
	at com.intellij.openapi.progress.impl.ProgressRunner.lambda$new$0(ProgressRunner.java:83)
	at com.intellij.openapi.progress.impl.ProgressRunner.lambda$submit$3(ProgressRunner.java:244)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcess$2(CoreProgressManager.java:188)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$executeProcessUnderProgress$12(CoreProgressManager.java:624)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:698)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computeUnderProgress(CoreProgressManager.java:646)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:623)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:66)
	at com.intellij.openapi.progress.impl.CoreProgressManager.runProcess(CoreProgressManager.java:175)
	at com.intellij.openapi.progress.impl.ProgressRunner.lambda$submit$4(ProgressRunner.java:244)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1700)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:668)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:665)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1.run(Executors.java:665)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.lang.IllegalStateException: Calling invokeAndWait from read-action leads to possible deadlock.
	at com.intellij.openapi.application.impl.ApplicationImpl.invokeAndWait(ApplicationImpl.java:446)
	at com.intellij.openapi.application.impl.ApplicationImpl.invokeAndWait(ApplicationImpl.java:455)
	at snyk.iac.annotator.IacBaseAnnotator.doAnnotate(IacBaseAnnotator.kt:34)
	at snyk.iac.annotator.IacBaseAnnotator.doAnnotate(IacBaseAnnotator.kt:24)
	at com.intellij.codeInsight.daemon.impl.ExternalToolPass.doAnnotate(ExternalToolPass.java:218)
	... 43 more
```