### PR TITLE
feat: Show specific description when no IaC or OSS files found but corresponded scan performed [ROAD-644]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Snyk Changelog
 
+## [2.4.32]
+
+### Changed
+- Show specific description when no IaC or OSS files found but corresponded scan performed
+
 ## [2.4.31]
 
 ### Fixed

--- a/src/main/kotlin/io/snyk/plugin/ui/UIUtils.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/UIUtils.kt
@@ -19,6 +19,8 @@ import java.awt.Container
 import java.awt.Dimension
 import java.awt.Font
 import java.awt.Insets
+import java.util.regex.Matcher
+import java.util.regex.Pattern
 import javax.swing.ImageIcon
 import javax.swing.JComponent
 import javax.swing.JEditorPane
@@ -341,4 +343,37 @@ fun wrapWithScrollPane(panel: JPanel): JScrollPane {
         }, 100
     )
     return scrollPane
+}
+
+// "stolen" from https://stackoverflow.com/a/12053940/7577274
+fun txtToHtml(s: String): String {
+    val builder = StringBuilder()
+    var previousWasASpace = false
+    for (c in s.toCharArray()) {
+        if (c == ' ') {
+            if (previousWasASpace) {
+                builder.append("&nbsp;")
+                previousWasASpace = false
+                continue
+            }
+            previousWasASpace = true
+        } else {
+            previousWasASpace = false
+        }
+        when (c) {
+            '<' -> builder.append("&lt;")
+            '>' -> builder.append("&gt;")
+            '&' -> builder.append("&amp;")
+            '"' -> builder.append("&quot;")
+            '\n' -> builder.append("<br>")
+            '\t' -> builder.append("&nbsp; &nbsp; &nbsp;")
+            else -> builder.append(c)
+        }
+    }
+    var converted = builder.toString()
+    val str = "(?i)\\b((?:https?://|www\\d{0,3}[.]|[a-z0-9.\\-]+[.][a-z]{2,4}/)(?:[^\\s()<>]+|\\(([^\\s()<>]+|(\\([^\\s()<>]+\\)))*\\))+(?:\\(([^\\s()<>]+|(\\([^\\s()<>]+\\)))*\\)|[^\\s`!()\\[\\]{};:\'\".,<>?«»“”‘’]))"
+    val patt: Pattern = Pattern.compile(str)
+    val matcher: Matcher = patt.matcher(converted)
+    converted = matcher.replaceAll("<a href=\"$1\">$1</a>")
+    return converted
 }

--- a/src/main/kotlin/io/snyk/plugin/ui/UIUtils.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/UIUtils.kt
@@ -13,6 +13,7 @@ import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.UIUtil
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.ui.toolwindow.LabelProvider
+import org.apache.commons.lang.StringEscapeUtils
 import snyk.common.isSnykCodeAvailable
 import java.awt.Color
 import java.awt.Container
@@ -345,35 +346,14 @@ fun wrapWithScrollPane(panel: JPanel): JScrollPane {
     return scrollPane
 }
 
-// "stolen" from https://stackoverflow.com/a/12053940/7577274
 fun txtToHtml(s: String): String {
-    val builder = StringBuilder()
-    var previousWasASpace = false
-    for (c in s.toCharArray()) {
-        if (c == ' ') {
-            if (previousWasASpace) {
-                builder.append("&nbsp;")
-                previousWasASpace = false
-                continue
-            }
-            previousWasASpace = true
-        } else {
-            previousWasASpace = false
-        }
-        when (c) {
-            '<' -> builder.append("&lt;")
-            '>' -> builder.append("&gt;")
-            '&' -> builder.append("&amp;")
-            '"' -> builder.append("&quot;")
-            '\n' -> builder.append("<br>")
-            '\t' -> builder.append("&nbsp; &nbsp; &nbsp;")
-            else -> builder.append(c)
-        }
-    }
-    var converted = builder.toString()
+    val escapedHtml = StringEscapeUtils.escapeHtml(s)
+    val newLineConverted = escapedHtml
+        .replace("\n", "<br>")
+        .replace("\t", "&nbsp; &nbsp; &nbsp;")
+    // html link converter "stolen" from https://stackoverflow.com/a/12053940/7577274
     val str = "(?i)\\b((?:https?://|www\\d{0,3}[.]|[a-z0-9.\\-]+[.][a-z]{2,4}/)(?:[^\\s()<>]+|\\(([^\\s()<>]+|(\\([^\\s()<>]+\\)))*\\))+(?:\\(([^\\s()<>]+|(\\([^\\s()<>]+\\)))*\\)|[^\\s`!()\\[\\]{};:\'\".,<>?«»“”‘’]))"
     val patt: Pattern = Pattern.compile(str)
-    val matcher: Matcher = patt.matcher(converted)
-    converted = matcher.replaceAll("<a href=\"$1\">$1</a>")
-    return converted
+    val matcher: Matcher = patt.matcher(newLineConverted)
+    return matcher.replaceAll("<a href=\"$1\">$1</a>")
 }


### PR DESCRIPTION
1. if no file supported by IaC is found, on click on the IaC root node in the tree, the vulnerability description panel should display the following text  (from CLI): `Could not find any valid IaC files`
2. if no file supported by OSS is found, on click on the OSS root node in the tree, the vulnerability description panel should display the following text (from CLI): `Could not detect supported target files in <project-path>.\nPlease see our documentation for supported languages and target files: https://snyk.co/udVgQ and make sure you are in the right directory.`

![image](https://user-images.githubusercontent.com/14268320/169088646-9ac2a758-3d97-436a-bf63-02c830da64c2.png)

![image](https://user-images.githubusercontent.com/14268320/169088469-9136705a-b70a-4053-8e68-556a2a72526d.png)
