### PR TITLE
feat: show additional info for organization setting [ROAD-736]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,9 @@
 # Snyk Changelog
 
-## [2.4.23]
+## [2.4.22]
 
 ### Changed
 - Provide an additional info to the “Organization” setting
-
-## [2.4.22]
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Snyk Changelog
 
+## [2.4.23]
+
+### Changed
+- Provide an additional info to the “Organization” setting
+
 ## [2.4.22]
 
 ### Fixed
@@ -49,7 +54,7 @@
 - Fix Container: invalid token shows error and does not redirect to Auth panel
 - Fix Container: should handle case if no images in project found
 - Fix Container: node still showing last results even if disabled
-- improved Snyk Container image parsing in K8S files
+- Improved Snyk Container image parsing in K8S files
 
 ## [2.4.17]
 

--- a/src/main/kotlin/io/snyk/plugin/ui/SnykSettingsDialog.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/SnykSettingsDialog.kt
@@ -1,11 +1,13 @@
 package io.snyk.plugin.ui
 
+import com.intellij.ide.BrowserUtil
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.ComponentValidator
 import com.intellij.openapi.ui.ValidationInfo
+import com.intellij.ui.ContextHelpLabel
 import com.intellij.ui.DocumentAdapter
 import com.intellij.ui.IdeBorderFactory
 import com.intellij.ui.components.JBPasswordField
@@ -20,6 +22,7 @@ import io.snyk.plugin.services.SnykApplicationSettingsStateService
 import io.snyk.plugin.services.download.SnykCliDownloaderService
 import io.snyk.plugin.settings.SnykProjectSettingsConfigurable
 import io.snyk.plugin.ui.settings.ScanTypesPanel
+import snyk.SnykBundle
 import snyk.amplitude.AmplitudeExperimentService
 import snyk.amplitude.api.ExperimentUser
 import java.awt.Insets
@@ -175,7 +178,7 @@ class SnykSettingsDialog(
                 1,
                 1,
                 1,
-                1,
+                3,
                 UIGridConstraints.ANCHOR_WEST,
                 UIGridConstraints.FILL_HORIZONTAL,
                 UIGridConstraints.SIZEPOLICY_WANT_GROW,
@@ -215,7 +218,7 @@ class SnykSettingsDialog(
                 2,
                 1,
                 1,
-                2,
+                3,
                 UIGridConstraints.ANCHOR_WEST,
                 UIGridConstraints.FILL_HORIZONTAL,
                 UIGridConstraints.SIZEPOLICY_WANT_GROW,
@@ -235,7 +238,7 @@ class SnykSettingsDialog(
                 3,
                 1,
                 1,
-                2,
+                3,
                 UIGridConstraints.ANCHOR_WEST,
                 UIGridConstraints.FILL_NONE,
                 UIGridConstraints.SIZEPOLICY_WANT_GROW,
@@ -279,6 +282,32 @@ class SnykSettingsDialog(
                 UIGridConstraints.ANCHOR_WEST,
                 UIGridConstraints.FILL_HORIZONTAL,
                 UIGridConstraints.SIZEPOLICY_WANT_GROW,
+                UIGridConstraints.SIZEPOLICY_FIXED,
+                null,
+                null,
+                null,
+                0,
+                false
+            )
+        )
+
+        val organizationContextHelpLabel = ContextHelpLabel.createWithLink(
+            null,
+            SnykBundle.message("snyk.settings.organization.tooltip.description"),
+            SnykBundle.message("snyk.settings.organization.tooltip.linkText")
+        ) {
+            BrowserUtil.browse(SnykBundle.message("snyk.settings.organization.tooltip.link"))
+        }
+        generalSettingsPanel.add(
+            organizationContextHelpLabel,
+            UIGridConstraints(
+                4,
+                3,
+                1,
+                1,
+                UIGridConstraints.ANCHOR_EAST,
+                UIGridConstraints.FILL_NONE,
+                UIGridConstraints.SIZEPOLICY_FIXED,
                 UIGridConstraints.SIZEPOLICY_FIXED,
                 null,
                 null,

--- a/src/main/kotlin/snyk/SnykBundle.kt
+++ b/src/main/kotlin/snyk/SnykBundle.kt
@@ -1,0 +1,12 @@
+package snyk
+
+import com.intellij.DynamicBundle
+import org.jetbrains.annotations.PropertyKey
+
+private const val BUNDLE = "SnykBundle"
+
+object SnykBundle : DynamicBundle(BUNDLE) {
+    @JvmStatic
+    fun message(@PropertyKey(resourceBundle = BUNDLE) key: String, vararg params: Any) =
+        getMessage(key, *params)
+}

--- a/src/main/resources/SnykBundle.properties
+++ b/src/main/resources/SnykBundle.properties
@@ -1,0 +1,3 @@
+snyk.settings.organization.tooltip.description=An organization groups projects, and can have team members who can access these projects.
+snyk.settings.organization.tooltip.linkText=What’s a Snyk organization
+snyk.settings.organization.tooltip.link=https://docs.snyk.io/features/user-and-group-management/managing-groups-and-organizations/whats-a-snyk-organization


### PR DESCRIPTION
This PR adds following features:
- providing hint for "Organization" settings (as context help label JB component)
- support for using message bundles (property files) => get rid of hard-coded text from source code

<details open>
  <summary>General settings screenshot</summary>

  <img width="976" alt="Screen Shot 2022-03-19 at 04 21 14" src="https://user-images.githubusercontent.com/60606414/159104832-5b59c037-8f9d-4fad-8bbb-5f277b7ec6ed.png">
</details>

