### PR TITLE
feat: sast settings with organization as url query param [ROAD-734]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [2.4.20]
 
+### Changed
+- Check Snyk Code enablement using configured organization from settings.
+
 ### Fixed
 
 - avoid any IDE internal InvocationTargetException for project services

--- a/src/main/kotlin/io/snyk/plugin/net/CliConfigService.kt
+++ b/src/main/kotlin/io/snyk/plugin/net/CliConfigService.kt
@@ -3,13 +3,14 @@ package io.snyk.plugin.net
 import com.google.gson.annotations.SerializedName
 import retrofit2.Call
 import retrofit2.http.GET
+import retrofit2.http.Query
 
 /**
  * An endpoint to get information about CLI configuration like SAST etc.
  */
 interface CliConfigService {
     @GET(apiName)
-    fun sast(): Call<CliConfigSettings>
+    fun sast(@Query("org") org: String? = null): Call<CliConfigSettings>
 
     companion object {
         const val apiName = "cli-config/settings/sast"

--- a/src/main/kotlin/io/snyk/plugin/net/SnykApiClient.kt
+++ b/src/main/kotlin/io/snyk/plugin/net/SnykApiClient.kt
@@ -10,9 +10,6 @@ import retrofit2.Retrofit
 class SnykApiClient constructor(
     private val retrofit: Retrofit
 ) {
-    val sastSettings: CliConfigSettings?
-        get() = executeRequest(CliConfigService.apiName, cliConfigService().sast())
-
     val userId: String?
         get() = executeRequest(UserService.apiName, userService().userMe())?.id
 
@@ -31,6 +28,10 @@ class SnykApiClient constructor(
             userServiceEndpoint = retrofit.create(UserService::class.java)
         }
         return userServiceEndpoint
+    }
+
+    fun sastSettings(org: String? = null): CliConfigSettings? {
+        return executeRequest(CliConfigService.apiName, cliConfigService().sast(org))
     }
 
     private fun <T> executeRequest(apiName: String, retrofitCall: Call<T>): T? = try {

--- a/src/main/kotlin/io/snyk/plugin/services/SnykApiService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykApiService.kt
@@ -23,7 +23,10 @@ import javax.net.ssl.X509TrustManager
 class SnykApiService : Disposable {
 
     val sastSettings: CliConfigSettings?
-        get() = snykApiClient?.sastSettings
+        get() {
+            val pluginSettings = service<SnykApplicationSettingsStateService>()
+            return snykApiClient?.sastSettings(pluginSettings.organization)
+        }
 
     val userId: String?
         get() = snykApiClient?.userId

--- a/src/test/kotlin/io/snyk/plugin/net/CliConfigServiceTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/net/CliConfigServiceTest.kt
@@ -1,0 +1,71 @@
+package io.snyk.plugin.net
+
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okio.buffer
+import okio.source
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.core.IsEqual.equalTo
+import org.hamcrest.core.IsNull.nullValue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import snyk.net.HttpClient
+import java.nio.charset.StandardCharsets
+
+class CliConfigServiceTest {
+    @JvmField
+    @Rule
+    val server: MockWebServer = MockWebServer()
+
+    private lateinit var cliConfigServiceUnderTest: CliConfigService
+
+    @Before
+    fun setUp() {
+        val httpClient = HttpClient().apply {
+            connectTimeout = 1
+            readTimeout = 1
+            writeTimeout = 1
+        }
+        val retrofit = Retrofit.Builder()
+            .client(httpClient.build())
+            .baseUrl(server.url("/").toString())
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+
+        cliConfigServiceUnderTest = retrofit.create(CliConfigService::class.java)
+    }
+
+    @Test
+    fun `sast should not contain org query param if org is null`() {
+        server.enqueueResponse("sast_local-code-engine-disabled_200.json", 200)
+
+        val request = cliConfigServiceUnderTest.sast().request()
+
+        assertThat(request.url.queryParameter("org"), nullValue())
+    }
+
+    @Test
+    fun `sast should contain org query param if org is specified`() {
+        server.enqueueResponse("sast_local-code-engine-disabled_200.json", 200)
+
+        val request = cliConfigServiceUnderTest.sast("my-cool-test-org").request()
+
+        assertThat(request.url.queryParameter("org"), equalTo("my-cool-test-org"))
+    }
+}
+
+internal fun MockWebServer.enqueueResponse(fileName: String, statusCode: Int) {
+    val inputStream = javaClass.classLoader?.getResourceAsStream("test-fixtures/api-responses/snyk/$fileName")
+
+    val source = inputStream?.let { inputStream.source().buffer() }
+    source?.let {
+        enqueue(
+            MockResponse()
+                .setResponseCode(statusCode)
+                .setBody(source.readString(StandardCharsets.UTF_8))
+        )
+    }
+}

--- a/src/test/resources/test-fixtures/api-responses/snyk/sast_local-code-engine-disabled_200.json
+++ b/src/test/resources/test-fixtures/api-responses/snyk/sast_local-code-engine-disabled_200.json
@@ -1,0 +1,9 @@
+{
+  "sastEnabled": true,
+  "localCodeEngine": {
+    "allowCloudUpload": false,
+    "url": "",
+    "enabled": false
+  },
+  "org": "test-organization"
+}


### PR DESCRIPTION
This PR adds a feature to check SAST API endpoint with organization from settings (if configured).
Default value for org Retrofit query param is `null`. In this case Retrofit will omit URL query param.