### PR TITLE
fix: `IllegalArgumentException: wrong column` for issue's description panel creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Snyk Changelog
 
+## [2.4.29]
+
+### Fixed
+- `IllegalArgumentException: wrong column` for issue's description panel creation
+
 ## [2.4.28]
 
 ### Changed
@@ -7,7 +12,6 @@
 
 ### Fixed
 - generic .dcignore file creation failure and exceptions
-
 
 ## [2.4.27]
 

--- a/src/main/kotlin/io/snyk/plugin/ui/UIUtils.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/UIUtils.kt
@@ -216,7 +216,8 @@ fun descriptionHeaderPanel(
         cwes.size * 2 + // CWEs with `|`
         cves.size * 2 + // CVEs with `|`
         2 + // CVSS
-        2 // Snyk description
+        2 + // Snyk description
+        customLabels.size * 2 // Labels with `|`
     panel.layout = GridLayoutManager(1, columnCount, Insets(0, 0, 0, 0), 5, 0)
 
     panel.add(

--- a/src/test/kotlin/io/snyk/plugin/ui/UIUtilsTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/UIUtilsTest.kt
@@ -1,0 +1,15 @@
+package io.snyk.plugin.ui
+
+import org.junit.Test
+import javax.swing.JLabel
+
+class UIUtilsTest {
+
+    @Test
+    fun `descriptionHeaderPanel should not fail with customLabels`() {
+        descriptionHeaderPanel(
+            issueNaming = "test naming",
+            customLabels = (1..10).toList().map { JLabel(it.toString()) }
+        )
+    }
+}


### PR DESCRIPTION
will fix [IllegalArgumentException](https://sentry.io/organizations/snyk/issues/3211044785/?referrer=slack)

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [x] README.md updated, if user-facing
