### PR TITLE
fix: Avoid IncorrectOperationException due to already disposed SnykTolWindowPanel when SnykAuthPanel invoked.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Avoiding IncorrectOperationException by remove direct project service's requests.
 - Avoid ClassNotFoundException due to not bundled Json support in some IDE.
+- Avoid IncorrectOperationException due to already disposed SnykToolWindowPanel when SnykAuthPanel invoked.
 
 ## [2.4.25]
 

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
@@ -647,6 +647,7 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
     }
 
     fun displayAuthPanel() {
+        if (Disposer.isDisposed(this)) return
         displayTreeAndDescriptionPanels()
         doCleanUi()
         descriptionPanel.removeAll()


### PR DESCRIPTION
will fix [IncorrectOperationException](https://sentry.io/organizations/snyk/issues/3023294926/?referrer=slack)