### PR TITLE
fix: Container cache updates on full/partial file content deletion [ROAD-751]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Snyk Vulnerability Database issue url resulting in 404 when opened from details panel.
+- Container results/images cache was not updated on full/partial file content deletion.
 
 ## [2.4.18]
 

--- a/src/main/kotlin/snyk/container/KubernetesImageCache.kt
+++ b/src/main/kotlin/snyk/container/KubernetesImageCache.kt
@@ -12,7 +12,7 @@ import com.jetbrains.rd.util.concurrentMapOf
 @Service
 class KubernetesImageCache(val project: Project) {
     private val images = concurrentMapOf<VirtualFile, Set<KubernetesWorkloadImage>>()
-    private val logger = Logger.getInstance(javaClass.name)
+    private val logger = Logger.getInstance(javaClass)
 
     fun clear() {
         images.clear()
@@ -54,7 +54,12 @@ class KubernetesImageCache(val project: Project) {
     fun extractFromFile(file: VirtualFile) {
         val extractFromFile = YAMLImageExtractor.extractFromFile(file, project)
         if (extractFromFile.isNotEmpty()) {
+            logger.debug("${if (images.contains(file)) "updated" else "added"} $file in cache")
             images[file] = extractFromFile
+        } else if (images.contains(file)) {
+            // case when all images from file (cached before) been removed
+            logger.debug("removed $file from cache")
+            images.remove(file)
         }
     }
 }

--- a/src/main/kotlin/snyk/container/YAMLImageExtractor.kt
+++ b/src/main/kotlin/snyk/container/YAMLImageExtractor.kt
@@ -7,7 +7,7 @@ import com.intellij.psi.PsiFile
 import io.snyk.plugin.findPsiFileIgnoringExceptions
 
 object YAMLImageExtractor {
-    private val logger = Logger.getInstance(javaClass.name)
+    private val logger = Logger.getInstance(javaClass)
     private val imageRegEx = "(?<=([-\\s]image:))(\\s*[a-zA-Z0-9./\\-_]+)(:)?([a-zA-Z0-9./\\-_]+)?".toRegex()
 
     private fun extractImages(file: PsiFile): Set<KubernetesWorkloadImage> {


### PR DESCRIPTION
Fix next bugs:
1. On full file content deletion caches are not updated.
2. On partial file content deletion KubernetesImageCache is not updated.