### PR TITLE
feat: use snyk-code-client 2.3.0 to make analysis retrieval more resilient [ROAD-730]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Snyk Changelog
 
+## [2.4.23]
+
+### Fixed
+- Snyk Code: make analysis retrieval more resilient to server/net errors.
+
 ## [2.4.22]
 
 ### Changed

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     implementation("com.google.code.gson:gson:2.8.9")
     implementation("com.segment.analytics.java:analytics:3.1.3")
     implementation("io.sentry:sentry:5.6.0")
-    implementation("io.snyk.code.sdk:snyk-code-client:2.2.1")
+    implementation("io.snyk.code.sdk:snyk-code-client:2.3.0")
     implementation("ly.iterative.itly:plugin-iteratively:1.2.11")
     implementation("ly.iterative.itly:plugin-schema-validator:1.2.11") {
         exclude(group = "org.slf4j")

--- a/src/main/kotlin/io/snyk/plugin/snykcode/CodeRestApi.kt
+++ b/src/main/kotlin/io/snyk/plugin/snykcode/CodeRestApi.kt
@@ -1,0 +1,5 @@
+package io.snyk.plugin.snykcode
+
+import ai.deepcode.javaclient.DeepCodeRestApiImpl
+
+val codeRestApi = DeepCodeRestApiImpl()

--- a/src/main/kotlin/io/snyk/plugin/snykcode/core/AnalysisData.kt
+++ b/src/main/kotlin/io/snyk/plugin/snykcode/core/AnalysisData.kt
@@ -1,12 +1,14 @@
 package io.snyk.plugin.snykcode.core
 
 import ai.deepcode.javaclient.core.AnalysisDataBase
+import io.snyk.plugin.snykcode.codeRestApi
 
 class AnalysisData private constructor() : AnalysisDataBase(
     PDU.instance,
     HashContentUtils.instance,
     SnykCodeParams.instance,
-    SCLogger.instance
+    SCLogger.instance,
+    codeRestApi
 ) {
     override fun updateUIonFilesRemovalFromCache(files: MutableCollection<Any>) {
         //probably not needed yet

--- a/src/main/kotlin/io/snyk/plugin/snykcode/core/SnykCodeParams.kt
+++ b/src/main/kotlin/io/snyk/plugin/snykcode/core/SnykCodeParams.kt
@@ -3,6 +3,7 @@ package io.snyk.plugin.snykcode.core
 import ai.deepcode.javaclient.core.DeepCodeParamsBase
 import io.snyk.plugin.getWaitForResultsTimeout
 import io.snyk.plugin.pluginSettings
+import io.snyk.plugin.snykcode.codeRestApi
 import io.snyk.plugin.toSnykCodeApiUrl
 
 class SnykCodeParams private constructor() : DeepCodeParamsBase(
@@ -14,7 +15,8 @@ class SnykCodeParams private constructor() : DeepCodeParamsBase(
     pluginSettings().token,
     "",
     "${SCLogger.presentableName}-Jetbrains",
-    { getWaitForResultsTimeout() }
+    { getWaitForResultsTimeout() },
+    codeRestApi
 ) {
 
     init {

--- a/src/main/kotlin/io/snyk/plugin/snykcode/core/SnykCodeUtils.kt
+++ b/src/main/kotlin/io/snyk/plugin/snykcode/core/SnykCodeUtils.kt
@@ -9,13 +9,15 @@ import com.intellij.openapi.vcs.changes.ChangeListManager
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
+import io.snyk.plugin.snykcode.codeRestApi
 
 class SnykCodeUtils private constructor() : DeepCodeUtilsBase(
     AnalysisData.instance,
     SnykCodeParams.instance,
     SnykCodeIgnoreInfoHolder.instance,
     PDU.instance,
-    SCLogger.instance
+    SCLogger.instance,
+    codeRestApi
 ) {
     private val scLogger: SCLogger = SCLogger.instance
 


### PR DESCRIPTION
Could/Should be merged after https://github.com/snyk/code-sdk-java/pull/33 and publishing `snyk-code-client 2.3.0` to maven