### PR TITLE
fix: plugin first-time-run issues [ROAD-731]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Fixed
 
 - URL encode proxy credentials
+- Honoring user's product selection on welcome screen before first ever scan
+- Proper message when Code product is disabled due to unreachable org settings on backend
+- Auth screen has priority to be shown in case of invalid/empty token
+- Code scan endpoint url was internally corrupted after any Snyk settings change
 
 ## [2.4.29]
 

--- a/src/integTest/kotlin/io/snyk/plugin/TestUtils.kt
+++ b/src/integTest/kotlin/io/snyk/plugin/TestUtils.kt
@@ -3,8 +3,15 @@ package io.snyk.plugin
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.testFramework.replaceService
+import com.intellij.util.io.RequestBuilder
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.mockkObject
 import io.snyk.plugin.services.SnykApplicationSettingsStateService
 import io.snyk.plugin.services.SnykProjectSettingsStateService
+import io.snyk.plugin.services.download.CliDownloader
+import io.snyk.plugin.services.download.HttpRequestHelper
 
 fun setupDummyCliFile() {
     val cliFile = getCliFile()
@@ -34,4 +41,12 @@ fun resetSettings(project: Project?) {
         SnykProjectSettingsStateService(),
         project
     )
+}
+
+/** low level avoiding download the CLI file */
+fun mockCliDownload() {
+    val requestBuilderMockk = mockk<RequestBuilder>(relaxed = true)
+    justRun { requestBuilderMockk.saveToFile(any(), any()) }
+    mockkObject(HttpRequestHelper)
+    every { HttpRequestHelper.createRequest(CliDownloader.LATEST_RELEASE_DOWNLOAD_URL) } returns requestBuilderMockk
 }

--- a/src/integTest/kotlin/io/snyk/plugin/services/CliAdapterTest.kt
+++ b/src/integTest/kotlin/io/snyk/plugin/services/CliAdapterTest.kt
@@ -31,24 +31,6 @@ class CliAdapterTest : LightPlatformTestCase() {
     }
 
     @Test
