### PR TITLE
fix: generic .dcignore file creation failure and exceptions [ROAD-531]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Snyk Changelog
 
+## [2.4.28]
+
+### Fixed
+- generic .dcignore file creation failure and exceptions
+
 ## [2.4.27]
 
 ### Changed

--- a/src/main/kotlin/io/snyk/plugin/SnykPostStartupActivity.kt
+++ b/src/main/kotlin/io/snyk/plugin/SnykPostStartupActivity.kt
@@ -61,8 +61,6 @@ class SnykPostStartupActivity : StartupActivity.DumbAware {
             listenersActivated = true
         }
 
-        SnykCodeIgnoreInfoHolder.instance.createDcIgnoreIfNeeded(project)
-
         if (!ApplicationManager.getApplication().isUnitTestMode) {
             getSnykTaskQueueService(project)?.downloadLatestRelease()
         }

--- a/src/main/kotlin/io/snyk/plugin/services/SnykCodeService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykCodeService.kt
@@ -6,6 +6,7 @@ import io.snyk.plugin.events.SnykScanListener
 import io.snyk.plugin.getSyncPublisher
 import io.snyk.plugin.snykcode.core.RunUtils
 import io.snyk.plugin.snykcode.core.SCLogger
+import io.snyk.plugin.snykcode.core.SnykCodeIgnoreInfoHolder
 
 /**
  * Wrap work with SnykCode.
@@ -15,6 +16,7 @@ class SnykCodeService(val project: Project) {
 
     fun scan() {
         SCLogger.instance.logInfo("Re-Analyse Project requested for: $project")
+        SnykCodeIgnoreInfoHolder.instance.createDcIgnoreIfNeeded(project)
         RunUtils.instance.rescanInBackgroundCancellableDelayed(project, 0, false, false)
         getSyncPublisher(project, SnykScanListener.SNYK_SCAN_TOPIC)?.scanningStarted()
     }

--- a/src/main/kotlin/io/snyk/plugin/snykcode/core/SnykCodeIgnoreInfoHolder.kt
+++ b/src/main/kotlin/io/snyk/plugin/snykcode/core/SnykCodeIgnoreInfoHolder.kt
@@ -34,14 +34,22 @@ class SnykCodeIgnoreInfoHolder private constructor() : DeepCodeIgnoreInfoHolderB
         val prjBasePath = project.basePath
         val gitignore = File("$prjBasePath/.gitignore")
         val dcignore = File("$prjBasePath/.dcignore")
-        if (!gitignore.exists() && dcignore.createNewFile()) {
-            val fullDcIgnoreText = this.javaClass.classLoader.getResource("full.dcignore")
-                ?.readText()
-                ?: throw RuntimeException("full.dcignore can not be found in plugin's resources")
-            dcignore.writeText(fullDcIgnoreText)
-            SnykBalloonNotificationHelper.showInfo(
-                "We added generic .dcignore file to upload only project's source code.", project
-            )
+        if (!gitignore.exists()) {
+            val genericDcIgnoreFileCreated = try {
+                dcignore.createNewFile()
+            } catch (e: Exception) {
+                SCLogger.instance.logWarn("Failed to create generic .dcignore: $e")
+                false
+            }
+            if (genericDcIgnoreFileCreated) {
+                val fullDcIgnoreText = this.javaClass.classLoader.getResource("full.dcignore")
+                    ?.readText()
+                    ?: throw RuntimeException("full.dcignore can not be found in plugin's resources")
+                dcignore.writeText(fullDcIgnoreText)
+                SnykBalloonNotificationHelper.showInfo(
+                    "We added generic .dcignore file to upload only project's source code.", project
+                )
+            }
         }
     }
 


### PR DESCRIPTION
### Description

will fix #173 and related `IOException: Permission denied` exceptions

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [x] README.md updated, if user-facing

### Screenshots / GIFs
