### PR TITLE
fix: `IllegalStateException` when no `Document` found for invalid(obsolete) file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Empty (or cancelled request for) proxy credentials
+- `IllegalStateException` when no `Document` found for invalid(obsolete) file
 
 ## [2.4.30]
 

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SuggestionDescriptionPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SuggestionDescriptionPanel.kt
@@ -125,7 +125,7 @@ class SuggestionDescriptionPanel(
     private fun getLineOfCode(range: MyTextRange, file: SnykCodeFile?): String {
         if (file == null) return "<File Not Found>"
         val document = PDU.toPsiFile(file)?.let { PsiDocumentManager.getInstance(file.project).getDocument(it) }
-            ?: throw IllegalStateException("No document found for ${file.virtualFile.path}")
+            ?: return "<No Document Found>"
         val chars = document.charsSequence
         val startOffset = range.start
         val textLength = document.textLength

--- a/src/test/kotlin/snyk/common/IgnoreServiceTest.kt
+++ b/src/test/kotlin/snyk/common/IgnoreServiceTest.kt
@@ -9,6 +9,7 @@ import io.mockk.verify
 import io.snyk.plugin.cli.CliNotExistsException
 import io.snyk.plugin.cli.ConsoleCommandRunner
 import io.snyk.plugin.getCliFile
+import io.snyk.plugin.isCliInstalled
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.services.SnykApplicationSettingsStateService
 import junit.framework.TestCase.assertEquals
@@ -33,6 +34,7 @@ class IgnoreServiceTest {
 
         every { pluginSettings() } returns settings
         every { getCliFile() } returns File.createTempFile("cliTestTmpFile", ".tmp")
+        every { isCliInstalled() } returns true
         every { project.basePath } returns expectedWorkingDirectory
         every { settings.token } returns expectedApiToken
         every { settings.getAdditionalParameters() } returns ""


### PR DESCRIPTION
will fix [IllegalStateException](https://sentry.io/organizations/snyk/issues/3267773115/?referrer=slack)