### PR TITLE
chore: enable request logging when SnykCode logger is in debug mode [ROAD-843]

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,18 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  '*':
+    - build/*:
+        reason: None Given
+        expires: 2032-05-20T07:12:38.106Z
+        created: 2022-04-20T07:12:38.108Z
+    - src/integTest/*:
+        reason: None Given
+        expires: 2022-05-20T07:13:02.819Z
+        created: 2022-04-20T07:13:02.822Z
+    - src/test/*:
+        reason: None Given
+        expires: 2022-05-20T07:13:09.929Z
+        created: 2022-04-20T07:13:09.932Z
+patch: {}

--- a/.snyk
+++ b/.snyk
@@ -7,12 +7,4 @@ ignore:
         reason: None Given
         expires: 2032-05-20T07:12:38.106Z
         created: 2022-04-20T07:12:38.108Z
-    - src/integTest/*:
-        reason: None Given
-        expires: 2022-05-20T07:13:02.819Z
-        created: 2022-04-20T07:13:02.822Z
-    - src/test/*:
-        reason: None Given
-        expires: 2022-05-20T07:13:09.929Z
-        created: 2022-04-20T07:13:09.932Z
 patch: {}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Snyk Changelog
 
+## [2.4.28]
+
+### Changed
+- Enable HTTP request logging when Snyk Code logger in debug mode
+
 ## [2.4.27]
 
 ### Changed
@@ -15,7 +20,6 @@
 
 - Updated Snyk Code API to 2.3.1 (limit file size to 1 MB)
 - Provide link to [Privacy Policy](https://snyk.io/policies/privacy/) and [Terms of Service](https://snyk.io/policies/terms-of-service/) on Welcome screen.
-
 ### Fixed
 
 - Avoiding IncorrectOperationException by remove direct project service's requests.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,8 +27,8 @@ repositories {
 dependencies {
     implementation("org.commonmark:commonmark:0.18.2")
     implementation("com.google.code.gson:gson:2.9.0")
-    implementation("com.segment.analytics.java:analytics:3.1.3")
-    implementation("io.sentry:sentry:5.7.0")
+    implementation("com.segment.analytics.java:analytics:3.2.0")
+    implementation("io.sentry:sentry:5.7.2")
     implementation("io.snyk.code.sdk:snyk-code-client:2.3.1")
     implementation("ly.iterative.itly:plugin-iteratively:1.2.11")
     implementation("ly.iterative.itly:plugin-schema-validator:1.2.11") {

--- a/src/main/kotlin/io/snyk/plugin/snykcode/core/SnykCodeParams.kt
+++ b/src/main/kotlin/io/snyk/plugin/snykcode/core/SnykCodeParams.kt
@@ -5,7 +5,7 @@ import com.intellij.openapi.diagnostic.Logger
 import io.snyk.plugin.getWaitForResultsTimeout
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.snykcode.codeRestApi
-import io.snyk.plugin.toSnykCodeApiUrl
+import snyk.common.toSnykCodeApiUrl
 
 class SnykCodeParams private constructor() : DeepCodeParamsBase(
     true,
@@ -20,12 +20,28 @@ class SnykCodeParams private constructor() : DeepCodeParamsBase(
     { getWaitForResultsTimeout() },
     codeRestApi
 ) {
+    private val requestLogging = Logger.getInstance(SCLogger.presentableName + "RequestLogging").isDebugEnabled
 
     init {
-        val requestLogging = Logger.getInstance(SCLogger.presentableName).isDebugEnabled
         setApiUrl(
             toSnykCodeApiUrl(pluginSettings().customEndpointUrl),
             pluginSettings().ignoreUnknownCA,
+            requestLogging
+        )
+    }
+
+    override fun setApiUrl(apiUrl: String) {
+        setApiUrl(
+            toSnykCodeApiUrl(apiUrl),
+            pluginSettings().ignoreUnknownCA,
+            requestLogging
+        )
+    }
+
+    override fun setApiUrl(apiUrl: String, disableSslVerification: Boolean) {
+        setApiUrl(
+            toSnykCodeApiUrl(apiUrl),
+            disableSslVerification,
             requestLogging
         )
     }

--- a/src/main/kotlin/io/snyk/plugin/snykcode/core/SnykCodeParams.kt
+++ b/src/main/kotlin/io/snyk/plugin/snykcode/core/SnykCodeParams.kt
@@ -1,10 +1,11 @@
 package io.snyk.plugin.snykcode.core
 
 import ai.deepcode.javaclient.core.DeepCodeParamsBase
+import com.intellij.openapi.diagnostic.Logger
 import io.snyk.plugin.getWaitForResultsTimeout
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.snykcode.codeRestApi
-import snyk.common.toSnykCodeApiUrl
+import io.snyk.plugin.toSnykCodeApiUrl
 
 class SnykCodeParams private constructor() : DeepCodeParamsBase(
     true,
@@ -21,8 +22,12 @@ class SnykCodeParams private constructor() : DeepCodeParamsBase(
 ) {
 
     init {
-        val apiUrl = toSnykCodeApiUrl(pluginSettings().customEndpointUrl)
-        setApiUrl(apiUrl, pluginSettings().ignoreUnknownCA)
+        val requestLogging = Logger.getInstance(SCLogger.presentableName).isDebugEnabled
+        setApiUrl(
+            toSnykCodeApiUrl(pluginSettings().customEndpointUrl),
+            pluginSettings().ignoreUnknownCA,
+            requestLogging
+        )
     }
 
     override fun consentGiven(project: Any): Boolean {

--- a/src/main/kotlin/io/snyk/plugin/snykcode/core/SnykCodeParams.kt
+++ b/src/main/kotlin/io/snyk/plugin/snykcode/core/SnykCodeParams.kt
@@ -20,7 +20,7 @@ class SnykCodeParams private constructor() : DeepCodeParamsBase(
     { getWaitForResultsTimeout() },
     codeRestApi
 ) {
-    fun requestLogging() = Logger.getInstance(SCLogger.presentableName + "RequestLogging").isDebugEnabled
+    private fun requestLogging() = Logger.getInstance(SCLogger.presentableName + "RequestLogging").isDebugEnabled
 
     init {
         setApiUrl(

--- a/src/main/kotlin/io/snyk/plugin/snykcode/core/SnykCodeParams.kt
+++ b/src/main/kotlin/io/snyk/plugin/snykcode/core/SnykCodeParams.kt
@@ -20,13 +20,13 @@ class SnykCodeParams private constructor() : DeepCodeParamsBase(
     { getWaitForResultsTimeout() },
     codeRestApi
 ) {
-    private val requestLogging = Logger.getInstance(SCLogger.presentableName + "RequestLogging").isDebugEnabled
+    fun requestLogging() = Logger.getInstance(SCLogger.presentableName + "RequestLogging").isDebugEnabled
 
     init {
         setApiUrl(
             toSnykCodeApiUrl(pluginSettings().customEndpointUrl),
             pluginSettings().ignoreUnknownCA,
-            requestLogging
+            requestLogging()
         )
     }
 
@@ -34,7 +34,7 @@ class SnykCodeParams private constructor() : DeepCodeParamsBase(
         setApiUrl(
             toSnykCodeApiUrl(apiUrl),
             pluginSettings().ignoreUnknownCA,
-            requestLogging
+            requestLogging()
         )
     }
 
@@ -42,7 +42,7 @@ class SnykCodeParams private constructor() : DeepCodeParamsBase(
         setApiUrl(
             toSnykCodeApiUrl(apiUrl),
             disableSslVerification,
-            requestLogging
+            requestLogging()
         )
     }
 


### PR DESCRIPTION
### Description

This PR enables HTTP request logging for the Snyk Code Client when the `SnykCode` logger is set to debug and enables to monitor / check API communication, thus.

### Checklist

- [ x ] Tests all succeed
- [ x ] Linted
- [ x ] CHANGELOG.md updated
- [ x ] README.md updated, if user-facing

### Screenshots / GIFs

