### PR TITLE
fix/feat/chore: navigation enhancement and annotation fixes [ROAD-567][ROAD-732]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Fixed
 - All failed scan results for artifacts(file, image) are now shown in the results(Tree) too (right after successful scan results).
+- Open Source Scan results annotations are shown for Gradle(Groovy) dependencies.
+
+### Added
+- Navigation to the Editor for the Open Source Scan results and all failed artifact's scan results.
 
 ## [2.4.33]
 

--- a/src/integTest/kotlin/snyk/container/ContainerBulkFileListenerTest.kt
+++ b/src/integTest/kotlin/snyk/container/ContainerBulkFileListenerTest.kt
@@ -139,7 +139,7 @@ class ContainerBulkFileListenerTest : BasePlatformTestCase() {
         val fakeContainerResult = ContainerResult(listOf(issuesForImage))
         val toolWindowPanel = project.service<SnykToolWindowPanel>()
         getSnykCachedResults(project)?.currentContainerResult = fakeContainerResult
-        toolWindowPanel.getRootContainerIssuesTreeNode().add(ContainerImageTreeNode(issuesForImage, project))
+        toolWindowPanel.getRootContainerIssuesTreeNode().add(ContainerImageTreeNode(issuesForImage, project) {})
 
         getKubernetesImageCache(project)?.extractFromFile(addedPsiFile.virtualFile)
     }

