### PR TITLE
fix: caret is wrongly jumping to the last selected line in the Tree when editing file with issues.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Snyk Vulnerability Scanner Changelog
 
+## [2.4.15]
+
+### Fixed
+
+- Caret is wrongly jumping to the last selected line in the Tree when editing file with issues.
+
 ## [2.4.14]
 
 ### Changed

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
@@ -413,7 +413,7 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
 
                     val textRange = suggestion.ranges[index]
                         ?: throw IllegalArgumentException(suggestion.ranges.toString())
-                    if (psiFile.virtualFile.isValid) {
+                    if (!smartReloadMode && psiFile.virtualFile.isValid) {
                         navigateToSource(psiFile.virtualFile, textRange.start, textRange.end)
                     }
 
@@ -439,7 +439,7 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
                     )
                     descriptionPanel.add(scrollPane, BorderLayout.CENTER)
 
-                    if (virtualFile != null && virtualFile.isValid) {
+                    if (!smartReloadMode && virtualFile != null && virtualFile.isValid) {
                         val document = FileDocumentManager.getInstance().getDocument(virtualFile)
                         if (document != null) {
                             val lineNumber = iacIssue.lineNumber.let {
@@ -472,7 +472,7 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
                         .find { it.image == issuesForImage.imageName }
                     val virtualFile = targetImage?.virtualFile
                     val line = targetImage?.lineNumber?.let { it - 1 } // to 1-based count used in the editor
-                    if (virtualFile != null && virtualFile.isValid && line != null) {
+                    if (!smartReloadMode && virtualFile != null && virtualFile.isValid && line != null) {
                         val document = FileDocumentManager.getInstance().getDocument(virtualFile)
                         if (document != null) {
                             val lineNumber = if (0 <= line && line < document.lineCount) line else 0


### PR DESCRIPTION

https://user-images.githubusercontent.com/20150761/153420414-789cfe6b-bf05-4442-8e20-f3232455ee4a.mov

