### PR TITLE
fix: use environment variable when disabling usage analytics [ROAD-741]

### DIFF
--- a/src/integTest/kotlin/io/snyk/plugin/cli/ConsoleCommandRunnerTest.kt
+++ b/src/integTest/kotlin/io/snyk/plugin/cli/ConsoleCommandRunnerTest.kt
@@ -78,6 +78,20 @@ class ConsoleCommandRunnerTest : LightPlatformTestCase() {
     }
 
     @Test
+    fun testSetupCliEnvironmentVariablesWithDisabledUsageAnalytics() {
+        val originalUsageAnalyticsEnabled = pluginSettings().usageAnalyticsEnabled
+        try {
+            pluginSettings().usageAnalyticsEnabled = false
+            val generalCommandLine = GeneralCommandLine("")
+            ConsoleCommandRunner().setupCliEnvironmentVariables(generalCommandLine, "")
+
+            assertEquals("1", generalCommandLine.environment["SNYK_CFG_DISABLE_ANALYTICS"])
+        } finally {
+            pluginSettings().usageAnalyticsEnabled = originalUsageAnalyticsEnabled
+        }
+    }
+
+    @Test
     fun testSetupCliEnvironmentVariablesWithProxyWithoutAuth() {
         val httpConfigurable = HttpConfigurable.getInstance()
         val originalProxyHost = httpConfigurable.PROXY_HOST

--- a/src/integTest/kotlin/snyk/iac/IacServiceTest.kt
+++ b/src/integTest/kotlin/snyk/iac/IacServiceTest.kt
@@ -65,16 +65,6 @@ class IacServiceTest : LightPlatformTestCase() {
     }
 
     @Test
-    fun testBuildCliCommandsListWithDisableAnalyticsParameter() {
-        setupDummyCliFile()
-        pluginSettings().usageAnalyticsEnabled = false
-
-        val cliCommands = iacService.buildCliCommandsList_TEST_ONLY(listOf("fake_cli_command"))
-
-        assertFalse(cliCommands.contains("--DISABLE_ANALYTICS"))
-    }
-
-    @Test
     fun testBuildCliCommandsListWithFileParameter() {
         setupDummyCliFile()
 

--- a/src/integTest/kotlin/snyk/oss/OssServiceTest.kt
+++ b/src/integTest/kotlin/snyk/oss/OssServiceTest.kt
@@ -58,16 +58,6 @@ class OssServiceTest : LightPlatformTestCase() {
     }
 
     @Test
-    fun testBuildCliCommandsListWithDisableAnalyticsParameter() {
-        setupDummyCliFile()
-        pluginSettings().usageAnalyticsEnabled = false
-
-        val cliCommands = ossService.buildCliCommandsList_TEST_ONLY(listOf("fake_cli_command"))
-
-        assertTrue(cliCommands.contains("--DISABLE_ANALYTICS"))
-    }
-
-    @Test
     fun testBuildCliCommandsListWithFileParameter() {
         setupDummyCliFile()
 

--- a/src/main/kotlin/io/snyk/plugin/cli/ConsoleCommandRunner.kt
+++ b/src/main/kotlin/io/snyk/plugin/cli/ConsoleCommandRunner.kt
@@ -95,6 +95,10 @@ open class ConsoleCommandRunner {
         if (customEndpoint != null && customEndpoint.isNotEmpty()) {
             commandLine.environment["SNYK_API"] = customEndpoint
         }
+        if (!pluginSettings().usageAnalyticsEnabled) {
+            commandLine.environment["SNYK_CFG_DISABLE_ANALYTICS"] = "1"
+        }
+
         commandLine.environment["SNYK_INTEGRATION_NAME"] = pluginInfo.integrationName
         commandLine.environment["SNYK_INTEGRATION_VERSION"] = pluginInfo.integrationVersion
         commandLine.environment["SNYK_INTEGRATION_ENVIRONMENT"] = pluginInfo.integrationEnvironment

--- a/src/main/kotlin/snyk/oss/OssService.kt
+++ b/src/main/kotlin/snyk/oss/OssService.kt
@@ -68,10 +68,6 @@ class OssService(project: Project) : CliAdapter<OssResult>(project) {
 
         options.add("--json")
 
-        if (!settings.usageAnalyticsEnabled) {
-            options.add("--DISABLE_ANALYTICS")
-        }
-
         val additionalParameters = settings.getAdditionalParameters(project)
 
         if (additionalParameters != null && additionalParameters.trim().isNotEmpty()) {


### PR DESCRIPTION
This PR use CLI environment variable (`SNYK_CFG_DISABLE_ANALYTICS`) instead of CLI flag. The flag doesn't work for IaC and Container.