### PR TITLE
Fix/container issues grouping by Id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
 ### Added
 - For tree with results `Expand All`/`Collapse All` together with `Expand All Child` (for selected node) actions added;
 
+### Changed
+- Naming for scan results in the tree and naming of result's count is corrected.
+
 ## [2.4.35]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Snyk Changelog
 
+## [2.4.37]
+
+### Fixed
+- Found Container vulnerabilities now grouped by ID (similar to OSS results);
+- For Container images with no remediation/fix available issues count(grouped by severity) now is shown.
+
+### Added
+- In the result's tree, second level nodes(file/image) now have number of vulnerabilities/issues found in it.
+
 ## [2.4.36]
 
 ### Fixed
@@ -8,7 +17,7 @@
 - Container scan for no-images-found case now produce correct message and visuals.
 
 ### Added
-- For tree with results `Expand All`/`Collapse All` together with `Expand All Child` (for selected node) actions added.
+- For tree with results `Expand All`/`Collapse All` together with `Expand All Child` (for selected node) actions added;
 
 ## [2.4.35]
 

--- a/src/integTest/kotlin/snyk/container/ContainerBulkFileListenerTest.kt
+++ b/src/integTest/kotlin/snyk/container/ContainerBulkFileListenerTest.kt
@@ -129,6 +129,7 @@ class ContainerBulkFileListenerTest : BasePlatformTestCase() {
             vulnerabilities = listOf(containerIssue),
             projectName = "fake project name",
             docker = Docker(),
+            uniqueCount = 1,
             error = null,
             imageName = "nginx",
             workloadImages = listOf(KubernetesWorkloadImage(

--- a/src/integTest/kotlin/snyk/container/annotator/BaseImageRemediationFixTest.kt
+++ b/src/integTest/kotlin/snyk/container/annotator/BaseImageRemediationFixTest.kt
@@ -96,7 +96,7 @@ class BaseImageRemediationFixTest : BasePlatformTestCase() {
 
         val firstContainerIssuesForImage = containerResult.allCliIssues!![0]
         val baseImageRemediationInfo =
-            getContainerService(project)?.convertRemediation(firstContainerIssuesForImage.docker.baseImageRemediation)
+            getContainerService(project)?.convertRemediation(firstContainerIssuesForImage)
         return firstContainerIssuesForImage.copy(
             baseImageRemediationInfo = baseImageRemediationInfo,
             workloadImages = emptyList()

--- a/src/integTest/kotlin/snyk/container/annotator/ContainerYamlAnnotatorTest.kt
+++ b/src/integTest/kotlin/snyk/container/annotator/ContainerYamlAnnotatorTest.kt
@@ -248,7 +248,7 @@ class ContainerYamlAnnotatorTest : BasePlatformTestCase() {
 
         val firstContainerIssuesForImage = containerResult.allCliIssues!![0]
         val baseImageRemediationInfo =
-            getContainerService(project)?.convertRemediation(firstContainerIssuesForImage.docker.baseImageRemediation)
+            getContainerService(project)?.convertRemediation(firstContainerIssuesForImage)
 
         val workloadImages = listOf(KubernetesWorkloadImage("nginx:1.16.0", virtualFile, 21))
         containerResult.allCliIssues = listOf(
@@ -267,7 +267,7 @@ class ContainerYamlAnnotatorTest : BasePlatformTestCase() {
 
         val firstContainerIssuesForImage = containerResult.allCliIssues!![0]
         val baseImageRemediationInfo =
-            getContainerService(project)?.convertRemediation(firstContainerIssuesForImage.docker.baseImageRemediation)
+            getContainerService(project)?.convertRemediation(firstContainerIssuesForImage)
 
         val workloadImages1 = KubernetesWorkloadImage("nginx:1.16.0", virtualFile, 21)
         val workloadImages2 = KubernetesWorkloadImage("nginx:1.16.0", virtualFile, 23)
@@ -283,9 +283,24 @@ class ContainerYamlAnnotatorTest : BasePlatformTestCase() {
     private fun createContainerImageForIssuesWithSeverity(
         severity: String = Severity.CRITICAL.toString()
     ): ContainerIssuesForImage {
-        val containerIssue = ContainerIssue("", "", "", severity, packageManager = "npm", from = emptyList())
+        val containerIssue = ContainerIssue(
+            id = "",
+            title = "",
+            description = "",
+            severity = severity,
+            packageManager = "npm",
+            from = emptyList()
+        )
         val vulnerabilities = listOf(containerIssue, containerIssue.copy()) // force the tests to filter duplicates
         val docker = Docker(null)
-        return ContainerIssuesForImage(vulnerabilities, "test", docker, null, "nginx:1.16.0", null)
+        return ContainerIssuesForImage(
+            vulnerabilities = vulnerabilities,
+            projectName = "test",
+            docker = docker,
+            uniqueCount = 1,
+            error = null,
+            imageName = "nginx:1.16.0",
+            baseImageRemediationInfo = null
+        )
     }
 }

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
@@ -534,7 +534,7 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
                     OSS_ROOT_TEXT + when {
                         count == NODE_INITIAL_STATE -> ""
                         count == 0 -> NO_ISSUES_FOUND_TEXT
-                        count > 0 -> " - $count vulnerabilit${if (count > 1) "ies" else "y"}$addHMLPostfix"
+                        count > 0 -> ProductType.OSS.getIssuesCountText(count) + addHMLPostfix
                         count == NODE_NOT_SUPPORTED_STATE -> NO_SUPPORTED_PACKAGE_MANAGER_FOUND
                         else -> throw IllegalStateException("ResultsCount is meaningful")
                     }
@@ -549,7 +549,7 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
                 CODE_SECURITY_ROOT_TEXT + when {
                     count == NODE_INITIAL_STATE -> ""
                     count == 0 -> NO_ISSUES_FOUND_TEXT
-                    count > 0 -> " - $count vulnerabilit${if (count > 1) "ies" else "y"}$addHMLPostfix"
+                    count > 0 -> ProductType.CODE_SECURITY.getIssuesCountText(count) + addHMLPostfix
                     else -> throw IllegalStateException("ResultsCount is meaningful")
                 }
             }
@@ -563,7 +563,7 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
                 CODE_QUALITY_ROOT_TEXT + when {
                     count == NODE_INITIAL_STATE -> ""
                     count == 0 -> NO_ISSUES_FOUND_TEXT
-                    count > 0 -> " - $count issue${if (count > 1) "s" else ""}$addHMLPostfix"
+                    count > 0 -> ProductType.CODE_QUALITY.getIssuesCountText(count) + addHMLPostfix
                     else -> throw IllegalStateException("ResultsCount is meaningful")
                 }
             }
@@ -577,7 +577,7 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
                 IAC_ROOT_TEXT + when {
                     count == NODE_INITIAL_STATE -> ""
                     count == 0 -> NO_ISSUES_FOUND_TEXT
-                    count > 0 -> " - $count issue${if (count > 1) "s" else ""}$addHMLPostfix"
+                    count > 0 -> ProductType.IAC.getIssuesCountText(count) + addHMLPostfix
                     count == NODE_NOT_SUPPORTED_STATE -> NO_SUPPORTED_IAC_FILES_FOUND
                     else -> throw IllegalStateException("ResultsCount is meaningful")
                 }
@@ -592,7 +592,7 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
                 CONTAINER_ROOT_TEXT + when {
                     count == NODE_INITIAL_STATE -> ""
                     count == 0 -> NO_ISSUES_FOUND_TEXT
-                    count > 0 -> " - $count vulnerabilit${if (count > 1) "ies" else "y"}$addHMLPostfix"
+                    count > 0 -> ProductType.CONTAINER.getIssuesCountText(count) + addHMLPostfix
                     count == NODE_NOT_SUPPORTED_STATE -> NO_CONTAINER_IMAGES_FOUND
                     else -> throw IllegalStateException("ResultsCount is meaningful")
                 }
@@ -861,9 +861,9 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
                         ContainerImageTreeNode(issuesForImage, project, navigateToImage(issuesForImage.imageName))
                     rootContainerIssuesTreeNode.add(imageTreeNode)
 
-                    issuesForImage.vulnerabilities
-                        .filter { settings.hasSeverityEnabledAndFiltered(it.getSeverity()) }
-                        .sortedByDescending { it.getSeverity() }
+                    issuesForImage.groupedVulnsById.values
+                        .filter { settings.hasSeverityEnabledAndFiltered(it.head.getSeverity()) }
+                        .sortedByDescending { it.head.getSeverity() }
                         .forEach {
                             imageTreeNode.add(
                                 ContainerIssueTreeNode(it, project, navigateToImage(issuesForImage.imageName))

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykTreeCellRenderer.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykTreeCellRenderer.kt
@@ -25,6 +25,7 @@ import io.snyk.plugin.ui.toolwindow.nodes.root.RootSecurityIssuesTreeNode
 import io.snyk.plugin.ui.toolwindow.nodes.secondlevel.ErrorTreeNode
 import io.snyk.plugin.ui.toolwindow.nodes.secondlevel.FileTreeNode
 import io.snyk.plugin.ui.toolwindow.nodes.secondlevel.SnykCodeFileTreeNode
+import snyk.common.ProductType
 import snyk.common.SnykError
 import snyk.container.ContainerIssue
 import snyk.container.ContainerIssuesForImage
@@ -66,9 +67,9 @@ class SnykTreeCellRenderer : ColoredTreeCellRenderer() {
                 }
             }
             is FileTreeNode -> {
-                val ossVulnerabilitiesForFile = value.userObject as OssVulnerabilitiesForFile
-                nodeIcon = PackageManagerIconProvider.getIcon(ossVulnerabilitiesForFile.packageManager.toLowerCase())
-                text = ossVulnerabilitiesForFile.sanitizedTargetFile
+                val fileVulns = value.userObject as OssVulnerabilitiesForFile
+                nodeIcon = PackageManagerIconProvider.getIcon(fileVulns.packageManager.toLowerCase())
+                text = fileVulns.sanitizedTargetFile + ProductType.OSS.getIssuesCountText(value.childCount)
 
                 val snykCachedResults = getSnykCachedResults(value.project)
                 if (snykCachedResults?.currentOssResults == null) {
@@ -92,7 +93,7 @@ class SnykTreeCellRenderer : ColoredTreeCellRenderer() {
             }
             is SnykCodeFileTreeNode -> {
                 val file = value.userObject
-                text = PDU.toSnykCodeFile(file).virtualFile.name
+                text = PDU.toSnykCodeFile(file).virtualFile.name + ProductType.CODE_SECURITY.getIssuesCountText(value.childCount)
                 val psiFile = PDU.toPsiFile(file)
                 nodeIcon = psiFile?.getIcon(Iconable.ICON_FLAG_READ_STATUS)
                 if (!AnalysisData.instance.isFileInCache(file)) {
@@ -104,7 +105,7 @@ class SnykTreeCellRenderer : ColoredTreeCellRenderer() {
             is IacFileTreeNode -> {
                 val iacVulnerabilitiesForFile = value.userObject as IacIssuesForFile
                 nodeIcon = PackageManagerIconProvider.getIcon(iacVulnerabilitiesForFile.packageManager.toLowerCase())
-                text = iacVulnerabilitiesForFile.targetFile
+                text = iacVulnerabilitiesForFile.targetFile + ProductType.IAC.getIssuesCountText(value.childCount)
 
                 val snykCachedResults = getSnykCachedResults(value.project)
                 if (snykCachedResults?.currentIacResult == null || iacVulnerabilitiesForFile.obsolete) {
@@ -116,7 +117,7 @@ class SnykTreeCellRenderer : ColoredTreeCellRenderer() {
             is ContainerImageTreeNode -> {
                 val issuesForImage = value.userObject as ContainerIssuesForImage
                 nodeIcon = SnykIcons.CONTAINER_IMAGE
-                text = issuesForImage.imageName
+                text = issuesForImage.imageName + ProductType.CONTAINER.getIssuesCountText(value.childCount)
 
                 val snykCachedResults = getSnykCachedResults(value.project)
                 if (snykCachedResults?.currentContainerResult == null || issuesForImage.obsolete) {

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykTreeCellRenderer.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykTreeCellRenderer.kt
@@ -11,6 +11,7 @@ import io.snyk.plugin.getSnykCachedResults
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.snykcode.core.AnalysisData
 import io.snyk.plugin.snykcode.core.PDU
+import io.snyk.plugin.snykcode.core.SnykCodeFile
 import io.snyk.plugin.snykcode.getSeverityAsEnum
 import io.snyk.plugin.ui.PackageManagerIconProvider
 import io.snyk.plugin.ui.getDisabledIcon
@@ -69,7 +70,7 @@ class SnykTreeCellRenderer : ColoredTreeCellRenderer() {
             is FileTreeNode -> {
                 val fileVulns = value.userObject as OssVulnerabilitiesForFile
                 nodeIcon = PackageManagerIconProvider.getIcon(fileVulns.packageManager.toLowerCase())
-                text = fileVulns.sanitizedTargetFile + ProductType.OSS.getIssuesCountText(value.childCount)
+                text = fileVulns.sanitizedTargetFile + ProductType.OSS.getCountText(value.childCount)
 
                 val snykCachedResults = getSnykCachedResults(value.project)
                 if (snykCachedResults?.currentOssResults == null) {
@@ -86,14 +87,15 @@ class SnykTreeCellRenderer : ColoredTreeCellRenderer() {
                     if (suggestion.title.isNullOrEmpty()) suggestion.message else suggestion.title
                 }"
                 val parentFileNode = value.parent as SnykCodeFileTreeNode
-                if (!AnalysisData.instance.isFileInCache(parentFileNode.userObject)) {
+                val file = (parentFileNode.userObject as Pair<SnykCodeFile, ProductType>).first
+                if (!AnalysisData.instance.isFileInCache(file)) {
                     attributes = SimpleTextAttributes.GRAYED_ATTRIBUTES
                     nodeIcon = getDisabledIcon(nodeIcon)
                 }
             }
             is SnykCodeFileTreeNode -> {
-                val file = value.userObject
-                text = PDU.toSnykCodeFile(file).virtualFile.name + ProductType.CODE_SECURITY.getIssuesCountText(value.childCount)
+                val (file, productType) = value.userObject as Pair<SnykCodeFile, ProductType>
+                text = PDU.toSnykCodeFile(file).virtualFile.name + productType.getCountText(value.childCount)
                 val psiFile = PDU.toPsiFile(file)
                 nodeIcon = psiFile?.getIcon(Iconable.ICON_FLAG_READ_STATUS)
                 if (!AnalysisData.instance.isFileInCache(file)) {
@@ -105,7 +107,7 @@ class SnykTreeCellRenderer : ColoredTreeCellRenderer() {
             is IacFileTreeNode -> {
                 val iacVulnerabilitiesForFile = value.userObject as IacIssuesForFile
                 nodeIcon = PackageManagerIconProvider.getIcon(iacVulnerabilitiesForFile.packageManager.toLowerCase())
-                text = iacVulnerabilitiesForFile.targetFile + ProductType.IAC.getIssuesCountText(value.childCount)
+                text = iacVulnerabilitiesForFile.targetFile + ProductType.IAC.getCountText(value.childCount)
 
                 val snykCachedResults = getSnykCachedResults(value.project)
                 if (snykCachedResults?.currentIacResult == null || iacVulnerabilitiesForFile.obsolete) {
@@ -117,7 +119,7 @@ class SnykTreeCellRenderer : ColoredTreeCellRenderer() {
             is ContainerImageTreeNode -> {
                 val issuesForImage = value.userObject as ContainerIssuesForImage
                 nodeIcon = SnykIcons.CONTAINER_IMAGE
-                text = issuesForImage.imageName + ProductType.CONTAINER.getIssuesCountText(value.childCount)
+                text = issuesForImage.imageName + ProductType.CONTAINER.getCountText(value.childCount)
 
                 val snykCachedResults = getSnykCachedResults(value.project)
                 if (snykCachedResults?.currentContainerResult == null || issuesForImage.obsolete) {

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/nodes/leaf/SuggestionTreeNode.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/nodes/leaf/SuggestionTreeNode.kt
@@ -11,6 +11,7 @@ import io.snyk.plugin.ui.toolwindow.nodes.secondlevel.SnykCodeFileTreeNode
 import io.snyk.plugin.ui.toolwindow.panels.IssueDescriptionPanelBase
 import io.snyk.plugin.ui.toolwindow.panels.SuggestionDescriptionPanel
 import snyk.analytics.IssueInTreeIsClicked
+import snyk.common.ProductType
 import javax.swing.tree.DefaultMutableTreeNode
 
 class SuggestionTreeNode(
@@ -28,8 +29,9 @@ class SuggestionTreeNode(
                 .severity(suggestion.getIssueSeverityOrNull())
                 .build()
         )
-        val snykCodeFile = (this.parent as? SnykCodeFileTreeNode)?.userObject as? SnykCodeFile
+        val snykCodeFileTreeNode = this.parent as? SnykCodeFileTreeNode
             ?: throw IllegalArgumentException(this.toString())
+        val snykCodeFile = (snykCodeFileTreeNode.userObject as Pair<SnykCodeFile, ProductType>).first
         return SuggestionDescriptionPanel(snykCodeFile, suggestion, rangeIndex)
     }
 }

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/nodes/secondlevel/SnykCodeFileTreeNode.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/nodes/secondlevel/SnykCodeFileTreeNode.kt
@@ -1,6 +1,10 @@
 package io.snyk.plugin.ui.toolwindow.nodes.secondlevel
 
 import io.snyk.plugin.snykcode.core.SnykCodeFile
+import snyk.common.ProductType
 import javax.swing.tree.DefaultMutableTreeNode
 
-class SnykCodeFileTreeNode(file: SnykCodeFile) : DefaultMutableTreeNode(file)
+class SnykCodeFileTreeNode(
+    file: SnykCodeFile,
+    productType: ProductType
+) : DefaultMutableTreeNode(Pair(file, productType))

--- a/src/main/kotlin/snyk/common/ProductType.kt
+++ b/src/main/kotlin/snyk/common/ProductType.kt
@@ -7,41 +7,61 @@ enum class ProductType(
 ) {
     OSS(
         productSelectionName = "Snyk Open Source",
-        treeName = "Open Source Vulnerabilities",
+        treeName = "Open Source",
         description = "Find and automatically fix open source vulnerabilities"
     ) {
-        override fun getIssuesCountText(count: Int): String = " - $count vulnerabilit${if (count > 1) "ies" else "y"}"
+        override fun getCountText(count: Int, isUniqueCount: Boolean): String =
+            getVulnerabilitiesCountText(count, isUniqueCount)
     },
     IAC(
         productSelectionName = "Snyk Infrastructure as Code",
-        treeName = "Configuration Issues",
+        treeName = "Configuration",
         description = "Find and fix insecure configurations in Terraform and Kubernetes code"
-    ),
+    ) {
+        override fun getCountText(count: Int, isUniqueCount: Boolean): String =
+            getIssuesCountText(count, isUniqueCount)
+    },
     CONTAINER(
         productSelectionName = "Snyk Container",
-        treeName = "Container Vulnerabilities",
+        treeName = "Container",
         description = "Find and fix vulnerabilities in container images and Kubernetes applications"
     ) {
-        override fun getIssuesCountText(count: Int): String = " - $count vulnerabilit${if (count > 1) "ies" else "y"}"
+        override fun getCountText(count: Int, isUniqueCount: Boolean): String =
+            getVulnerabilitiesCountText(count, isUniqueCount)
     },
     CODE_SECURITY(
         productSelectionName = "Snyk Code Security",
-        treeName = "Code Security Issues",
+        treeName = "Code Security",
         description = "Find and fix vulnerabilities in your application code in real time"
-    ),
+    ) {
+        override fun getCountText(count: Int, isUniqueCount: Boolean): String =
+            getVulnerabilitiesCountText(count, isUniqueCount)
+    },
     CODE_QUALITY(
         productSelectionName = "Snyk Code Quality",
-        treeName = "Code Quality Issues",
+        treeName = "Code Quality",
         description = "Find and fix code quality issues in your application code in real time"
-    ),
+    ) {
+        override fun getCountText(count: Int, isUniqueCount: Boolean): String =
+            getIssuesCountText(count, isUniqueCount)
+    },
     ADVISOR(
         productSelectionName = "Snyk Advisor (early preview)",
         treeName = "",
         description = "Discover the health (maintenance, community, popularity & security)\n" +
             "status of your open source packages"
-    );
+    ) {
+        override fun getCountText(count: Int, isUniqueCount: Boolean): String =
+            getIssuesCountText(count, isUniqueCount)
+    };
 
     override fun toString(): String = productSelectionName
 
-    open fun getIssuesCountText(count: Int): String = " - $count issue${if (count > 1) "s" else ""}"
+    abstract fun getCountText(count: Int, isUniqueCount: Boolean = false): String
+
+    protected fun getIssuesCountText(count: Int, isUnique: Boolean = false): String =
+        " - $count${if (isUnique) " unique" else ""} issue${if (count > 1) "s" else ""}"
+
+    protected fun getVulnerabilitiesCountText(count: Int, isUnique: Boolean = false): String =
+        " - $count${if (isUnique) " unique" else ""} vulnerabilit${if (count > 1) "ies" else "y"}"
 }

--- a/src/main/kotlin/snyk/common/ProductType.kt
+++ b/src/main/kotlin/snyk/common/ProductType.kt
@@ -9,7 +9,9 @@ enum class ProductType(
         productSelectionName = "Snyk Open Source",
         treeName = "Open Source Vulnerabilities",
         description = "Find and automatically fix open source vulnerabilities"
-    ),
+    ) {
+        override fun getIssuesCountText(count: Int): String = " - $count vulnerabilit${if (count > 1) "ies" else "y"}"
+    },
     IAC(
         productSelectionName = "Snyk Infrastructure as Code",
         treeName = "Configuration Issues",
@@ -19,7 +21,9 @@ enum class ProductType(
         productSelectionName = "Snyk Container",
         treeName = "Container Vulnerabilities",
         description = "Find and fix vulnerabilities in container images and Kubernetes applications"
-    ),
+    ) {
+        override fun getIssuesCountText(count: Int): String = " - $count vulnerabilit${if (count > 1) "ies" else "y"}"
+    },
     CODE_SECURITY(
         productSelectionName = "Snyk Code Security",
         treeName = "Code Security Issues",
@@ -38,4 +42,6 @@ enum class ProductType(
     );
 
     override fun toString(): String = productSelectionName
+
+    open fun getIssuesCountText(count: Int): String = " - $count issue${if (count > 1) "s" else ""}"
 }

--- a/src/main/kotlin/snyk/container/annotator/BaseImageRemediationFix.kt
+++ b/src/main/kotlin/snyk/container/annotator/BaseImageRemediationFix.kt
@@ -27,10 +27,10 @@ class BaseImageRemediationFix(
     private val logger = logger<BaseImageRemediationFix>()
 
     init {
-        if (containerIssuesForImage.baseImageRemediationInfo == null)
-            throw IllegalArgumentException("Trying to create quick fix without remediation")
-
         val imageRemediationInfo = containerIssuesForImage.baseImageRemediationInfo
+        if (imageRemediationInfo?.isRemediationAvailable() != true) {
+            throw IllegalArgumentException("Trying to create quick fix without remediation")
+        }
         imageNameToFix = determineTargetImage(imageRemediationInfo)
     }
 

--- a/src/main/kotlin/snyk/container/annotator/ContainerYamlAnnotator.kt
+++ b/src/main/kotlin/snyk/container/annotator/ContainerYamlAnnotator.kt
@@ -65,9 +65,7 @@ class ContainerYamlAnnotator : ExternalAnnotator<PsiFile, Unit>() {
     }
 
     private fun shouldAddQuickFix(forImage: ContainerIssuesForImage): Boolean {
-        val baseImageRemediation = forImage.docker.baseImageRemediation
-        if (baseImageRemediation == null || !baseImageRemediation.isRemediationAvailable()) return false
-        if (forImage.baseImageRemediationInfo == null) return false
+        if (forImage.baseImageRemediationInfo?.isRemediationAvailable() != true) return false
 
         val baseImageName = forImage.imageName.split(":")[0]
         val imageNameToFix =
@@ -81,7 +79,7 @@ class ContainerYamlAnnotator : ExternalAnnotator<PsiFile, Unit>() {
         val vulnerabilityString = if (total == 1) "vulnerability" else "vulnerabilities"
         return buildString {
             val remediationString = when {
-                image.baseImageRemediationInfo != null -> "Upgrade image to a newer version"
+                image.baseImageRemediationInfo?.isRemediationAvailable() == true -> "Upgrade image to a newer version"
                 else -> ""
             }
             append("Snyk found $total $vulnerabilityString. $remediationString")

--- a/src/main/kotlin/snyk/container/ui/BaseImageRemediationDetailPanel.kt
+++ b/src/main/kotlin/snyk/container/ui/BaseImageRemediationDetailPanel.kt
@@ -61,10 +61,12 @@ class BaseImageRemediationDetailPanel(
     private fun baseRemediationInfoPanel(): JPanel {
         val panel = JPanel(GridLayoutManager(4, 4, Insets(0, 0, 0, 0), 0, 10))
 
-        panel.add(
-            JLabel("Recommendations for upgrading the base image"),
-            baseGridConstraintsAnchorWest(0)
-        )
+        imageIssues.baseImageRemediationInfo?.let {
+            panel.add(
+                JLabel(it.recommendationForUpgrade),
+                baseGridConstraintsAnchorWest(0)
+            )
+        }
 
         panel.add(
             innerRemediationInfoPanel(),

--- a/src/main/kotlin/snyk/container/ui/ContainerIssueDetailPanel.kt
+++ b/src/main/kotlin/snyk/container/ui/ContainerIssueDetailPanel.kt
@@ -1,7 +1,10 @@
 package snyk.container.ui
 
+import com.intellij.ui.components.labels.LinkLabel
 import com.intellij.uiDesigner.core.GridLayoutManager
 import io.snyk.plugin.ui.DescriptionHeaderPanel
+import io.snyk.plugin.ui.baseGridConstraintsAnchorWest
+import io.snyk.plugin.ui.boldLabel
 import io.snyk.plugin.ui.descriptionHeaderPanel
 import io.snyk.plugin.ui.getReadOnlyClickableHtmlJEditorPane
 import io.snyk.plugin.ui.insertTitleAndResizableTextIntoPanelColumns
@@ -14,15 +17,17 @@ import java.awt.Insets
 import javax.swing.JPanel
 
 class ContainerIssueDetailPanel(
-    private val issue: ContainerIssue
-) : IssueDescriptionPanelBase(title = issue.title, severity = issue.getSeverity()) {
+    private val groupedVulns: Collection<ContainerIssue>
+) : IssueDescriptionPanelBase(title = groupedVulns.first().title, severity = groupedVulns.first().getSeverity()) {
+
+    private val issue = groupedVulns.first()
 
     init {
         createUI()
     }
 
     override fun createMainBodyPanel(): Pair<JPanel, Int> {
-        val lastRowToAddSpacer = 3
+        val lastRowToAddSpacer = 4
         val panel = JPanel(
             GridLayoutManager(lastRowToAddSpacer + 1, 1, Insets(10, 10, 20, 20), -1, 10)
         )
@@ -33,8 +38,13 @@ class ContainerIssueDetailPanel(
         )
 
         panel.add(
-            overviewPanel(),
+            getDetailedPathsPanel(),
             panelGridConstraints(2)
+        )
+
+        panel.add(
+            overviewPanel(),
+            panelGridConstraints(3)
         )
 
         return Pair(panel, lastRowToAddSpacer)
@@ -51,10 +61,14 @@ class ContainerIssueDetailPanel(
 
     private fun mainPanel(): JPanel {
         val panel = JPanel(
-            GridLayoutManager(2, 2, Insets(0,0, 0, 0), 50, -1)
+            GridLayoutManager(2, 2, Insets(0, 0, 0, 0), 30, -1)
         )
 
-        val introducedThrough = issue.from
+        val introducedThrough = groupedVulns
+            .mapNotNull { vulnerability ->
+                vulnerability.from.let { if (it.size > 1) it[1] else null }
+            }
+            .distinct()
         if (introducedThrough.isNotEmpty()) {
             insertTitleAndResizableTextIntoPanelColumns(
                 panel = panel,
@@ -64,21 +78,93 @@ class ContainerIssueDetailPanel(
             )
         }
 
-        val fixedInText = issue.nearestFixedInVersion
-        if (!fixedInText.isNullOrBlank()) {
-            insertTitleAndResizableTextIntoPanelColumns(
-                panel = panel,
-                row = 1,
-                title = "Fixed in:",
-                htmlText = fixedInText
-            )
-        }
+        val fixedInText = issue.nearestFixedInVersion ?: "Not fixed"
+        insertTitleAndResizableTextIntoPanelColumns(
+            panel = panel,
+            row = 1,
+            title = "Fixed in:",
+            htmlText = fixedInText
+        )
 
         return panel
     }
 
+    private fun getDetailedPathsPanel(): JPanel {
+        val detailsPanel = JPanel()
+        detailsPanel.layout = GridLayoutManager(2, 2, Insets(20, 0, 0, 0), -1, -1)
+
+        detailsPanel.add(
+            boldLabel("Detailed paths").apply {
+                font = font.deriveFont(14f)
+            },
+            baseGridConstraintsAnchorWest(
+                row = 0
+            )
+        )
+
+        detailsPanel.add(
+            getInnerDetailedPathsPanel(3),
+            panelGridConstraints(
+                row = 1
+            )
+        )
+
+        return detailsPanel
+    }
+
+    private fun getInnerDetailedPathsPanel(itemsToShow: Int? = null): JPanel {
+        val detailsPanel = JPanel()
+        detailsPanel.layout = GridLayoutManager(groupedVulns.size + 2, 2, Insets(0, 0, 0, 0), -1, -1)
+
+        groupedVulns
+            .take(itemsToShow ?: groupedVulns.size)
+            .forEachIndexed { index, vuln ->
+                val detailPanel = JPanel()
+                detailPanel.layout = GridLayoutManager(2, 2, Insets(0, 0, 0, 0), 30, 5)
+
+                insertTitleAndResizableTextIntoPanelColumns(
+                    panel = detailPanel,
+                    row = 0,
+                    title = "Introduced through:",
+                    htmlText = vuln.from.joinToString(separator = " > ")
+                )
+
+                insertTitleAndResizableTextIntoPanelColumns(
+                    panel = detailPanel,
+                    row = 1,
+                    title = "Fix:",
+                    htmlText = vuln.nearestFixedInVersion ?: "none"
+                )
+
+                detailsPanel.add(
+                    detailPanel,
+                    panelGridConstraints(
+                        row = index + 1
+                    )
+                )
+            }
+
+        if (itemsToShow != null && itemsToShow < groupedVulns.size) {
+            val showMoreLabel = LinkLabel.create("...and ${groupedVulns.size - itemsToShow} more") {
+                detailsPanel.removeAll()
+                detailsPanel.add(
+                    getInnerDetailedPathsPanel(),
+                    panelGridConstraints(
+                        row = 0
+                    )
+                )
+            }
+            detailsPanel.add(
+                showMoreLabel,
+                baseGridConstraintsAnchorWest(groupedVulns.size + 1)
+            )
+        }
+
+        return detailsPanel
+    }
+
     private fun overviewPanel(): JPanel {
-        val panel = JPanel(GridLayoutManager(2, 2, Insets(0, 5, 0, 0), -1, 0))
+        val panel = JPanel(GridLayoutManager(2, 2, Insets(10, 5, 0, 0), -1, 0))
 
         val descriptionMarkdown = issue.description.replaceFirst("## NVD Description", "## Description")
         val document = Parser.builder().build().parse(descriptionMarkdown)

--- a/src/main/kotlin/snyk/container/ui/ContainerIssueTreeNode.kt
+++ b/src/main/kotlin/snyk/container/ui/ContainerIssueTreeNode.kt
@@ -11,20 +11,20 @@ import snyk.container.ContainerIssue
 import javax.swing.tree.DefaultMutableTreeNode
 
 class ContainerIssueTreeNode(
-    private val issue: ContainerIssue,
+    private val groupedVulns: List<ContainerIssue>,
     val project: Project,
     override val navigateToSource: () -> Unit
-) : DefaultMutableTreeNode(issue), NavigatableToSourceTreeNode, DescriptionHolderTreeNode {
+) : DefaultMutableTreeNode(groupedVulns.first()), NavigatableToSourceTreeNode, DescriptionHolderTreeNode {
 
     override fun getDescriptionPanel(logEventNeeded: Boolean): IssueDescriptionPanelBase {
         if (logEventNeeded) getSnykAnalyticsService().logIssueInTreeIsClicked(
             IssueInTreeIsClicked.builder()
                 .ide(IssueInTreeIsClicked.Ide.JETBRAINS)
                 .issueType(IssueInTreeIsClicked.IssueType.CONTAINER_VULNERABILITY)
-                .issueId(issue.id)
-                .severity(issue.getIssueSeverityOrNull())
+                .issueId(groupedVulns.first().id)
+                .severity(groupedVulns.first().getIssueSeverityOrNull())
                 .build()
         )
-        return ContainerIssueDetailPanel(issue)
+        return ContainerIssueDetailPanel(groupedVulns)
     }
 }


### PR DESCRIPTION
~~**!!! Could be reviewed/merged after #392 only !!!**~~ done
- Found Container vulnerabilities now grouped by ID (similar to OSS results):
![image](https://user-images.githubusercontent.com/14268320/175818068-4dcf5797-441e-4f64-abe3-25b9c141be06.png)

- For images with no remediation/fix available issues count(grouped by severity) now shown too:
![image](https://user-images.githubusercontent.com/14268320/175818258-588300bb-f416-46ac-b804-d5ab0cce5730.png)

- Naming for scan results in the tree and naming of result's count is corrected.
- In the result's tree, second level nodes(file/image) now have number of vulnerabilities/issues found in it:
![image](https://user-images.githubusercontent.com/14268320/175952309-65cca30d-b5a8-4c1e-9efc-785ba22106a1.png)