### PR TITLE
fix: Container scan for no-images-found case now produce correct message and visuals.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Results (json) received from CLI are now sanitized for correctness.
 - For mixed correct and failed-to-parse json results: successfully parsed elements will be shown alongside with errors.
+- Container scan for no-images-found case now produce correct message and visuals.
 
 ## [2.4.35]
 

--- a/src/integTest/kotlin/snyk/container/ContainerServiceIntegTest.kt
+++ b/src/integTest/kotlin/snyk/container/ContainerServiceIntegTest.kt
@@ -177,4 +177,23 @@ class ContainerServiceIntegTest : LightPlatform4TestCase() {
                 allCliIssues.any { it.imageName == "jenkins/jenkins:lts" }
         )
     }
+
+    @Test
+    fun `no images to scan case should produce correct ContainerResult`() {
+        // create KubernetesImageCache mock
+        val cache = spyk(KubernetesImageCache(project))
+        every { cache.getKubernetesWorkloadImages() } returns emptySet()
+        cut.setKubernetesImageCache(cache)
+
+        val containerResult = cut.scan()
+
+        verify { cache.getKubernetesWorkloadImages() }
+        assertFalse("Container scan should NOT succeed", containerResult.isSuccessful())
+        val allCliIssues = containerResult.allCliIssues
+        assertNull("Images with issues should be NOT found", allCliIssues)
+        assertTrue(
+            "ContainerResult should hold NO_IMAGES_TO_SCAN_ERROR inside",
+            containerResult.getFirstError() == ContainerService.NO_IMAGES_TO_SCAN_ERROR
+        )
+    }
 }

--- a/src/main/kotlin/snyk/container/ContainerService.kt
+++ b/src/main/kotlin/snyk/container/ContainerService.kt
@@ -31,7 +31,7 @@ class ContainerService(project: Project) : CliAdapter<ContainerIssuesForImage, C
         val imageNames = imageCache?.getKubernetesWorkloadImageNamesFromCache() ?: emptySet()
         LOG.debug("container scan requested for ${imageNames.size} images: $imageNames")
         if (imageNames.isEmpty()) {
-            return ContainerResult(emptyList(), listOf(NO_IMAGES_TO_SCAN_ERROR))
+            return ContainerResult(null, listOf(NO_IMAGES_TO_SCAN_ERROR))
         }
         val tempResult = execute(commands + imageNames)
         if (!tempResult.isSuccessful()) {


### PR DESCRIPTION
Current
![image](https://user-images.githubusercontent.com/14268320/175995696-a44e0207-8b9f-47ec-a2b4-4da0592b95a2.png)


Fixed
![image](https://user-images.githubusercontent.com/14268320/175995637-ee327b83-8975-435c-b13a-1057df939f4e.png)
