### PR TITLE
fix: for Snyk Code multi-file issues code snippet in some data flow steps shown from wrong file [ROAD-846]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Empty (or cancelled request for) proxy credentials
 - `IllegalStateException` when no `Document` found for invalid(obsolete) file
+- For Snyk Code multi-file issues code snippet in some data flow steps shown from wrong file
 
 ## [2.4.30]
 

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SuggestionDescriptionPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SuggestionDescriptionPanel.kt
@@ -241,7 +241,7 @@ class SuggestionDescriptionPanel(
         }
         stepPanel.add(positionLabel, baseGridConstraintsAnchorWest(0, indent = 1))
 
-        val codeLine = codeLine(markerRange, snykCodeFile)
+        val codeLine = codeLine(markerRange, fileToNavigate)
         codeLine.isOpaque = false
         stepPanel.add(
             codeLine,


### PR DESCRIPTION
It's a bug of UI presentation for correct underlying data, so UI tests are omitted and check done manually.
![image](https://user-images.githubusercontent.com/14268320/167851340-ae201e13-fee2-4fd7-bbf3-1dde47627e83.png)
