### PR TITLE
fix: array of successful and failed scan results parsing/presentation [ROAD-567]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Snyk Changelog
 
+## [2.4.34]
+
+### Fixed
+- All failed scan results for artifacts(file, image) are now shown in the results(Tree) too (right after successful scan results).
+
 ## [2.4.33]
 
 ### Fixed

--- a/src/integTest/kotlin/io/snyk/plugin/services/CliAdapterTest.kt
+++ b/src/integTest/kotlin/io/snyk/plugin/services/CliAdapterTest.kt
@@ -1,21 +1,28 @@
 package io.snyk.plugin.services
 
 import com.intellij.testFramework.LightPlatformTestCase
-import io.snyk.plugin.isCliInstalled
+import io.snyk.plugin.Severity
+import io.snyk.plugin.cli.CliResult
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.removeDummyCliFile
 import io.snyk.plugin.resetSettings
 import io.snyk.plugin.setupDummyCliFile
 import org.junit.Test
+import snyk.common.SnykError
 
 class CliAdapterTest : LightPlatformTestCase() {
 
     private val dummyCliAdapter by lazy {
-        object : CliAdapter<Any>(project) {
-            override fun getErrorResult(errorMsg: String): Any = Unit
-            override fun convertRawCliStringToCliResult(rawStr: String): Any = Unit
+        object : CliAdapter<Unit, DummyResults>(project) {
+            override fun getProductResult(cliIssues: List<Unit>?, snykErrors: List<SnykError>) = DummyResults()
+            override fun getCliIIssuesClass(): Class<Unit> = Unit::class.java
             override fun buildExtraOptions(): List<String> = emptyList()
         }
+    }
+
+    inner class DummyResults : CliResult<Unit>(null, emptyList()) {
+        override val issuesCount: Int? = null
+        override fun countBySeverity(severity: Severity): Int? = null
     }
 
     @Throws(Exception::class)

--- a/src/integTest/kotlin/io/snyk/plugin/services/SnykTaskQueueServiceTest.kt
+++ b/src/integTest/kotlin/io/snyk/plugin/services/SnykTaskQueueServiceTest.kt
@@ -79,7 +79,7 @@ class SnykTaskQueueServiceTest : LightPlatformTestCase() {
         service<SnykCliDownloaderService>().downloader = downloaderMock
         every { downloaderMock.expectedSha() } returns "test"
         every { downloaderMock.downloadFile(any(), any(), any()) } returns cliFile
-        every { getOssService(project)?.scan() } returns OssResult(null, null)
+        every { getOssService(project)?.scan() } returns OssResult(null)
 
         val settings = pluginSettings()
         settings.ossScanEnable = true
@@ -162,8 +162,9 @@ class SnykTaskQueueServiceTest : LightPlatformTestCase() {
         settings.snykCodeSecurityIssuesScanEnable = false
         settings.snykCodeQualityIssuesScanEnable = false
         settings.iacScanEnabled = true
+        getSnykCachedResults(project)?.currentIacResult = null
 
-        val fakeIacResult = IacResult(null, null)
+        val fakeIacResult = IacResult(emptyList())
 
         mockkStatic("io.snyk.plugin.UtilsKt")
         every { isIacEnabled() } returns true
@@ -180,7 +181,7 @@ class SnykTaskQueueServiceTest : LightPlatformTestCase() {
         mockkStatic("io.snyk.plugin.UtilsKt")
         every { isContainerEnabled() } returns true
         every { isCliInstalled() } returns true
-        val fakeContainerResult = ContainerResult(null, null)
+        val fakeContainerResult = ContainerResult(emptyList())
         every { getContainerService(project)?.scan() } returns fakeContainerResult
 
         val snykTaskQueueService = project.service<SnykTaskQueueService>()
@@ -191,7 +192,7 @@ class SnykTaskQueueServiceTest : LightPlatformTestCase() {
         settings.iacScanEnabled = false
         settings.containerScanEnabled = true
 
-        assertEquals(null, getSnykCachedResults(project)?.currentContainerResult)
+        getSnykCachedResults(project)?.currentContainerResult = null
 
         snykTaskQueueService.scan()
 

--- a/src/integTest/kotlin/snyk/container/ContainerBulkFileListenerTest.kt
+++ b/src/integTest/kotlin/snyk/container/ContainerBulkFileListenerTest.kt
@@ -136,7 +136,7 @@ class ContainerBulkFileListenerTest : BasePlatformTestCase() {
                 virtualFile = addedPsiFile.virtualFile
             ))
         )
-        val fakeContainerResult = ContainerResult(listOf(issuesForImage), null)
+        val fakeContainerResult = ContainerResult(listOf(issuesForImage))
         val toolWindowPanel = project.service<SnykToolWindowPanel>()
         getSnykCachedResults(project)?.currentContainerResult = fakeContainerResult
         toolWindowPanel.getRootContainerIssuesTreeNode().add(ContainerImageTreeNode(issuesForImage, project))

--- a/src/integTest/kotlin/snyk/container/annotator/BaseImageRemediationFixTest.kt
+++ b/src/integTest/kotlin/snyk/container/annotator/BaseImageRemediationFixTest.kt
@@ -91,7 +91,7 @@ class BaseImageRemediationFixTest : BasePlatformTestCase() {
 
     private fun createContainerIssuesForImage(): ContainerIssuesForImage {
         val containerResult = ContainerResult(
-            listOf(Gson().fromJson(containerResultWithRemediationJson, ContainerIssuesForImage::class.java)), null
+            listOf(Gson().fromJson(containerResultWithRemediationJson, ContainerIssuesForImage::class.java))
         )
 
         val firstContainerIssuesForImage = containerResult.allCliIssues!![0]

--- a/src/integTest/kotlin/snyk/container/annotator/ContainerYamlAnnotatorTest.kt
+++ b/src/integTest/kotlin/snyk/container/annotator/ContainerYamlAnnotatorTest.kt
@@ -243,7 +243,7 @@ class ContainerYamlAnnotatorTest : BasePlatformTestCase() {
 
     private fun createContainerResultWithIssueOnLine21(): ContainerResult {
         val containerResult = ContainerResult(
-            listOf(Gson().fromJson(containerResultWithRemediationJson, ContainerIssuesForImage::class.java)), null
+            listOf(Gson().fromJson(containerResultWithRemediationJson, ContainerIssuesForImage::class.java))
         )
 
         val firstContainerIssuesForImage = containerResult.allCliIssues!![0]
@@ -262,7 +262,7 @@ class ContainerYamlAnnotatorTest : BasePlatformTestCase() {
 
     private fun createContainerResultWithIssueOnLine21and23ForSameImageName(): ContainerResult {
         val containerResult = ContainerResult(
-            listOf(Gson().fromJson(containerResultWithRemediationJson, ContainerIssuesForImage::class.java)), null
+            listOf(Gson().fromJson(containerResultWithRemediationJson, ContainerIssuesForImage::class.java))
         )
 
         val firstContainerIssuesForImage = containerResult.allCliIssues!![0]

--- a/src/integTest/kotlin/snyk/iac/IacBulkFileListenerTest.kt
+++ b/src/integTest/kotlin/snyk/iac/IacBulkFileListenerTest.kt
@@ -48,7 +48,7 @@ class IacBulkFileListenerTest : BasePlatformTestCase() {
         )
         val iacIssuesForFile = IacIssuesForFile(listOf(iacIssue), file, filePath, "npm")
         val iacVulnerabilities = listOf(iacIssuesForFile)
-        val fakeIacResult = IacResult(iacVulnerabilities, null)
+        val fakeIacResult = IacResult(iacVulnerabilities)
         getSnykCachedResults(project)?.currentIacResult = fakeIacResult
         val rootIacIssuesTreeNode = project.service<SnykToolWindowPanel>().getRootIacIssuesTreeNode()
         rootIacIssuesTreeNode.add(IacFileTreeNode(iacIssuesForFile, project))
@@ -162,7 +162,7 @@ class IacBulkFileListenerTest : BasePlatformTestCase() {
 
     @Test
     fun `test currentIacResults should keep it when out-of-project IaC supported file content changed`() {
-        val fakeIacResult = IacResult(null, null)
+        val fakeIacResult = IacResult(null)
 
         val file = myFixture.addFileToProject("exclude/k8s-deployment.yaml", "")
         val module = ProjectRootManager.getInstance(project).fileIndex.getModuleForFile(file.virtualFile)!!

--- a/src/integTest/kotlin/snyk/iac/IacServiceTest.kt
+++ b/src/integTest/kotlin/snyk/iac/IacServiceTest.kt
@@ -99,8 +99,8 @@ class IacServiceTest : LightPlatformTestCase() {
         val iacResult = iacService.scan()
 
         assertFalse(iacResult.isSuccessful())
-        assertEquals(errorMsg, iacResult.error!!.message)
-        assertEquals(errorPath, iacResult.error!!.path)
+        assertEquals(errorMsg, iacResult.getFirstError()!!.message)
+        assertEquals(errorPath, iacResult.getFirstError()!!.path)
     }
 
     @Test
@@ -148,13 +148,13 @@ class IacServiceTest : LightPlatformTestCase() {
                     }
                 """.trimIndent())
         assertFalse(jsonErrorIacResult.isSuccessful())
-        assertEquals(errorMsg, jsonErrorIacResult.error!!.message)
-        assertEquals(errorPath, jsonErrorIacResult.error!!.path)
+        assertEquals(errorMsg, jsonErrorIacResult.getFirstError()!!.message)
+        assertEquals(errorPath, jsonErrorIacResult.getFirstError()!!.path)
 
         val rawErrorIacResult = iacService.convertRawCliStringToCliResult(errorMsg)
         assertFalse(rawErrorIacResult.isSuccessful())
-        assertEquals(errorMsg, rawErrorIacResult.error!!.message)
-        assertEquals(project.basePath, rawErrorIacResult.error!!.path)
+        assertEquals(errorMsg, rawErrorIacResult.getFirstError()!!.message)
+        assertEquals(project.basePath, rawErrorIacResult.getFirstError()!!.path)
     }
 
     @Test

--- a/src/integTest/kotlin/snyk/iac/annotator/IacHclAnnotatorTest.kt
+++ b/src/integTest/kotlin/snyk/iac/annotator/IacHclAnnotatorTest.kt
@@ -105,7 +105,7 @@ class IacHclAnnotatorTest : IacBaseAnnotatorCase() {
             severity = "", publicId = "", documentation = "", issue = "", impact = ""
         )
         val iacIssuesForFile = IacIssuesForFile(listOf(iacIssue), terraformManifestFile, file.path, "terraform")
-        return IacResult(listOf(iacIssuesForFile), null)
+        return IacResult(listOf(iacIssuesForFile))
     }
 
     private fun createIacResultWithIssueOnLine8(): IacResult {
@@ -116,7 +116,7 @@ class IacHclAnnotatorTest : IacBaseAnnotatorCase() {
             severity = "", publicId = "", documentation = "", issue = "", impact = ""
         )
         val iacIssuesForFile = IacIssuesForFile(listOf(iacIssue), terraformManifestFile, file.path, "terraform")
-        return IacResult(listOf(iacIssuesForFile), null)
+        return IacResult(listOf(iacIssuesForFile))
     }
 
     private fun createIacResultWithIssueOnLine18(): IacResult {
@@ -127,6 +127,6 @@ class IacHclAnnotatorTest : IacBaseAnnotatorCase() {
             severity = "", publicId = "", documentation = "", issue = "", impact = ""
         )
         val iacIssuesForFile = IacIssuesForFile(listOf(iacIssue), terraformManifestFile, file.path, "terraform")
-        return IacResult(listOf(iacIssuesForFile), null)
+        return IacResult(listOf(iacIssuesForFile))
     }
 }

--- a/src/integTest/kotlin/snyk/iac/annotator/IacJsonAnnotatorTest.kt
+++ b/src/integTest/kotlin/snyk/iac/annotator/IacJsonAnnotatorTest.kt
@@ -78,6 +78,6 @@ class IacJsonAnnotatorTest : IacBaseAnnotatorCase() {
         )
         val iacIssuesForFile =
             IacIssuesForFile(listOf(iacIssue), cloudformationManifestFile, file.path, "cloudformation")
-        return IacResult(listOf(iacIssuesForFile), null)
+        return IacResult(listOf(iacIssuesForFile))
     }
 }

--- a/src/integTest/kotlin/snyk/iac/annotator/IacYamlAnnotatorTest.kt
+++ b/src/integTest/kotlin/snyk/iac/annotator/IacYamlAnnotatorTest.kt
@@ -93,7 +93,7 @@ class IacYamlAnnotatorTest : IacBaseAnnotatorCase() {
         )
         val iacIssuesForFile =
             IacIssuesForFile(listOf(iacIssue), kubernetesManifestFile, file.path, "Kubernetes")
-        return IacResult(listOf(iacIssuesForFile), null)
+        return IacResult(listOf(iacIssuesForFile))
     }
 
     private fun createIacResultWithIssueOnLine20(): IacResult {
@@ -105,6 +105,6 @@ class IacYamlAnnotatorTest : IacBaseAnnotatorCase() {
         )
         val iacIssuesForFile =
             IacIssuesForFile(listOf(iacIssue), kubernetesManifestFile, file.path, "Kubernetes")
-        return IacResult(listOf(iacIssuesForFile), null)
+        return IacResult(listOf(iacIssuesForFile))
     }
 }

--- a/src/integTest/kotlin/snyk/oss/OssBulkFileListenerTest.kt
+++ b/src/integTest/kotlin/snyk/oss/OssBulkFileListenerTest.kt
@@ -25,7 +25,7 @@ class OssBulkFileListenerTest : BasePlatformTestCase() {
 
     @Test
     fun `test currentOssResults should be dropped when build file changed`() {
-        val fakeOssResult = OssResult(null, null)
+        val fakeOssResult = OssResult(null)
         getSnykCachedResults(project)?.currentOssResults = fakeOssResult
 
         myFixture.configureByText("package.json", "main project file")
@@ -38,7 +38,7 @@ class OssBulkFileListenerTest : BasePlatformTestCase() {
 
     @Test
     fun `test keep currentOssResults when out-of-project build file content changed`() {
-        val fakeOssResult = OssResult(null, null)
+        val fakeOssResult = OssResult(null)
 
         val file = myFixture.addFileToProject("exclude/package.json", "")
         val module = ProjectRootManager.getInstance(project).fileIndex.getModuleForFile(file.virtualFile)!!

--- a/src/integTest/kotlin/snyk/oss/OssServiceTest.kt
+++ b/src/integTest/kotlin/snyk/oss/OssServiceTest.kt
@@ -126,8 +126,8 @@ class OssServiceTest : LightPlatformTestCase() {
         assertFalse(cliResult.isSuccessful())
         assertEquals(
             "Missing node_modules folder: we can't test without dependencies.\nPlease run 'npm install' first.",
-            cliResult.error!!.message)
-        assertEquals("/Users/user/Desktop/example-npm-project", cliResult.error!!.path)
+            cliResult.getFirstError()!!.message)
+        assertEquals("/Users/user/Desktop/example-npm-project", cliResult.getFirstError()!!.path)
     }
 
     @Test
@@ -197,16 +197,16 @@ class OssServiceTest : LightPlatformTestCase() {
                 """.trimIndent())
         assertFalse(jsonErrorCliResult.isSuccessful())
         assertEquals("Missing node_modules folder: we can't test without dependencies.\nPlease run 'npm install' first.",
-            jsonErrorCliResult.error!!.message)
-        assertEquals("/Users/user/Desktop/example-npm-project", jsonErrorCliResult.error!!.path)
+            jsonErrorCliResult.getFirstError()!!.message)
+        assertEquals("/Users/user/Desktop/example-npm-project", jsonErrorCliResult.getFirstError()!!.path)
 
         val rawErrorCliResult = ossService.convertRawCliStringToCliResult("""
                     Missing node_modules folder: we can't test without dependencies. Please run 'npm install' first.
                 """.trimIndent())
         assertFalse(rawErrorCliResult.isSuccessful())
         assertEquals("Missing node_modules folder: we can't test without dependencies. Please run 'npm install' first.",
-            rawErrorCliResult.error!!.message)
-        assertEquals(project.basePath, rawErrorCliResult.error!!.path)
+            rawErrorCliResult.getFirstError()!!.message)
+        assertEquals(project.basePath, rawErrorCliResult.getFirstError()!!.path)
     }
 
     @Test

--- a/src/integTest/kotlin/snyk/oss/annotator/OSSGoModAnnotatorTest.kt
+++ b/src/integTest/kotlin/snyk/oss/annotator/OSSGoModAnnotatorTest.kt
@@ -138,5 +138,5 @@ class OSSGoModAnnotatorTest : BasePlatformTestCase() {
     }
 
     private fun createOssResultWithIssues(): OssResult =
-        OssResult(listOf(Gson().fromJson(ossResult, OssVulnerabilitiesForFile::class.java)), null)
+        OssResult(listOf(Gson().fromJson(ossResult, OssVulnerabilitiesForFile::class.java)))
 }

--- a/src/integTest/kotlin/snyk/oss/annotator/OSSGradleKtsAnnotatorTest.kt
+++ b/src/integTest/kotlin/snyk/oss/annotator/OSSGradleKtsAnnotatorTest.kt
@@ -150,5 +150,5 @@ class OSSGradleKtsAnnotatorTest : BasePlatformTestCase() {
     }
 
     private fun createGradleKtsOssResultWithIssues(): OssResult =
-        OssResult(listOf(Gson().fromJson(ossResultGradleKts, OssVulnerabilitiesForFile::class.java)), null)
+        OssResult(listOf(Gson().fromJson(ossResultGradleKts, OssVulnerabilitiesForFile::class.java)))
 }

--- a/src/integTest/kotlin/snyk/oss/annotator/OSSMavenAnnotatorTest.kt
+++ b/src/integTest/kotlin/snyk/oss/annotator/OSSMavenAnnotatorTest.kt
@@ -138,5 +138,5 @@ class OSSMavenAnnotatorTest : BasePlatformTestCase() {
     }
 
     private fun createOssResultWithIssues(): OssResult =
-        OssResult(listOf(Gson().fromJson(ossResult, OssVulnerabilitiesForFile::class.java)), null)
+        OssResult(listOf(Gson().fromJson(ossResult, OssVulnerabilitiesForFile::class.java)))
 }

--- a/src/integTest/kotlin/snyk/oss/annotator/OSSNpmAnnotatorTest.kt
+++ b/src/integTest/kotlin/snyk/oss/annotator/OSSNpmAnnotatorTest.kt
@@ -160,5 +160,5 @@ class OSSNpmAnnotatorTest : BasePlatformTestCase() {
     }
 
     private fun createOssResultWithIssues(): OssResult =
-        OssResult(listOf(Gson().fromJson(ossResult, OssVulnerabilitiesForFile::class.java)), null)
+        OssResult(listOf(Gson().fromJson(ossResult, OssVulnerabilitiesForFile::class.java)))
 }

--- a/src/integTest/resources/container-test-results/debian-nginx-fake_critical_only.json
+++ b/src/integTest/resources/container-test-results/debian-nginx-fake_critical_only.json
@@ -5314,5 +5314,10 @@
       }
     },
     "path": "nginx"
+  },
+  {
+    "ok": false,
+    "error": "Failed to scan image \"fake-image-name\". Please make sure the image and/or repository exist, and that you are using the correct credentials.",
+    "path": "fake-image-name"
   }
 ]