-    fun testIsCliInstalledFailed() {
-        removeDummyCliFile()
-
-        val isCliInstalled = isCliInstalled()
-
-        assertFalse(isCliInstalled)
-    }
-
-    @Test
-    fun testIsCliInstalledSuccess() {
-        setupDummyCliFile()
-
-        val isCliInstalled = isCliInstalled()
-
-        assertTrue(isCliInstalled)
-    }
-
-    @Test
     fun testBuildCliCommandsListWithInsecureParameter() {
         setupDummyCliFile()
 

--- a/src/main/kotlin/io/snyk/plugin/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/Utils.kt
@@ -81,7 +81,7 @@ fun getSnykProjectSettingsService(project: Project): SnykProjectSettingsStateSer
 
 fun getCliFile() = File(getPluginPath(), Platform.current().snykWrapperFileName)
 
-fun isCliInstalled(): Boolean = getCliFile().exists()
+fun isCliInstalled(): Boolean = ApplicationManager.getApplication().isUnitTestMode || getCliFile().exists()
 
 fun pluginSettings(): SnykApplicationSettingsStateService = getApplicationService()
 

--- a/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
@@ -42,7 +42,7 @@ class SnykApplicationSettingsStateService : PersistentStateComponent<SnykApplica
     var containerScanEnabled: Boolean = true
 
     var sastOnServerEnabled: Boolean? = null
-    var localCodeEngineEnabled: Boolean? = false
+    var localCodeEngineEnabled: Boolean? = null
     var reportFalsePositivesEnabled: Boolean? = null
     var usageAnalyticsEnabled = true
     var crashReportingEnabled = true

--- a/src/main/kotlin/io/snyk/plugin/services/download/CliDownloader.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/download/CliDownloader.kt
@@ -4,7 +4,6 @@ import com.intellij.openapi.progress.ProgressIndicator
 import io.snyk.plugin.cli.Platform
 import io.snyk.plugin.services.download.HttpRequestHelper.createRequest
 import java.io.File
-import java.net.URL
 import java.nio.file.AtomicMoveNotSupportedException
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
@@ -15,8 +14,8 @@ class CliDownloader {
     companion object {
         const val BASE_URL = "https://static.snyk.io"
         const val LATEST_RELEASES_URL = "$BASE_URL/cli/latest/version"
-        const val LATEST_RELEASE_DOWNLOAD_URL = "$BASE_URL/cli/latest/%s"
-        const val SHA256_DOWNLOAD_URL = "$BASE_URL/cli/latest/%s.sha256"
+        val LATEST_RELEASE_DOWNLOAD_URL = "$BASE_URL/cli/latest/${Platform.current().snykWrapperFileName}"
+        val SHA256_DOWNLOAD_URL = "$BASE_URL/cli/latest/${Platform.current().snykWrapperFileName}.sha256"
     }
 
     fun calculateSha256(bytes: ByteArray): String {
@@ -39,10 +38,8 @@ class CliDownloader {
         try {
             downloadFile.deleteOnExit()
 
-            val url = URL(String.format(LATEST_RELEASE_DOWNLOAD_URL, Platform.current().snykWrapperFileName)).toString()
-
             indicator.checkCanceled()
-            createRequest(url).saveToFile(downloadFile, indicator)
+            createRequest(LATEST_RELEASE_DOWNLOAD_URL).saveToFile(downloadFile, indicator)
 
             indicator.checkCanceled()
             verifyChecksum(expectedSha, downloadFile.readBytes())
@@ -72,8 +69,7 @@ class CliDownloader {
     }
 
     fun expectedSha(): String {
-        val url = String.format(SHA256_DOWNLOAD_URL, Platform.current().snykWrapperFileName)
-        val request = createRequest(url)
+        val request = createRequest(SHA256_DOWNLOAD_URL)
         return request.readString().split(" ")[0]
     }
 }

--- a/src/main/kotlin/io/snyk/plugin/settings/SnykProjectSettingsConfigurable.kt
+++ b/src/main/kotlin/io/snyk/plugin/settings/SnykProjectSettingsConfigurable.kt
@@ -45,7 +45,7 @@ class SnykProjectSettingsConfigurable(val project: Project) : SearchableConfigur
         }
 
         applicationSettingsStateService.customEndpointUrl = customEndpoint
-        SnykCodeParams.instance.apiUrl = toSnykCodeApiUrl(customEndpoint)
+        SnykCodeParams.instance.apiUrl = customEndpoint
         SnykCodeParams.instance.isDisableSslVerification = snykSettingsDialog.isIgnoreUnknownCA()
 
         applicationSettingsStateService.token = snykSettingsDialog.getToken()

--- a/src/main/kotlin/io/snyk/plugin/ui/UIUtils.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/UIUtils.kt
@@ -84,12 +84,16 @@ fun insertTitleAndResizableTextIntoPanelColumns(
     )
 }
 
-fun snykCodeAvailabilityPostfix(): String = when {
-    !isSnykCodeAvailable(pluginSettings().customEndpointUrl) -> " (disabled for endpoint)"
-    (pluginSettings().sastOnServerEnabled ?: true && pluginSettings().localCodeEngineEnabled ?: true) ->
-        " (disabled due to Local Code Engine)"
-    !(pluginSettings().sastOnServerEnabled ?: false) -> " (disabled in Snyk.io)"
-    else -> ""
+fun snykCodeAvailabilityPostfix(): String {
+    val sastOnServerEnabled = pluginSettings().sastOnServerEnabled
+    val localCodeEngineEnabled = pluginSettings().localCodeEngineEnabled
+    return when {
+        !isSnykCodeAvailable(pluginSettings().customEndpointUrl) -> " (disabled for endpoint)"
+        (sastOnServerEnabled == null && localCodeEngineEnabled == null) -> " (disabled due to unreachable server settings)"
+        (sastOnServerEnabled != false && localCodeEngineEnabled == true) -> " (disabled due to Local Code Engine)"
+        sastOnServerEnabled != true -> " (disabled in Snyk.io)"
+        else -> ""
+    }
 }
 
 fun getReadOnlyClickableHtmlJEditorPane(

--- a/src/main/kotlin/io/snyk/plugin/ui/actions/SnykTreeScanTypeFilterAction.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/actions/SnykTreeScanTypeFilterAction.kt
@@ -27,7 +27,7 @@ class SnykTreeScanTypeFilterAction : ComboBoxAction() {
 
     override fun update(e: AnActionEvent) {
         val project = e.project
-        e.presentation.isEnabled = project != null && !project.isDisposed
+        e.presentation.isEnabled = project != null && !project.isDisposed && !settings.token.isNullOrEmpty()
     }
 
     override fun createPopupActionGroup(button: JComponent?): DefaultActionGroup {
@@ -55,8 +55,7 @@ class SnykTreeScanTypeFilterAction : ComboBoxAction() {
         }
     }
 
-    private fun isSnykCodeAvailable(): Boolean =
-        snyk.common.isSnykCodeAvailable(settings.customEndpointUrl) && (settings.sastOnServerEnabled ?: false)
+    private fun isSnykCodeAvailable(): Boolean = snykCodeAvailabilityPostfix().isEmpty()
 
     private fun showSettings(project: Project) {
         ShowSettingsUtil.getInstance().showSettingsDialog(project, SnykProjectSettingsConfigurable::class.java)
@@ -64,7 +63,8 @@ class SnykTreeScanTypeFilterAction : ComboBoxAction() {
 
     private fun createSecurityIssuesScanAction(): AnAction {
         return object : ToggleAction("Security Issues${snykCodeAvailabilityPostfix()}") {
-            override fun isSelected(e: AnActionEvent): Boolean = settings.snykCodeSecurityIssuesScanEnable
+            override fun isSelected(e: AnActionEvent): Boolean =
+                settings.snykCodeSecurityIssuesScanEnable && isSnykCodeAvailable()
 
             override fun setSelected(e: AnActionEvent, state: Boolean) {
                 if (!state && isLastScanTypeDisabling(e)) return
@@ -79,7 +79,8 @@ class SnykTreeScanTypeFilterAction : ComboBoxAction() {
 
     private fun createQualityIssuesScanAction(): AnAction {
         return object : ToggleAction("Quality Issues${snykCodeAvailabilityPostfix()}") {
-            override fun isSelected(e: AnActionEvent): Boolean = settings.snykCodeQualityIssuesScanEnable
+            override fun isSelected(e: AnActionEvent): Boolean =
+                settings.snykCodeQualityIssuesScanEnable && isSnykCodeAvailable()
 
             override fun setSelected(e: AnActionEvent, state: Boolean) {
                 if (!state && isLastScanTypeDisabling(e)) return

--- a/src/test/kotlin/io/snyk/plugin/TestUtils.kt
+++ b/src/test/kotlin/io/snyk/plugin/TestUtils.kt
@@ -1,0 +1,17 @@
+package io.snyk.plugin
+
+import com.intellij.util.io.RequestBuilder
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.snyk.plugin.services.download.CliDownloader
+import io.snyk.plugin.services.download.HttpRequestHelper
+
+/** low level avoiding download the CLI file */
+fun mockCliDownload() {
+    val requestBuilderMockk = mockk<RequestBuilder>(relaxed = true)
+    justRun { requestBuilderMockk.saveToFile(any(), any()) }
+    mockkObject(HttpRequestHelper)
+    every { HttpRequestHelper.createRequest(CliDownloader.LATEST_RELEASE_DOWNLOAD_URL) } returns requestBuilderMockk
+}

--- a/src/test/kotlin/io/snyk/plugin/services/download/CliDownloaderTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/services/download/CliDownloaderTest.kt
@@ -1,12 +1,11 @@
 package io.snyk.plugin.services.download
 
-import com.intellij.util.Url
-import com.intellij.util.io.HttpRequests
 import io.mockk.every
-import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
+import io.snyk.plugin.cli.Platform
+import io.snyk.plugin.mockCliDownload
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.services.SnykApplicationSettingsStateService
 import junit.framework.TestCase.assertEquals
@@ -52,12 +51,18 @@ class CliDownloaderTest {
 
     @Test
     fun `should download cli information from base url`() {
-        assertEquals("${CliDownloader.BASE_URL}/cli/latest/%s", CliDownloader.LATEST_RELEASE_DOWNLOAD_URL)
+        assertEquals(
+            "${CliDownloader.BASE_URL}/cli/latest/${Platform.current().snykWrapperFileName}",
+            CliDownloader.LATEST_RELEASE_DOWNLOAD_URL
+        )
     }
 
     @Test
     fun `should download sha256 from base url`() {
-        assertEquals("${CliDownloader.BASE_URL}/cli/latest/%s.sha256", CliDownloader.SHA256_DOWNLOAD_URL)
+        assertEquals(
+            "${CliDownloader.BASE_URL}/cli/latest/${Platform.current().snykWrapperFileName}.sha256",
+            CliDownloader.SHA256_DOWNLOAD_URL
+        )
     }
 
     @Test
@@ -68,10 +73,8 @@ class CliDownloaderTest {
         Files.write(testFile.toPath(), dummyContent)
         val cut = CliDownloader()
         val expectedSha = cut.calculateSha256("wrong sha".toByteArray())
-        mockkStatic(HttpRequests::class)
-        justRun {
-            HttpRequests.request(any<Url>()).productNameAsUserAgent().saveToFile(any<File>(), any())
-        }
+
+        mockCliDownload()
 
         try {
             cut.downloadFile(testFile, expectedSha, mockk(relaxed = true))


### PR DESCRIPTION
- Honoring user's product selection on welcome screen before first ever scan
- Proper message when Code product is disabled due to unreachable org settings on backend
- Auth screen has priority to be shown in case of invalid/empty token
- Code scan endpoint url was internally corrupted after any Snyk settings change

chore: tests refactoring and improvement, also do only one actual CLI download test and use mocks in other tests

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [x] README.md updated, if user-facing