--- a/src/integTest/kotlin/snyk/oss/OssServiceTest.kt
+++ b/src/integTest/kotlin/snyk/oss/OssServiceTest.kt
@@ -252,9 +252,8 @@ class OssServiceTest : LightPlatformTestCase() {
 
     private fun touchAllFields(ossResultToCheck: OssResult) {
         ossResultToCheck.allCliIssues?.forEach {
-            it.displayTargetFile
+            it.sanitizedTargetFile
             it.packageManager
-            it.projectName
             it.uniqueCount
             it.vulnerabilities.forEach { vuln ->
                 with(vuln) {

--- a/src/integTest/kotlin/snyk/oss/annotator/OSSGoModAnnotatorTest.kt
+++ b/src/integTest/kotlin/snyk/oss/annotator/OSSGoModAnnotatorTest.kt
@@ -27,7 +27,7 @@ import java.nio.file.Paths
 
 @Suppress("DuplicatedCode", "FunctionName")
 class OSSGoModAnnotatorTest : BasePlatformTestCase() {
-    private var cut = OSSGoModAnnotator()
+    private val cut by lazy { OSSGoModAnnotator() }
     private val annotationHolderMock = mockk<AnnotationHolder>(relaxed = true)
     private val fileName = "go.mod"
     private val ossResult =
@@ -54,7 +54,6 @@ class OSSGoModAnnotatorTest : BasePlatformTestCase() {
         pluginSettings().fileListenerEnabled = false
         file = myFixture.copyFileToProject(fileName)
         psiFile = WriteAction.computeAndWait<PsiFile, Throwable> { psiManager.findFile(file)!! }
-        cut = OSSGoModAnnotator()
     }
 
     override fun tearDown() {

--- a/src/integTest/kotlin/snyk/oss/annotator/OSSGradleAnnotatorTest.kt
+++ b/src/integTest/kotlin/snyk/oss/annotator/OSSGradleAnnotatorTest.kt
@@ -4,9 +4,7 @@ import com.google.gson.Gson
 import com.intellij.codeInsight.intention.IntentionAction
 import com.intellij.lang.annotation.AnnotationBuilder
 import com.intellij.lang.annotation.AnnotationHolder
-import com.intellij.openapi.application.WriteAction
 import com.intellij.openapi.util.TextRange
-import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiFile
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.intellij.testFramework.replaceService
@@ -17,6 +15,8 @@ import io.mockk.unmockkAll
 import io.mockk.verify
 import io.snyk.plugin.pluginSettings
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.plugins.groovy.GroovyFileType
+import org.jetbrains.plugins.groovy.lang.psi.GroovyFile
 import org.junit.Before
 import org.junit.Test
 import snyk.common.SnykCachedResults
@@ -27,20 +27,29 @@ import snyk.oss.Vulnerability
 import java.nio.file.Paths
 
 @Suppress("DuplicatedCode", "FunctionName")
-class OSSGradleKtsAnnotatorTest : BasePlatformTestCase() {
-    private var cut = OSSGradleKtsAnnotator()
+class OSSGradleAnnotatorTest : BasePlatformTestCase() {
+    private val cut by lazy { OSSGradleAnnotator() }
     private val annotationHolderMock = mockk<AnnotationHolder>(relaxed = true)
-    private val buildGradleKtsFilename = "build.gradle.kts"
-    private val ossResultGradleKts =
-        javaClass.classLoader.getResource("oss-test-results/oss-result-gradle-kts.json")!!.readText(Charsets.UTF_8)
 
-    private lateinit var virtualFileBuildGradleKts: VirtualFile
-    private lateinit var buildGradleKts: KtFile
+    private val ossResultGradleKtsJson =
+        javaClass.classLoader.getResource("oss-test-results/oss-result-gradle-kts.json")!!.readText(Charsets.UTF_8)
+    private val buildGradleKts: KtFile by lazy {
+        myFixture.configureByFile("build.gradle.kts")!! as KtFile
+    }
+    private val ossResultGradleJson =
+        javaClass.classLoader.getResource("oss-test-results/oss-result-gradle.json")!!.readText(Charsets.UTF_8)
+    private val buildGradle: GroovyFile by lazy {
+        val buildGradleText = OSSGradleAnnotator::class.java
+            .getResource("/test-fixtures/oss/annotator/build.gradle")!!.readText(Charsets.UTF_8)
+        val groovyFile = myFixture.configureByText(GroovyFileType.GROOVY_FILE_TYPE, buildGradleText)!! as GroovyFile
+        groovyFile.name = "build.gradle"
+        return@lazy groovyFile
+    }
 
     private val snykCachedResults: SnykCachedResults = mockk(relaxed = true)
 
     override fun getTestDataPath(): String {
-        val resource = OSSGradleKtsAnnotator::class.java.getResource("/test-fixtures/oss/annotator")
+        val resource = OSSGradleAnnotator::class.java.getResource("/test-fixtures/oss/annotator")
         requireNotNull(resource) { "Make sure that the resource $resource exists!" }
         return Paths.get(resource.toURI()).toString()
     }
@@ -53,11 +62,6 @@ class OSSGradleKtsAnnotatorTest : BasePlatformTestCase() {
         unmockkAll()
         project.replaceService(SnykCachedResults::class.java, snykCachedResults, project)
         pluginSettings().fileListenerEnabled = false
-        virtualFileBuildGradleKts = myFixture.copyFileToProject(buildGradleKtsFilename)
-        buildGradleKts = WriteAction.computeAndWait<KtFile, Throwable> {
-            psiManager.findFile(virtualFileBuildGradleKts)!! as KtFile
-        }
-        cut = OSSGradleKtsAnnotator()
     }
 
     override fun tearDown() {
@@ -77,11 +81,20 @@ class OSSGradleKtsAnnotatorTest : BasePlatformTestCase() {
     }
 
     @Test
+    fun `test gradle apply should trigger newAnnotation call`() {
+        every { snykCachedResults.currentOssResults } returns createGradleOssResultWithIssues()
+
+        cut.apply(buildGradle, Unit, annotationHolderMock)
+
+        verify(exactly = 6) { annotationHolderMock.newAnnotation(any(), any()) }
+    }
+
+    @Test
     fun `test textRange for Gradle Kts pom`() {
         val ossResult = createGradleKtsOssResultWithIssues()
         val vulnerabilities = ossResult.allCliIssues!![0].vulnerabilities
 
-        var issue = vulnerabilities[0] // org.jetbrains.kotlin:kotlin-test-junit")
+        var issue = vulnerabilities[0] // org.jetbrains.kotlin:kotlin-test-junit
         var expectedStart = 980
         var expectedEnd = 1018
         checkRangeFinding(expectedStart, expectedEnd, issue, buildGradleKts)
@@ -107,11 +120,60 @@ class OSSGradleKtsAnnotatorTest : BasePlatformTestCase() {
         checkRangeFinding(expectedStart, expectedEnd, issue, buildGradleKts)
     }
 
+    @Test
+    fun `test textRange for Gradle pom`() {
+        val ossResult = createGradleOssResultWithIssues()
+        val vulnerabilities = ossResult.allCliIssues!![0].vulnerabilities
+
+        // 'com.google.guava:guava:29.0-jre'
+        checkRangeFinding(
+            expectedStart = 720,
+            expectedEnd = 753,
+            issue = vulnerabilities[0],
+            psiFile = buildGradle
+        )
+        // 'junit:junit:4.13'
+        checkRangeFinding(
+            expectedStart = 874,
+            expectedEnd = 892,
+            issue = vulnerabilities[1],
+            psiFile = buildGradle
+        )
+        // 'org.apache.logging.log4j:log4j-core:2.14.1'
+        checkRangeFinding(
+            expectedStart = 773,
+            expectedEnd = 817,
+            issue = vulnerabilities[2],
+            psiFile = buildGradle
+        )
+        // 'org.apache.logging.log4j:log4j-core:2.14.1'
+        checkRangeFinding(
+            expectedStart = 773,
+            expectedEnd = 817,
+            issue = vulnerabilities[3],
+            psiFile = buildGradle
+        )
+        // 'org.apache.logging.log4j:log4j-core:2.14.1'
+        checkRangeFinding(
+            expectedStart = 773,
+            expectedEnd = 817,
+            issue = vulnerabilities[4],
+            psiFile = buildGradle
+        )
+        // 'org.apache.logging.log4j:log4j-core:2.14.1'
+        checkRangeFinding(
+            expectedStart = 773,
+            expectedEnd = 817,
+            issue = vulnerabilities[5],
+            psiFile = buildGradle
+        )
+    }
+
     private fun checkRangeFinding(
         expectedStart: Int,
         expectedEnd: Int,
         issue: Vulnerability,
-        psiFile: PsiFile = buildGradleKts
+        psiFile: PsiFile
     ) {
         val expectedRange = TextRange(expectedStart, expectedEnd)
         val actualRange = cut.textRange(psiFile, issue)
@@ -150,5 +212,8 @@ class OSSGradleKtsAnnotatorTest : BasePlatformTestCase() {
     }
 
     private fun createGradleKtsOssResultWithIssues(): OssResult =
-        OssResult(listOf(Gson().fromJson(ossResultGradleKts, OssVulnerabilitiesForFile::class.java)))
+        OssResult(listOf(Gson().fromJson(ossResultGradleKtsJson, OssVulnerabilitiesForFile::class.java)))
+
+    private fun createGradleOssResultWithIssues(): OssResult =
+        OssResult(listOf(Gson().fromJson(ossResultGradleJson, OssVulnerabilitiesForFile::class.java)))
 }

--- a/src/integTest/kotlin/snyk/oss/annotator/OSSMavenAnnotatorTest.kt
+++ b/src/integTest/kotlin/snyk/oss/annotator/OSSMavenAnnotatorTest.kt
@@ -29,7 +29,7 @@ import java.nio.file.Paths
 
 @Suppress("DuplicatedCode", "FunctionName")
 class OSSMavenAnnotatorTest : BasePlatformTestCase() {
-    private var cut = OSSMavenAnnotator()
+    private val cut by lazy { OSSMavenAnnotator() }
     private val annotationHolderMock = mockk<AnnotationHolder>(relaxed = true)
     private val fileName = "pom.xml"
     private val ossResult =
@@ -56,7 +56,6 @@ class OSSMavenAnnotatorTest : BasePlatformTestCase() {
         pluginSettings().fileListenerEnabled = false
         file = myFixture.copyFileToProject(fileName)
         psiFile = WriteAction.computeAndWait<PsiFile, Throwable> { psiManager.findFile(file)!! }
-        cut = OSSMavenAnnotator()
     }
 
     override fun tearDown() {

--- a/src/integTest/resources/oss-test-results/oss-result-package-no-remediation.json
+++ b/src/integTest/resources/oss-test-results/oss-result-package-no-remediation.json
@@ -1,0 +1,166 @@
+{
+  "vulnerabilities": [
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N",
+      "alternativeIds": [],
+      "creationTime": "2021-01-28T07:59:50.454879Z",
+      "credit": [
+        "cthackers"
+      ],
+      "cvssScore": 7.4,
+      "description": "## Overview\n[adm-zip](https://www.npmjs.com/package/adm-zip) is a JavaScript implementation for zip data compression for NodeJS.\n\nAffected versions of this package are vulnerable to Directory Traversal. It could extract files outside the target folder.\n\n## Details\n\nA Directory Traversal attack (also known as path traversal) aims to access files and directories that are stored outside the intended folder. By manipulating files with \"dot-dot-slash (../)\" sequences and its variations, or by using absolute file paths, it may be possible to access arbitrary files and directories stored on file system, including application source code, configuration, and other critical system files.\n\nDirectory Traversal vulnerabilities can be generally divided into two types:\n\n- **Information Disclosure**: Allows the attacker to gain information about the folder structure or read the contents of sensitive files on the system.\n\n`st` is a module for serving static files on web pages, and contains a [vulnerability of this type](https://snyk.io/vuln/npm:st:20140206). In our example, we will serve files from the `public` route.\n\nIf an attacker requests the following URL from our server, it will in turn leak the sensitive private key of the root user.\n\n```\ncurl http://localhost:8080/public/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/root/.ssh/id_rsa\n```\n**Note** `%2e` is the URL encoded version of `.` (dot).\n\n- **Writing arbitrary files**: Allows the attacker to create or replace existing files. This type of vulnerability is also known as `Zip-Slip`. \n\nOne way to achieve this is by using a malicious `zip` archive that holds path traversal filenames. When each filename in the zip archive gets concatenated to the target extraction folder, without validation, the final path ends up outside of the target folder. If an executable or a configuration file is overwritten with a file containing malicious code, the problem can turn into an arbitrary code execution issue quite easily.\n\nThe following is an example of a `zip` archive with one benign file and one malicious file. Extracting the malicious file will result in traversing out of the target folder, ending up in `/root/.ssh/` overwriting the `authorized_keys` file:\n\n```\n2018-04-15 22:04:29 .....           19           19  good.txt\n2018-04-15 22:04:42 .....           20           20  ../../../../../../root/.ssh/authorized_keys\n```\n\n## Remediation\nUpgrade `adm-zip` to version 0.5.2 or higher.\n## References\n- [GitHub Commit](https://github.com/cthackers/adm-zip/commit/119dcad6599adccc77982feb14a0c7440fa63013)\n",
+      "disclosureTime": "2021-01-28T07:59:22Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "0.5.2"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JS-ADMZIP-1065796",
+      "identifiers": {
+        "CVE": [],
+        "CWE": [
+          "CWE-22"
+        ]
+      },
+      "language": "js",
+      "malicious": false,
+      "modificationTime": "2021-02-15T17:04:17.878741Z",
+      "moduleName": "adm-zip",
+      "packageManager": "npm",
+      "packageName": "adm-zip",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2021-02-15T17:04:18.109270Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/cthackers/adm-zip/commit/119dcad6599adccc77982feb14a0c7440fa63013"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "<0.5.2"
+        ]
+      },
+      "severity": "high",
+      "socialTrendAlert": false,
+      "title": "Directory Traversal",
+      "severityWithCritical": "high",
+      "from": [
+        "goof@1.0.1",
+        "adm-zip@0.4.7"
+      ],
+      "upgradePath": [
+        false,
+        "adm-zip@0.5.2"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "adm-zip",
+      "version": "0.4.7"
+    }
+  ],
+  "ok": false,
+  "dependencyCount": 1,
+  "org": "bastian.doetsch",
+  "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.22.1\n# ignores vulnerabilities until expiry date; change duration by modifying expiry date\nignore:\n  SNYK-CC-TF-97:\n    - '*':\n        reason: None Given\n        expires: 2022-02-24T09:15:50.476Z\n        created: 2022-01-25T09:15:50.477Z\n        source: cli\n  SNYK-CC-TF-98:\n    - '*':\n        reason: None Given\n        expires: 2022-02-24T09:19:47.336Z\n        created: 2022-01-25T09:19:47.338Z\n        source: cli\n  SNYK-CC-AWS-414:\n    - 'aws.tf > resource > aws_db_instance[km_db] > iam_database_authentication_enabled':\n        reason: None Given\n        expires: 2022-03-11T15:25:07.691Z\n        created: 2022-02-09T15:25:07.693Z\n        source: cli\npatch: {}\n",
+  "isPrivate": true,
+  "licensesPolicy": {
+    "severities": {},
+    "orgLicenseRules": {
+      "AGPL-1.0": {
+        "licenseType": "AGPL-1.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "AGPL-3.0": {
+        "licenseType": "AGPL-3.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "Artistic-1.0": {
+        "licenseType": "Artistic-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "Artistic-2.0": {
+        "licenseType": "Artistic-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "CDDL-1.0": {
+        "licenseType": "CDDL-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "CPOL-1.02": {
+        "licenseType": "CPOL-1.02",
+        "severity": "high",
+        "instructions": ""
+      },
+      "EPL-1.0": {
+        "licenseType": "EPL-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "GPL-2.0": {
+        "licenseType": "GPL-2.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "GPL-3.0": {
+        "licenseType": "GPL-3.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "LGPL-2.0": {
+        "licenseType": "LGPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-2.1": {
+        "licenseType": "LGPL-2.1",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-3.0": {
+        "licenseType": "LGPL-3.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-1.1": {
+        "licenseType": "MPL-1.1",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-2.0": {
+        "licenseType": "MPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MS-RL": {
+        "licenseType": "MS-RL",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "SimPL-2.0": {
+        "licenseType": "SimPL-2.0",
+        "severity": "high",
+        "instructions": ""
+      }
+    }
+  },
+  "packageManager": "npm",
+  "ignoreSettings": null,
+  "summary": "362 vulnerable dependency paths",
+  "filesystemPolicy": true,
+  "filtered": {
+    "ignore": [],
+    "patch": []
+  },
+  "uniqueCount": 1,
+  "projectName": "goof",
+  "displayTargetFile": "package-lock.json",
+  "path": "/Users/bdoetsch/workspace/goof"
+}

--- a/src/main/kotlin/io/snyk/plugin/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/Utils.kt
@@ -47,6 +47,7 @@ import snyk.container.ContainerService
 import snyk.container.KubernetesImageCache
 import snyk.iac.IacScanService
 import snyk.oss.OssService
+import snyk.oss.OssTextRangeFinder
 import java.io.File
 import java.net.URL
 import java.security.KeyStore
@@ -97,6 +98,8 @@ fun getSnykAnalyticsService(): SnykAnalyticsService = getApplicationService()
 fun getSnykAdvisorModel(): SnykAdvisorModel = getApplicationService()
 
 fun getAdvisorService(): AdvisorService = getApplicationService<AdvisorServiceImpl>()
+
+fun getOssTextRangeFinderService(): OssTextRangeFinder = getApplicationService()
 
 fun getPluginPath() = PathManager.getPluginsPath() + "/snyk-intellij-plugin"
 

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/ErrorTreeNode.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/ErrorTreeNode.kt
@@ -6,5 +6,6 @@ import javax.swing.tree.DefaultMutableTreeNode
 
 class ErrorTreeNode(
     snykError: SnykError,
-    val project: Project
-) : DefaultMutableTreeNode(snykError)
+    val project: Project,
+    override val navigateToSource: () -> Unit
+) : DefaultMutableTreeNode(snykError), NavigatableToSourceTreeNode

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/NavigatableToSourceTreeNode.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/NavigatableToSourceTreeNode.kt
@@ -1,0 +1,5 @@
+package io.snyk.plugin.ui.toolwindow
+
+interface NavigatableToSourceTreeNode {
+    val navigateToSource: () -> Unit
+}

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SuggestionTreeNode.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SuggestionTreeNode.kt
@@ -3,5 +3,8 @@ package io.snyk.plugin.ui.toolwindow
 import ai.deepcode.javaclient.core.SuggestionForFile
 import javax.swing.tree.DefaultMutableTreeNode
 
-class SuggestionTreeNode(suggestion: SuggestionForFile, rangeIndex: Int)
-    : DefaultMutableTreeNode(Pair(suggestion, rangeIndex))
+class SuggestionTreeNode(
+    suggestion: SuggestionForFile,
+    rangeIndex: Int,
+    override val navigateToSource: () -> Unit
+) : DefaultMutableTreeNode(Pair(suggestion, rangeIndex)), NavigatableToSourceTreeNode

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/VulnerabilityTreeCellRenderer.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/VulnerabilityTreeCellRenderer.kt
@@ -58,7 +58,7 @@ class VulnerabilityTreeCellRenderer : ColoredTreeCellRenderer() {
             is FileTreeNode -> {
                 val ossVulnerabilitiesForFile = value.userObject as OssVulnerabilitiesForFile
                 nodeIcon = PackageManagerIconProvider.getIcon(ossVulnerabilitiesForFile.packageManager.toLowerCase())
-                text = ossVulnerabilitiesForFile.displayTargetFile
+                text = ossVulnerabilitiesForFile.sanitizedTargetFile
 
                 val snykCachedResults = getSnykCachedResults(value.project)
                 if (snykCachedResults?.currentOssResults == null) {

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/VulnerabilityTreeNode.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/VulnerabilityTreeNode.kt
@@ -6,5 +6,6 @@ import javax.swing.tree.DefaultMutableTreeNode
 
 class VulnerabilityTreeNode(
     groupedVulns: Collection<Vulnerability>,
-    val project: Project
-) : DefaultMutableTreeNode(groupedVulns)
+    val project: Project,
+    override val navigateToSource: () -> Unit
+) : DefaultMutableTreeNode(groupedVulns), NavigatableToSourceTreeNode

--- a/src/main/kotlin/snyk/container/ui/ContainerImageTreeNode.kt
+++ b/src/main/kotlin/snyk/container/ui/ContainerImageTreeNode.kt
@@ -1,10 +1,12 @@
 package snyk.container.ui
 
 import com.intellij.openapi.project.Project
+import io.snyk.plugin.ui.toolwindow.NavigatableToSourceTreeNode
 import snyk.container.ContainerIssuesForImage
 import javax.swing.tree.DefaultMutableTreeNode
 
 class ContainerImageTreeNode(
     issuesForImage: ContainerIssuesForImage,
-    val project: Project
-) : DefaultMutableTreeNode(issuesForImage)
+    val project: Project,
+    override val navigateToSource: () -> Unit
+) : DefaultMutableTreeNode(issuesForImage), NavigatableToSourceTreeNode

--- a/src/main/kotlin/snyk/container/ui/ContainerIssueTreeNode.kt
+++ b/src/main/kotlin/snyk/container/ui/ContainerIssueTreeNode.kt
@@ -1,10 +1,12 @@
 package snyk.container.ui
 
 import com.intellij.openapi.project.Project
+import io.snyk.plugin.ui.toolwindow.NavigatableToSourceTreeNode
 import snyk.container.ContainerIssue
 import javax.swing.tree.DefaultMutableTreeNode
 
 class ContainerIssueTreeNode(
     issue: ContainerIssue,
-    val project: Project
-) : DefaultMutableTreeNode(issue)
+    val project: Project,
+    override val navigateToSource: () -> Unit
+) : DefaultMutableTreeNode(issue), NavigatableToSourceTreeNode

--- a/src/main/kotlin/snyk/iac/ui/toolwindow/IacIssueTreeNode.kt
+++ b/src/main/kotlin/snyk/iac/ui/toolwindow/IacIssueTreeNode.kt
@@ -1,10 +1,12 @@
 package snyk.iac.ui.toolwindow
 
 import com.intellij.openapi.project.Project
+import io.snyk.plugin.ui.toolwindow.NavigatableToSourceTreeNode
 import snyk.iac.IacIssue
 import javax.swing.tree.DefaultMutableTreeNode
 
 class IacIssueTreeNode(
     issue: IacIssue,
-    val project: Project
-) : DefaultMutableTreeNode(issue)
+    val project: Project,
+    override val navigateToSource: () -> Unit
+) : DefaultMutableTreeNode(issue), NavigatableToSourceTreeNode

--- a/src/main/kotlin/snyk/oss/OssTextRangeFinder.kt
+++ b/src/main/kotlin/snyk/oss/OssTextRangeFinder.kt
@@ -1,0 +1,18 @@
+package snyk.oss
+
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiFile
+
+@Service
+class OssTextRangeFinder {
+    private val availableFinders: MutableList<(psiFile: PsiFile, vulnerability: Vulnerability) -> TextRange> = mutableListOf()
+
+    fun registerFinder(finder: (psiFile: PsiFile, vulnerability: Vulnerability) -> TextRange) {
+        availableFinders.add(finder)
+    }
+
+    fun findTextRange(psiFile: PsiFile, vulnerability: Vulnerability): TextRange? = availableFinders.asSequence()
+        .map { it(psiFile, vulnerability) }
+        .firstOrNull { it != TextRange.EMPTY_RANGE }
+}

--- a/src/main/kotlin/snyk/oss/OssVulnerabilitiesForFile.kt
+++ b/src/main/kotlin/snyk/oss/OssVulnerabilitiesForFile.kt
@@ -1,12 +1,15 @@
 package snyk.oss
 
-class OssVulnerabilitiesForFile {
-    lateinit var vulnerabilities: List<Vulnerability>
-    lateinit var projectName: String
-    lateinit var displayTargetFile: String
-    lateinit var packageManager: String
-    var remediation: Remediation? = null
+data class OssVulnerabilitiesForFile(
+    val vulnerabilities: List<Vulnerability>,
+    private val displayTargetFile: String,
+    val packageManager: String,
+    val path: String,
+    val remediation: Remediation? = null
+) {
     val uniqueCount: Int get() = vulnerabilities.groupBy { it.id }.size
+
+    val sanitizedTargetFile: String get() = displayTargetFile.replace("-lock", "")
 
     fun toGroupedResult(): OssGroupedResult {
         val id2vulnerabilities = vulnerabilities.groupBy({ it.id }, { it })

--- a/src/main/kotlin/snyk/oss/annotator/OSSBaseAnnotator.kt
+++ b/src/main/kotlin/snyk/oss/annotator/OSSBaseAnnotator.kt
@@ -54,7 +54,7 @@ abstract class OSSBaseAnnotator : ExternalAnnotator<PsiFile, Unit>() {
         ProgressManager.checkCanceled()
 
         return ossResult.allCliIssues
-            ?.firstOrNull { filePath.endsWith(it.displayTargetFile.replace("-lock", "")) }
+            ?.firstOrNull { filePath.endsWith(it.sanitizedTargetFile) }
     }
 
     open fun annotationMessage(vulnerability: Vulnerability): String {

--- a/src/main/kotlin/snyk/oss/annotator/OSSGoModAnnotator.kt
+++ b/src/main/kotlin/snyk/oss/annotator/OSSGoModAnnotator.kt
@@ -1,10 +1,16 @@
 package snyk.oss.annotator
 
 import com.intellij.psi.PsiFile
+import io.snyk.plugin.getOssTextRangeFinderService
 import snyk.oss.OssVulnerabilitiesForFile
 import snyk.oss.Vulnerability
 
 class OSSGoModAnnotator : OSSBaseAnnotator() {
+
+    init {
+        getOssTextRangeFinderService().registerFinder(this::textRange)
+    }
+
     override fun lineMatches(psiFile: PsiFile, line: String, vulnerability: Vulnerability): Boolean {
         val fileName = psiFile.virtualFile.path
         return fileName.endsWith("go.mod") && !line.endsWith("// indirect") &&

--- a/src/main/kotlin/snyk/oss/annotator/OSSGradleAnnotator.kt
+++ b/src/main/kotlin/snyk/oss/annotator/OSSGradleAnnotator.kt
@@ -6,9 +6,14 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiRecursiveElementVisitor
 import com.intellij.psi.PsiWhiteSpace
+import io.snyk.plugin.getOssTextRangeFinderService
 import snyk.oss.Vulnerability
 
-class OSSGradleKtsAnnotator : OSSBaseAnnotator() {
+class OSSGradleAnnotator : OSSBaseAnnotator() {
+
+    init {
+        getOssTextRangeFinderService().registerFinder(this::textRange)
+    }
 
     override fun getIntroducingPackage(vulnerability: Vulnerability): String {
         return super.getIntroducingPackage(vulnerability)
@@ -61,9 +66,9 @@ class OSSGradleKtsAnnotator : OSSBaseAnnotator() {
             // no version given
             val depGroups = element.text.split(":")
             return if (depGroups.size > 2) {
-                "$packageName:$version" == element.text
+                element.textMatches("$packageName:$version") || element.textMatches("'$packageName:$version'")
             } else {
-                packageName == element.text
+                element.textMatches(packageName) || element.textMatches("'$packageName'")
             }
         }
     }

--- a/src/main/kotlin/snyk/oss/annotator/OSSMavenAnnotator.kt
+++ b/src/main/kotlin/snyk/oss/annotator/OSSMavenAnnotator.kt
@@ -7,10 +7,15 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.XmlRecursiveElementVisitor
 import com.intellij.psi.util.siblings
 import com.intellij.psi.xml.XmlTag
+import io.snyk.plugin.getOssTextRangeFinderService
 import snyk.oss.OssVulnerabilitiesForFile
 import snyk.oss.Vulnerability
 
 class OSSMavenAnnotator : OSSBaseAnnotator() {
+
+    init {
+        getOssTextRangeFinderService().registerFinder(this::textRange)
+    }
 
     override fun getIntroducingPackage(vulnerability: Vulnerability): String {
         return super.getIntroducingPackage(vulnerability).split(":")[1].replace("\"", "")

--- a/src/main/kotlin/snyk/oss/annotator/OSSNpmAnnotator.kt
+++ b/src/main/kotlin/snyk/oss/annotator/OSSNpmAnnotator.kt
@@ -9,11 +9,16 @@ import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiWhiteSpace
+import io.snyk.plugin.getOssTextRangeFinderService
 import snyk.common.intentionactions.AlwaysAvailableReplacementIntentionAction
 import snyk.oss.OssVulnerabilitiesForFile
 import snyk.oss.Vulnerability
 
 class OSSNpmAnnotator : OSSBaseAnnotator() {
+
+    init {
+        getOssTextRangeFinderService().registerFinder(this::textRange)
+    }
 
     override fun textRange(psiFile: PsiFile, vulnerability: Vulnerability): TextRange {
         if (psiFile.fileType !is JsonFileType || psiFile.name != "package.json") return TextRange.EMPTY_RANGE

--- a/src/main/resources/META-INF/optional/withJava.xml
+++ b/src/main/resources/META-INF/optional/withJava.xml
@@ -2,6 +2,6 @@
   <extensions defaultExtensionNs="com.intellij">
     <externalAnnotator language="JAVA" implementationClass="snyk.code.annotator.SnykCodeAnnotator"/>
     <externalAnnotator language="JAVA" implementationClass="snyk.oss.annotator.OSSMavenAnnotator"/>
-    <externalAnnotator language="Groovy" implementationClass="snyk.oss.annotator.OSSGradleKtsAnnotator"/>
+    <externalAnnotator language="Groovy" implementationClass="snyk.oss.annotator.OSSGradleAnnotator"/>
   </extensions>
 </idea-plugin>

--- a/src/main/resources/META-INF/optional/withKotlin.xml
+++ b/src/main/resources/META-INF/optional/withKotlin.xml
@@ -1,6 +1,6 @@
 <idea-plugin>
   <extensions defaultExtensionNs="com.intellij">
     <externalAnnotator language="kotlin" implementationClass="snyk.code.annotator.SnykCodeAnnotator"/>
-    <externalAnnotator language="kotlin" implementationClass="snyk.oss.annotator.OSSGradleKtsAnnotator"/>
+    <externalAnnotator language="kotlin" implementationClass="snyk.oss.annotator.OSSGradleAnnotator"/>
   </extensions>
 </idea-plugin>


### PR DESCRIPTION
fix: Open Source Scan results annotations are shown for Gradle(Groovy) dependencies;
feat: Navigation to the Editor for the Open Source Scan results and all failed artifact's scan results;
chore: refactoring to generalize/unify `Navigate to Source` for tree nodes.
![image](https://user-images.githubusercontent.com/14268320/173085720-deb55629-7efc-4760-a0be-768f0200736a.png)
