### PR TITLE
fix: 🐛 url-encode proxy credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `IllegalArgumentException: wrong column` for issue's description panel creation
 - failed psiFile search for invalid virtualFile
 - `InvocationTargetExceptions` by extracting caches to separate class
+- URL encode proxy credentials
 
 ## [2.4.28]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,19 @@
 # Snyk Changelog
 
+## [2.4.30]
+
+### Fixed
+
+- URL encode proxy credentials
+
 ## [2.4.29]
 
 ### Fixed
+
 - AlreadyDisposedException when annotations async refreshed for disposed project
 - `IllegalArgumentException: wrong column` for issue's description panel creation
 - failed psiFile search for invalid virtualFile
 - `InvocationTargetExceptions` by extracting caches to separate class
-- URL encode proxy credentials
 
 ## [2.4.28]
 

--- a/src/integTest/kotlin/io/snyk/plugin/cli/ConsoleCommandRunnerTest.kt
+++ b/src/integTest/kotlin/io/snyk/plugin/cli/ConsoleCommandRunnerTest.kt
@@ -32,6 +32,7 @@ import org.junit.Test
 import snyk.PLUGIN_ID
 import snyk.errorHandler.SentryErrorReporter
 import snyk.oss.OssService
+import java.net.URLEncoder
 import java.util.concurrent.TimeUnit
 
 class ConsoleCommandRunnerTest : LightPlatformTestCase() {
@@ -127,11 +128,13 @@ class ConsoleCommandRunnerTest : LightPlatformTestCase() {
             httpConfigurable.USE_HTTP_PROXY = true
             httpConfigurable.PROXY_AUTHENTICATION = true
             httpConfigurable.proxyLogin = "testLogin"
-            httpConfigurable.plainProxyPassword = "testPassword"
+            httpConfigurable.plainProxyPassword = "test%!@Password"
+            val encodedLogin = URLEncoder.encode(httpConfigurable.proxyLogin, "UTF-8")
+            val encodedPassword = URLEncoder.encode(httpConfigurable.plainProxyPassword, "UTF-8")
 
             val generalCommandLine = GeneralCommandLine("")
-            val expectedProxy = "http://${httpConfigurable.proxyLogin}:${httpConfigurable.plainProxyPassword}@" +
-                "${httpConfigurable.PROXY_HOST}:${httpConfigurable.PROXY_PORT}"
+            val expectedProxy =
+                "http://${encodedLogin}:${encodedPassword}@${httpConfigurable.PROXY_HOST}:${httpConfigurable.PROXY_PORT}"
 
             ConsoleCommandRunner().setupCliEnvironmentVariables(generalCommandLine, "")
 
@@ -178,8 +181,7 @@ class ConsoleCommandRunnerTest : LightPlatformTestCase() {
                     downloadIndicator = indicator
                     snykCliDownloaderService.downloadLatestRelease(indicator, project)
                 }
-            },
-            EmptyProgressIndicator()
+            }, EmptyProgressIndicator()
         )
 
         assertFalse("CLI binary should NOT exist at this stage", cliFile.exists())
@@ -203,9 +205,7 @@ class ConsoleCommandRunnerTest : LightPlatformTestCase() {
                         // this is expected and actually desired
                     }
                 }
-            },
-            EmptyProgressIndicator(),
-            null
+            }, EmptyProgressIndicator(), null
         )
 
         testRunFuture.get(30000, TimeUnit.MILLISECONDS)
@@ -238,13 +238,10 @@ class ConsoleCommandRunnerTest : LightPlatformTestCase() {
                 override fun run(indicator: ProgressIndicator) {
                     val output = ConsoleCommandRunner().execute(sleepCommand, getPluginPath(), "", project)
                     assertTrue(
-                        "Should get timeout error, but received:\n$output",
-                        output.startsWith("Execution timeout")
+                        "Should get timeout error, but received:\n$output", output.startsWith("Execution timeout")
                     )
                 }
-            },
-            EmptyProgressIndicator(),
-            null
+            }, EmptyProgressIndicator(), null
         )
         testRunFuture.get(30000, TimeUnit.MILLISECONDS)
 

--- a/src/main/kotlin/io/snyk/plugin/cli/ConsoleCommandRunner.kt
+++ b/src/main/kotlin/io/snyk/plugin/cli/ConsoleCommandRunner.kt
@@ -17,6 +17,7 @@ import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.ui.SnykBalloonNotificationHelper
 import snyk.errorHandler.SentryErrorReporter
 import snyk.pluginInfo
+import java.net.URLEncoder
 import java.nio.charset.Charset
 
 open class ConsoleCommandRunner {
@@ -72,9 +73,7 @@ open class ConsoleCommandRunner {
         val timeout = getWaitForResultsTimeout()
         val processOutput = try {
             ScriptRunnerUtil.getProcessOutput(
-                processHandler,
-                ScriptRunnerUtil.STDOUT_OR_STDERR_OUTPUT_KEY_FILTER,
-                timeout
+                processHandler, ScriptRunnerUtil.STDOUT_OR_STDERR_OUTPUT_KEY_FILTER, timeout
             )
         } catch (e: ExecutionException) {
             SentryErrorReporter.captureException(e)
@@ -108,9 +107,10 @@ open class ConsoleCommandRunner {
         if (proxySettings != null && proxySettings.USE_HTTP_PROXY && proxyHost.isNotEmpty()) {
             var authentication = ""
             if (proxySettings.PROXY_AUTHENTICATION) {
-                val auth =
-                    proxySettings.getPromptedAuthentication(proxyHost, "Snyk: Please enter your proxy password")
-                authentication = auth.userName + ":" + String(auth.password) + "@"
+                val auth = proxySettings.getPromptedAuthentication(proxyHost, "Snyk: Please enter your proxy password")
+                authentication = URLEncoder.encode(auth.userName, "UTF-8") + ":" + URLEncoder.encode(
+                    String(auth.password), "UTF-8"
+                ) + "@"
             }
             commandLine.environment["http_proxy"] = "http://$authentication$proxyHost:${proxySettings.PROXY_PORT}"
             commandLine.environment["https_proxy"] = "http://$authentication$proxyHost:${proxySettings.PROXY_PORT}"


### PR DESCRIPTION
### Description

Proxy credentials are part of the URI put into proxy environment variables. Thus, they need to be URL encoded.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated

### Screenshots / GIFs

