### PR TITLE
fix: 🐛 dont use kotlin file, but java.io.File (fixes #403) [ROAD-1068]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Snyk Changelog
 
-## [2.4.38]
+## [2.4.40]
+
+### Fixed
+
+- Plugin does not work in Jetbrains IDEs that are delivered without Kotlin
+
+## [2.4.39]
 
 ### Added
 

--- a/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
@@ -12,7 +12,7 @@ import io.snyk.plugin.cli.Platform
 import io.snyk.plugin.getPluginPath
 import io.snyk.plugin.getSnykProjectSettingsService
 import io.snyk.plugin.isProjectSettingsAvailable
-import org.jetbrains.kotlin.konan.file.File
+import java.io.File.separator
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -27,7 +27,7 @@ import java.util.UUID
 )
 class SnykApplicationSettingsStateService : PersistentStateComponent<SnykApplicationSettingsStateService> {
 
-    var cliPath: String = getPluginPath() + File.separator + Platform.current().snykWrapperFileName
+    var cliPath: String = getPluginPath() + separator + Platform.current().snykWrapperFileName
     var manageBinariesAutomatically: Boolean = true
     var fileListenerEnabled: Boolean = true
     var token: String? = null


### PR DESCRIPTION
### Description

By accident, a kotlin specific class was imported in to the Plugin Settings file.As not all IntelliJ-based IDEs bring Kotlin classes, the import led to a ClassNotFoundException and thus a plugin crash.

### Checklist

- [x] Linted
- [x] CHANGELOG.md updated

### Screenshots / GIFs
