### PR TITLE
chore: fill github releases with changelog from changelog.md

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,8 @@ jobs:
 
       - name: Extract release notes
         id: extract-release-notes
-        uses: ffurrer2/extract-release-notes@v1
+        run: |
+          echo "::set-output name=release_notes::$(./gradlew getChangelog --console=plain -q --no-header)"
 
       - name: Create release
         if: ${{ !env.ACT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,13 +51,21 @@ jobs:
           ./gradlew release -Prelease.dryRun
           echo "::set-output name=tagName::$(./gradlew cV -q -Prelease.quiet)"
 
-      - name: Create Github release
-        uses: "marvinpinto/action-automatic-releases@latest"
+      - name: Extract release notes
+        id: extract-release-notes
+        uses: ffurrer2/extract-release-notes@v1
+
+      - name: Create release
         if: ${{ !env.ACT }}
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "v${{ steps.createTag.outputs.tagName }}"
+          tag_name: "v${{ steps.createTag.outputs.tagName }}"
+          release_name: "v${{ steps.createTag.outputs.tagName }}"
+          draft: false
           prerelease: false
+          body: "${{ steps.extract-release-notes.outputs.release_notes }}"
 
       - name: Publish Plugin
         if: ${{ !env.ACT }}


### PR DESCRIPTION
Changed the release action to a different one. Hard to test, but locally it looked good:
```
[Release/release] ⭐  Run Extract release notes
[Release/release]   ☁  git clone 'https://github.com/ffurrer2/extract-release-notes' # ref=v1
[Release/release]   🐳  docker cp src=/Users/bdoetsch/.cache/act/ffurrer2-extract-release-notes@v1/ dst=/var/run/act/actions/ffurrer2-extract-release-notes@v1/
[Release/release]   🐳  docker exec cmd=[mkdir -p /var/run/act/actions/ffurrer2-extract-release-notes@v1/] user= workdir=
[Release/release]   🐳  docker exec cmd=[node /var/run/act/actions/ffurrer2-extract-release-notes@v1/dist/index.js] user= workdir=
[Release/release]   💬  ::debug::changelog-file = 'CHANGELOG.md'
[Release/release]   💬  ::debug::release-notes-file = ''
[Release/release]   💬  ::debug::prerelease = 'false'
[Release/release]   💬  ::debug::skip line: '# Snyk Changelog'
[Release/release]   💬  ::debug::skip line: ''
[Release/release]   💬  ::debug::version found: '## [2.4.20]'
[Release/release]   💬  ::debug::add line: ''
[Release/release]   💬  ::debug::add line: '### Fixed'
[Release/release]   💬  ::debug::add line: ''
[Release/release]   💬  ::debug::add line: '- avoid any IDE internal InvocationTargetException for project services'
[Release/release]   💬  ::debug::add line: '- Container results/images cache was not updated on full/partial file content deletion.'
[Release/release]   💬  ::debug::add line: ''
[Release/release]   💬  ::debug::next version found: '## [2.4.19]'
[Release/release]   💬  ::debug::release-notes = '### Fixed%0A%0A- avoid any IDE internal InvocationTargetException for project services%0A- Container results/images cache was not updated on full/partial file content deletion.'
|
[Release/release]   ⚙  ::set-output:: release_notes=### Fixed
```