### PR TITLE
fix: Container node UI bugs [ROAD-648] [ROAD-647] [ROAD-749]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fix Container: invalid token shows error and don’t redirect to Auth panel
+- Fix Container: invalid token shows error and does not redirect to Auth panel
 - Fix Container: should handle case if no images in project found
 - Fix Container: node still showing last results even if disabled
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,17 @@
 
 ## [2.4.18]
 
-### Fixed
-
-- Fix Container: invalid token shows error and does not redirect to Auth panel
-- Fix Container: should handle case if no images in project found
-- Fix Container: node still showing last results even if disabled
-
 ### Changed
 
 - Snyk Open Source: added editor annotations for Maven, NPM, and Kotlin Gradle
 - Snyk Open Source: added quickfix capability for package managers
 - Snyk Code: Annotations if plugins for the language are installed
 
-### Fixes
+### Fixed
 
+- Fix Container: invalid token shows error and does not redirect to Auth panel
+- Fix Container: should handle case if no images in project found
+- Fix Container: node still showing last results even if disabled
 - improved Snyk Container image parsing in K8S files
 
 ## [2.4.17]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [2.4.18]
 
+### Fixed
+
+- Fix Container: invalid token shows error and don’t redirect to Auth panel
+- Fix Container: should handle case if no images in project found
+- Fix Container: node still showing last results even if disabled
+
 ### Changed
 
 - Snyk Open Source: added editor annotations for Maven, NPM, and Kotlin Gradle

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
@@ -1164,7 +1164,7 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
         const val NO_OSS_FILES = "Could not detect supported target files in"
         const val NO_IAC_FILES = "Could not find any valid IaC files"
         const val NO_SUPPORTED_IAC_FILES_FOUND = " - No supported IaC files found"
-        const val NO_CONTAINER_IMAGES_FOUND = " - No Container images found"
+        const val NO_CONTAINER_IMAGES_FOUND = " - No container images found"
         const val NO_SUPPORTED_PACKAGE_MANAGER_FOUND = " - No supported package manager found"
         private const val TOOL_WINDOW_SPLITTER_PROPORTION_KEY = "SNYK_TOOL_WINDOW_SPLITTER_PROPORTION"
         private const val NODE_INITIAL_STATE = -1

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/TreePanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/TreePanel.kt
@@ -16,6 +16,7 @@ class TreePanel(tree: Tree) : SimpleToolWindowPanel(true, true) {
     private val actionManager = ActionManager.getInstance()
 
     init {
+        name = "treePanel"
         val severityToolbarPanel = JPanel(BorderLayout())
         severityToolbarPanel.add(JLabel("Severity: "), BorderLayout.WEST)
         severityToolbarPanel.add(getSeverityToolbar().component, BorderLayout.CENTER)

--- a/src/main/kotlin/snyk/container/ContainerService.kt
+++ b/src/main/kotlin/snyk/container/ContainerService.kt
@@ -38,7 +38,7 @@ class ContainerService(project: Project) : CliAdapter<ContainerResult>(
         val imageNames = images.map { it.image }
         LOG.debug("container scan requested for ${imageNames.size} images: $imageNames")
         if (imageNames.isEmpty()) {
-            return ContainerResult(emptyList(), null)
+            return ContainerResult(emptyList(), NO_IMAGES_TO_SCAN_ERROR)
         }
         val tempResult = execute(commands + imageNames)
         if (!tempResult.isSuccessful()) {
@@ -142,4 +142,8 @@ class ContainerService(project: Project) : CliAdapter<ContainerResult>(
         jsonStr.contains("\"vulnerabilities\":") && !jsonStr.contains("\"error\":")
 
     override fun buildExtraOptions(): List<String> = listOf("--json")
+
+    companion object {
+        val NO_IMAGES_TO_SCAN_ERROR = SnykError("", "")
+    }
 }

--- a/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanelTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanelTest.kt
@@ -67,10 +67,10 @@ class SnykToolWindowPanelTest : LightPlatform4TestCase() {
 
         cut = SnykToolWindowPanel(project)
 
-        val vulnerabilityTree = cut.vulnerabilitiesTree
         val authPanel = UIComponentFinder.getJPanelByName(cut, "authPanel")
         assertNotNull(authPanel)
-        assertEquals(findOnePixelSplitter(vulnerabilityTree), authPanel!!.parent)
+        val treePanel = UIComponentFinder.getJPanelByName(cut, "treePanel")
+        assertNotNull(treePanel)
     }
 
     @Test


### PR DESCRIPTION
fix: Container node still showing last results even if disabled
fix: Container node should handle case if no images in project found
fix: Container: invalid token shows error and don’t redirect to Auth panel