### PR TITLE
fix: AlreadyDisposedException when annotations async refreshed for disposed project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Snyk Changelog
 
+## [2.4.29]
+
+### Fixed
+- AlreadyDisposedException when annotations async refreshed for disposed project
+
 ## [2.4.28]
 
 ### Changed
@@ -7,7 +12,6 @@
 
 ### Fixed
 - generic .dcignore file creation failure and exceptions
-
 
 ## [2.4.27]
 

--- a/src/main/kotlin/io/snyk/plugin/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/Utils.kt
@@ -257,6 +257,7 @@ fun findPsiFileIgnoringExceptions(virtualFile: VirtualFile, project: Project): P
     }
 
 fun refreshAnnotationsForOpenFiles(project: Project) {
+    if (project.isDisposed) return
     val openFiles = FileEditorManager.getInstance(project).openFiles
     FileContentUtil.reparseFiles(project, openFiles.asList(), true)
     openFiles.forEach {


### PR DESCRIPTION
will fix [AlreadyDisposedException](https://sentry.io/organizations/snyk/issues/3211453802/?referrer=slack)