### PR TITLE
fix: Empty (or cancelled request for) proxy credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Snyk Changelog
 
+## [2.4.31]
+
+### Fixed
+
+- Empty (or cancelled request for) proxy credentials
+
 ## [2.4.30]
 
 ### Fixed

--- a/src/integTest/kotlin/io/snyk/plugin/cli/ConsoleCommandRunnerTest.kt
+++ b/src/integTest/kotlin/io/snyk/plugin/cli/ConsoleCommandRunnerTest.kt
@@ -152,6 +152,41 @@ class ConsoleCommandRunnerTest : LightPlatformTestCase() {
     }
 
     @Test
+    fun testSetupCliEnvironmentVariablesWithProxyWithCancelledAuth() {
+        val httpConfigurable = HttpConfigurable.getInstance()
+        val originalProxyHost = httpConfigurable.PROXY_HOST
+        val originalProxyPort = httpConfigurable.PROXY_PORT
+        val originalUseProxy = httpConfigurable.USE_HTTP_PROXY
+        val originalProxyAuthentication = httpConfigurable.PROXY_AUTHENTICATION
+        val originalAuthenticationCancelled = httpConfigurable.AUTHENTICATION_CANCELLED
+        val originalLogin = httpConfigurable.proxyLogin
+        val originalPassword = httpConfigurable.plainProxyPassword
+        try {
+            httpConfigurable.PROXY_PORT = 3128
+            httpConfigurable.PROXY_HOST = "testProxy"
+            httpConfigurable.USE_HTTP_PROXY = true
+            httpConfigurable.PROXY_AUTHENTICATION = true
+            httpConfigurable.AUTHENTICATION_CANCELLED = true
+
+            val generalCommandLine = GeneralCommandLine("")
+            val expectedProxy =
+                "http://${httpConfigurable.PROXY_HOST}:${httpConfigurable.PROXY_PORT}"
+
+            ConsoleCommandRunner().setupCliEnvironmentVariables(generalCommandLine, "")
+
+            assertEquals(expectedProxy, generalCommandLine.environment["https_proxy"])
+        } finally {
+            httpConfigurable.USE_HTTP_PROXY = originalUseProxy
+            httpConfigurable.PROXY_HOST = originalProxyHost
+            httpConfigurable.PROXY_PORT = originalProxyPort
+            httpConfigurable.PROXY_AUTHENTICATION = originalProxyAuthentication
+            httpConfigurable.AUTHENTICATION_CANCELLED = originalAuthenticationCancelled
+            httpConfigurable.proxyLogin = originalLogin
+            httpConfigurable.plainProxyPassword = originalPassword
+        }
+    }
+
+    @Test
     fun testSetupCliEnvironmentVariables() {
         val generalCommandLine = GeneralCommandLine("")
         val snykPluginVersion = PluginManagerCore.getPlugin(PluginId.getId(PLUGIN_ID))?.version ?: "UNKNOWN"

--- a/src/main/kotlin/io/snyk/plugin/cli/ConsoleCommandRunner.kt
+++ b/src/main/kotlin/io/snyk/plugin/cli/ConsoleCommandRunner.kt
@@ -105,17 +105,16 @@ open class ConsoleCommandRunner {
         val proxySettings = HttpConfigurable.getInstance()
         val proxyHost = proxySettings.PROXY_HOST
         if (proxySettings != null && proxySettings.USE_HTTP_PROXY && proxyHost.isNotEmpty()) {
-            var authentication = ""
-            if (proxySettings.PROXY_AUTHENTICATION) {
+            val authentication = if (proxySettings.PROXY_AUTHENTICATION) {
                 val auth = proxySettings.getPromptedAuthentication(proxyHost, "Snyk: Please enter your proxy password")
-                authentication = URLEncoder.encode(auth.userName, "UTF-8") + ":" + URLEncoder.encode(
-                    String(auth.password), "UTF-8"
-                ) + "@"
-            }
+                if (auth == null) "" else auth.userName.urlEncode() + ":" + String(auth.password).urlEncode() + "@"
+            } else ""
             commandLine.environment["http_proxy"] = "http://$authentication$proxyHost:${proxySettings.PROXY_PORT}"
             commandLine.environment["https_proxy"] = "http://$authentication$proxyHost:${proxySettings.PROXY_PORT}"
         }
     }
+
+    private fun String.urlEncode() = URLEncoder.encode(this, "UTF-8")
 
     companion object {
         const val PROCESS_CANCELLED_BY_USER = "PROCESS_CANCELLED_BY_USER"


### PR DESCRIPTION
Will fix [IllegalStateException](https://sentry.io/organizations/snyk/issues/3261803243/?referrer=slack)