--- a/src/main/kotlin/io/snyk/plugin/cli/CliResult.kt
+++ b/src/main/kotlin/io/snyk/plugin/cli/CliResult.kt
@@ -7,18 +7,20 @@ import java.time.temporal.ChronoUnit
 
 abstract class CliResult<CliIssues>(
     var allCliIssues: List<CliIssues>?,
-    var error: SnykError?
+    var errors: List<SnykError>
 ) {
 
     private val timestamp: Instant = Instant.now()
 
     fun isExpired(): Boolean = timestamp.plus(1, ChronoUnit.DAYS) < Instant.now()
 
-    fun isSuccessful(): Boolean = error == null
+    fun isSuccessful(): Boolean = allCliIssues != null
 
     abstract val issuesCount: Int?
 
     protected abstract fun countBySeverity(severity: Severity): Int?
+
+    fun getFirstError(): SnykError? = errors.firstOrNull()
 
     fun criticalSeveritiesCount(): Int = countBySeverity(Severity.CRITICAL) ?: 0
 

--- a/src/main/kotlin/io/snyk/plugin/services/CliAdapter.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/CliAdapter.kt
@@ -1,26 +1,37 @@
 package io.snyk.plugin.services
 
+import com.google.gson.Gson
+import com.google.gson.JsonArray
+import com.google.gson.JsonParser
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
+import io.snyk.plugin.cli.CliError
 import io.snyk.plugin.cli.CliNotExistsException
+import io.snyk.plugin.cli.CliResult
 import io.snyk.plugin.cli.ConsoleCommandRunner
 import io.snyk.plugin.getCliFile
 import io.snyk.plugin.isCliInstalled
 import io.snyk.plugin.pluginSettings
 import org.jetbrains.annotations.TestOnly
+import snyk.common.SnykError
+import snyk.errorHandler.SentryErrorReporter
 
 /**
  * Wrap work with Snyk CLI.
+ * See [Kotlin's generic type's magic](https://kotlinlang.org/docs/generics.htm).
  */
-abstract class CliAdapter<R>(val project: Project) {
+abstract class CliAdapter<CliIssues, R : CliResult<CliIssues>>(val project: Project) {
 
     private var consoleCommandRunner = ConsoleCommandRunner()
 
-    private val logger = logger<CliAdapter<R>>()
+    private val logger = logger<CliAdapter<CliIssues, R>>()
 
-    protected val projectPath: String = project.basePath
+    private val projectPath: String = project.basePath
         ?: throw IllegalStateException("Scan should not be performed on Default project (with `null` project base dir)")
 
+    /**
+     * !!! Public for tests only !!!
+     */
     fun execute(commands: List<String>): R =
         try {
             val cmds = buildCliCommandsList(commands)
@@ -31,13 +42,77 @@ abstract class CliAdapter<R>(val project: Project) {
             getErrorResult(exception.message ?: "Snyk CLI not installed.")
         }
 
-    protected abstract fun getErrorResult(errorMsg: String): R
+    private fun getErrorResult(errorMsg: String): R =
+        getProductResult(null, listOf(SnykError(errorMsg, projectPath)))
+
+    protected abstract fun getProductResult(cliIssues: List<CliIssues>?, snykErrors: List<SnykError> = emptyList()): R
 
     /**
-     * if rawStr == [ConsoleCommandRunner.PROCESS_CANCELLED_BY_USER] - CLI scan process
-     * was intentionally terminated by user.
+     * !!! Public for tests only !!!
+     *
+     * If result string not contains 'error' string and contain 'vulnerabilities' it says that everything is correct.
+     * If result string not contains '{' it means CLI return an error.
+     * And if result string contains 'error' and not contain 'vulnerabilities' it means CLI return error in JSON format.
+     * if result == [ConsoleCommandRunner.PROCESS_CANCELLED_BY_USER] - CLI scan process was terminated by user.
+     * if result is Empty - CLI fail to run (some notification already done in CLI execution code).
      */
-    abstract fun convertRawCliStringToCliResult(rawStr: String): R
+    fun convertRawCliStringToCliResult(rawStr: String): R =
+        try {
+            when {
+                rawStr == ConsoleCommandRunner.PROCESS_CANCELLED_BY_USER -> {
+                    getProductResult(null)
+                }
+                rawStr.isEmpty() -> {
+                    getErrorResult(CLI_PRODUCE_NO_OUTPUT)
+                }
+                rawStr.first() == '[' -> {
+                    convertRawCliStringWithArrayToCliResult(rawStr)
+                }
+                rawStr.first() == '{' -> {
+                    convertRawCliStringWithSingleEntryToCliResult(rawStr)
+                }
+                else -> getErrorResult(rawStr)
+            }
+        } catch (e: Throwable) {
+            // we should catch all exceptions here including JsonParseException, JsonSyntaxException, etc.
+            SentryErrorReporter.captureException(e)
+            getErrorResult("Failed to parse CLI output: ${e.message ?: e.toString()}")
+        }
+
+    private fun convertRawCliStringWithSingleEntryToCliResult(rawStr: String): R = when {
+        isSuccessCliJsonString(rawStr) -> {
+            getProductResult(listOf(Gson().fromJson(rawStr, getCliIIssuesClass())))
+        }
+        isErrorCliJsonString(rawStr) -> {
+            val cliError = Gson().fromJson(rawStr, CliError::class.java)
+            getProductResult(null, listOf(SnykError(cliError.message, cliError.path)))
+        }
+        else -> getErrorResult(rawStr)
+    }
+
+    private fun convertRawCliStringWithArrayToCliResult(rawStr: String): R {
+        // see https://sites.google.com/site/gson/gson-user-guide#TOC-Serializing-and-Deserializing-Collection-with-Objects-of-Arbitrary-Types
+        val jsonArray: JsonArray = JsonParser.parseString(rawStr).asJsonArray
+        val allErrors: MutableList<SnykError> = mutableListOf()
+        val cliIssues = jsonArray
+            .map { it.toString() }
+            .mapNotNull { elementAsSsting ->
+                val cliResult = convertRawCliStringWithSingleEntryToCliResult(elementAsSsting)
+                allErrors.addAll(cliResult.errors)
+                cliResult.allCliIssues
+            }
+            .flatten()
+        return getProductResult(cliIssues, allErrors)
+    }
+
+    // todo? potentially we should be able to get Class through `refined CliIssue` here, something like:
+    // private inline fun <reified CliIssues> getCliIIssuesClass(): Class<CliIssues> = CliIssues::class.java
+    // see https://kotlinlang.org/docs/inline-functions.htm#reified-type-parameters
+    protected abstract fun getCliIIssuesClass(): Class<CliIssues>
+
+    protected open fun isSuccessCliJsonString(jsonStr: String): Boolean = jsonStr.contains("\"vulnerabilities\":")
+
+    private fun isErrorCliJsonString(jsonStr: String): Boolean = jsonStr.contains("\"error\":")
 
     /**
      * Build list of commands for run Snyk CLI command.
@@ -80,4 +155,8 @@ abstract class CliAdapter<R>(val project: Project) {
 
     private fun getCliCommandPath(): String =
         if (isCliInstalled()) getCliFile().absolutePath else throw CliNotExistsException()
+
+    companion object {
+        const val CLI_PRODUCE_NO_OUTPUT = "CLI doesn't produce any output"
+    }
 }

--- a/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
@@ -144,7 +144,7 @@ class SnykTaskQueueService(val project: Project) {
                         }
                         scanPublisher?.scanningContainerFinished(containerResult)
                     } else {
-                        scanPublisher?.scanningContainerError(containerResult.error!!)
+                        scanPublisher?.scanningContainerError(containerResult.getFirstError()!!)
                     }
                 }
                 logger.debug("Container scan completed")
@@ -221,9 +221,10 @@ class SnykTaskQueueService(val project: Project) {
                     if (ossResult.isSuccessful()) {
                         scanPublisher?.scanningOssFinished(ossResult)
                     } else {
-                        scanPublisher?.scanningOssError(ossResult.error!!)
+                        scanPublisher?.scanningOssError(ossResult.getFirstError()!!)
                     }
                 }
+                DaemonCodeAnalyzer.getInstance(project).restart()
             }
         })
     }
@@ -257,7 +258,7 @@ class SnykTaskQueueService(val project: Project) {
                         }
                         scanPublisher?.scanningIacFinished(iacResult)
                     } else {
-                        scanPublisher?.scanningIacError(iacResult.error!!)
+                        scanPublisher?.scanningIacError(iacResult.getFirstError()!!)
                     }
                 }
                 logger.debug("IaC scan completed")

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/ErrorTreeNode.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/ErrorTreeNode.kt
@@ -1,0 +1,10 @@
+package io.snyk.plugin.ui.toolwindow
+
+import com.intellij.openapi.project.Project
+import snyk.common.SnykError
+import javax.swing.tree.DefaultMutableTreeNode
+
+class ErrorTreeNode(
+    snykError: SnykError,
+    val project: Project
+) : DefaultMutableTreeNode(snykError)

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/VulnerabilityTreeCellRenderer.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/VulnerabilityTreeCellRenderer.kt
@@ -1,6 +1,7 @@
 package io.snyk.plugin.ui.toolwindow
 
 import ai.deepcode.javaclient.core.SuggestionForFile
+import com.intellij.icons.AllIcons
 import com.intellij.openapi.util.Iconable
 import com.intellij.ui.ColoredTreeCellRenderer
 import com.intellij.ui.SimpleTextAttributes
@@ -14,6 +15,7 @@ import io.snyk.plugin.snykcode.getSeverityAsEnum
 import io.snyk.plugin.ui.PackageManagerIconProvider
 import io.snyk.plugin.ui.getDisabledIcon
 import io.snyk.plugin.ui.snykCodeAvailabilityPostfix
+import snyk.common.SnykError
 import snyk.container.ContainerIssue
 import snyk.container.ContainerIssuesForImage
 import snyk.container.ui.ContainerImageTreeNode
@@ -112,6 +114,11 @@ class VulnerabilityTreeCellRenderer : ColoredTreeCellRenderer() {
                     nodeIcon = getDisabledIcon(nodeIcon)
                     text += obsoleteSuffix
                 }
+            }
+            is ErrorTreeNode -> {
+                val snykError = value.userObject as SnykError
+                text = snykError.path + " - " + snykError.message
+                nodeIcon = AllIcons.General.Error
             }
             is IacIssueTreeNode -> {
                 val issue = (value.userObject as IacIssue)

--- a/src/main/kotlin/snyk/container/ContainerBulkFileListener.kt
+++ b/src/main/kotlin/snyk/container/ContainerBulkFileListener.kt
@@ -58,7 +58,8 @@ class ContainerBulkFileListener : SnykBulkFileListener() {
         if (containerRelatedVirtualFilesAffected.isEmpty()) return
         log.debug("update Container cache for $containerRelatedVirtualFilesAffected")
         val snykCachedResults = getSnykCachedResults(project)
-        val containerIssuesForImages = snykCachedResults?.currentContainerResult?.allCliIssues ?: return
+        val currentContainerResult = snykCachedResults?.currentContainerResult ?: return
+        val containerIssuesForImages = currentContainerResult.allCliIssues ?: return
 
         val newContainerIssuesForImagesList = containerIssuesForImages.map { issuesForImage ->
             if (issuesForImage.workloadImages.any { containerRelatedVirtualFilesAffected.contains(it.virtualFile) }) {
@@ -68,7 +69,7 @@ class ContainerBulkFileListener : SnykBulkFileListener() {
             }
         }
 
-        val newContainerCache = ContainerResult(newContainerIssuesForImagesList, null)
+        val newContainerCache = ContainerResult(newContainerIssuesForImagesList, currentContainerResult.errors)
         newContainerCache.rescanNeeded = true
         snykCachedResults.currentContainerResult = newContainerCache
         ApplicationManager.getApplication().invokeLater {

--- a/src/main/kotlin/snyk/container/ContainerResult.kt
+++ b/src/main/kotlin/snyk/container/ContainerResult.kt
@@ -4,11 +4,10 @@ import io.snyk.plugin.Severity
 import io.snyk.plugin.cli.CliResult
 import snyk.common.SnykError
 
-class ContainerResult(containerVulnerabilities: List<ContainerIssuesForImage>?, error: SnykError?) :
-    CliResult<ContainerIssuesForImage>(
-        containerVulnerabilities,
-        error
-    ) {
+class ContainerResult(
+    containerVulnerabilities: List<ContainerIssuesForImage>?,
+    errors: List<SnykError> = emptyList()
+) : CliResult<ContainerIssuesForImage>(containerVulnerabilities, errors) {
 
     var rescanNeeded: Boolean = false
 

--- a/src/main/kotlin/snyk/iac/IacBulkFileListener.kt
+++ b/src/main/kotlin/snyk/iac/IacBulkFileListener.kt
@@ -35,7 +35,8 @@ class IacBulkFileListener : SnykBulkFileListener() {
     ) {
         if (virtualFilesAffected.isEmpty()) return
         val snykCachedResults = getSnykCachedResults(project)
-        val iacFiles = snykCachedResults?.currentIacResult?.allCliIssues ?: return
+        val currentIacResult = snykCachedResults?.currentIacResult ?: return
+        val iacFiles = currentIacResult.allCliIssues ?: return
 
         val newIacFileList = iacFiles.toMutableList()
         val iacRelatedvirtualFilesAffected = virtualFilesAffected
@@ -53,7 +54,7 @@ class IacBulkFileListener : SnykBulkFileListener() {
 
         if (changed) {
             log.debug("update IaC cache for $iacRelatedvirtualFilesAffected")
-            val newIacCache = IacResult(newIacFileList.toImmutableList(), null)
+            val newIacCache = IacResult(newIacFileList.toImmutableList(), currentIacResult.errors)
             newIacCache.iacScanNeeded = true
             snykCachedResults.currentIacResult = newIacCache
             ApplicationManager.getApplication().invokeLater {

--- a/src/main/kotlin/snyk/iac/IacResult.kt
+++ b/src/main/kotlin/snyk/iac/IacResult.kt
@@ -6,8 +6,8 @@ import snyk.common.SnykError
 
 class IacResult(
     allIacVulnerabilities: List<IacIssuesForFile>?,
-    error: SnykError?
-) : CliResult<IacIssuesForFile>(allIacVulnerabilities, error) {
+    errors: List<SnykError> = emptyList()
+) : CliResult<IacIssuesForFile>(allIacVulnerabilities, errors) {
 
     var iacScanNeeded: Boolean = false
 

--- a/src/main/kotlin/snyk/iac/IacScanService.kt
+++ b/src/main/kotlin/snyk/iac/IacScanService.kt
@@ -1,57 +1,25 @@
 package snyk.iac
 
-import com.google.gson.Gson
-import com.google.gson.JsonSyntaxException
-import com.google.gson.reflect.TypeToken
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.project.Project
-import io.snyk.plugin.cli.CliError
-import io.snyk.plugin.cli.ConsoleCommandRunner
 import io.snyk.plugin.services.CliAdapter
 import snyk.common.SnykError
-import java.lang.reflect.Type
 
 /**
  * Wrap work with Snyk CLI for IaC (`iac test` command).
  */
 @Service
-class IacScanService(project: Project) : CliAdapter<IacResult>(project) {
+class IacScanService(project: Project) : CliAdapter<IacIssuesForFile, IacResult>(project) {
 
     fun scan(): IacResult = execute(listOf("iac", "test"))
 
-    override fun getErrorResult(errorMsg: String): IacResult = IacResult(null, SnykError(errorMsg, projectPath))
+    override fun getProductResult(cliIssues: List<IacIssuesForFile>?, snykErrors: List<SnykError>): IacResult =
+        IacResult(cliIssues, snykErrors)
 
-    override fun convertRawCliStringToCliResult(rawStr: String): IacResult =
-        try {
-            val iacIssuesForFileListType: Type = object : TypeToken<ArrayList<IacIssuesForFile>>() {}.type
-            when {
-                rawStr == ConsoleCommandRunner.PROCESS_CANCELLED_BY_USER -> {
-                    IacResult(null, null)
-                }
-                rawStr.isEmpty() -> {
-                    IacResult(null, SnykError("CLI fail to produce any output", projectPath))
-                }
-                rawStr.first() == '[' -> {
-                    IacResult(Gson().fromJson(rawStr, iacIssuesForFileListType), null)
-                }
-                rawStr.first() == '{' -> {
-                    if (isSuccessCliJsonString(rawStr)) {
-                        IacResult(listOf(Gson().fromJson(rawStr, IacIssuesForFile::class.java)), null)
-                    } else {
-                        val cliError = Gson().fromJson(rawStr, CliError::class.java)
-                        IacResult(null, SnykError(cliError.message, cliError.path))
-                    }
-                }
-                else -> {
-                    IacResult(null, SnykError(rawStr, projectPath))
-                }
-            }
-        } catch (e: JsonSyntaxException) {
-            IacResult(null, SnykError(e.message ?: e.toString(), projectPath))
-        }
+    override fun getCliIIssuesClass(): Class<IacIssuesForFile> = IacIssuesForFile::class.java
 
-    private fun isSuccessCliJsonString(jsonStr: String): Boolean =
-        jsonStr.contains("\"infrastructureAsCodeIssues\":") && !jsonStr.contains("\"error\":")
+    override fun isSuccessCliJsonString(jsonStr: String): Boolean =
+        jsonStr.contains("\"infrastructureAsCodeIssues\":")
 
     override fun buildExtraOptions(): List<String> = listOf("--json")
 }

--- a/src/main/kotlin/snyk/oss/OssResult.kt
+++ b/src/main/kotlin/snyk/oss/OssResult.kt
@@ -6,8 +6,8 @@ import snyk.common.SnykError
 
 class OssResult(
     allOssVulnerabilities: List<OssVulnerabilitiesForFile>?,
-    error: SnykError?
-) : CliResult<OssVulnerabilitiesForFile>(allOssVulnerabilities, error) {
+    errors: List<SnykError> = emptyList()
+) : CliResult<OssVulnerabilitiesForFile>(allOssVulnerabilities, errors) {
 
     override val issuesCount = allOssVulnerabilities?.sumBy { it.uniqueCount }
 

--- a/src/main/kotlin/snyk/oss/OssService.kt
+++ b/src/main/kotlin/snyk/oss/OssService.kt
@@ -1,66 +1,23 @@
 package snyk.oss
 
-import com.google.gson.Gson
-import com.google.gson.JsonSyntaxException
-import com.google.gson.reflect.TypeToken
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.project.Project
-import io.snyk.plugin.cli.CliError
-import io.snyk.plugin.cli.ConsoleCommandRunner
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.services.CliAdapter
 import snyk.common.SnykError
-import java.lang.reflect.Type
 
 /**
  * Wrap work with Snyk CLI for OSS (`test` command).
  */
 @Service
-class OssService(project: Project) : CliAdapter<OssResult>(project) {
+class OssService(project: Project) : CliAdapter<OssVulnerabilitiesForFile, OssResult>(project) {
 
     fun scan(): OssResult = execute(listOf("test"))
 
-    override fun getErrorResult(errorMsg: String): OssResult = OssResult(null, SnykError(errorMsg, projectPath))
+    override fun getProductResult(cliIssues: List<OssVulnerabilitiesForFile>?, snykErrors: List<SnykError>): OssResult =
+        OssResult(cliIssues, snykErrors)
 
-    /**
-     * If result string not contains 'error' string and contain 'vulnerabilities' it says that everything is correct.
-     * If result string not contains '{' it means CLI return an error.
-     * And if result string contains 'error' and not contain 'vulnerabilities' it means CLI return error in JSON format.
-     * if result == [ConsoleCommandRunner.PROCESS_CANCELLED_BY_USER] - CLI scan process was terminated by user.
-     * if result is Empty - CLI fail to run (some notification already done in CLI execution code).
-     */
-    override fun convertRawCliStringToCliResult(rawStr: String): OssResult =
-        try {
-            val ossVulnerabilitiesForFileListType: Type =
-                object : TypeToken<ArrayList<OssVulnerabilitiesForFile>>() {}.type
-            when {
-                rawStr == ConsoleCommandRunner.PROCESS_CANCELLED_BY_USER -> {
-                    OssResult(null, null)
-                }
-                rawStr.isEmpty() -> {
-                    OssResult(null, SnykError("CLI fail to produce any output", projectPath))
-                }
-                rawStr.first() == '[' -> {
-                    OssResult(Gson().fromJson(rawStr, ossVulnerabilitiesForFileListType), null)
-                }
-                rawStr.first() == '{' -> {
-                    if (isSuccessCliJsonString(rawStr)) {
-                        OssResult(listOf(Gson().fromJson(rawStr, OssVulnerabilitiesForFile::class.java)), null)
-                    } else {
-                        val cliError = Gson().fromJson(rawStr, CliError::class.java)
-                        OssResult(null, SnykError(cliError.message, cliError.path))
-                    }
-                }
-                else -> {
-                    OssResult(null, SnykError(rawStr, projectPath))
-                }
-            }
-        } catch (e: JsonSyntaxException) {
-            OssResult(null, SnykError(e.message ?: e.toString(), projectPath))
-        }
-
-    private fun isSuccessCliJsonString(jsonStr: String): Boolean =
-        jsonStr.contains("\"vulnerabilities\":") && !jsonStr.contains("\"error\":")
+    override fun getCliIIssuesClass(): Class<OssVulnerabilitiesForFile> = OssVulnerabilitiesForFile::class.java
 
     override fun buildExtraOptions(): List<String> {
         val settings = pluginSettings()


### PR DESCRIPTION
All failed scan results for artifacts(file, image) are now shown in the results(Tree) too (right after successful scan results).
![image](https://user-images.githubusercontent.com/14268320/172433637-818429cc-e172-4991-892b-3e5f004346a7.png)