### PR TITLE
fix: RIDER IDE now passes the --all-projects CLI arg by default [ROAD-1032]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Snyk Changelog
 
+## [2.4.43]
+
+### Fixed
+
+- `--all-projects` enabled by default for Rider IDE
+
 ## [2.4.41]
 
 ### Changed

--- a/src/integTest/kotlin/snyk/oss/OssServiceTest.kt
+++ b/src/integTest/kotlin/snyk/oss/OssServiceTest.kt
@@ -19,6 +19,7 @@ import io.snyk.plugin.setupDummyCliFile
 import org.junit.Test
 import snyk.PluginInformation
 import snyk.errorHandler.SentryErrorReporter
+import snyk.oss.OssService.Companion.ALL_PROJECTS_PARAM
 import snyk.pluginInfo
 
 class OssServiceTest : LightPlatformTestCase() {
@@ -119,9 +120,10 @@ class OssServiceTest : LightPlatformTestCase() {
         project.service<SnykProjectSettingsStateService>().additionalParameters =
             "--file=package.json --configuration-matching='iamaRegex' --all-projects"
 
-        val cliCommands = ossService.buildCliCommandsList_TEST_ONLY(listOf("fake_cli_command"))
-        val allProjectsCliCommands = cliCommands.filter { it == "--all-projects" }
-        assertTrue(allProjectsCliCommands.size == 1)
+        val countAllProjectsParams = ossService.buildCliCommandsList_TEST_ONLY(listOf("fake_cli_command"))
+            .count{ i -> i == ALL_PROJECTS_PARAM }
+
+        assertTrue(countAllProjectsParams == 1)
     }
 
     @Test

--- a/src/integTest/kotlin/snyk/oss/OssServiceTest.kt
+++ b/src/integTest/kotlin/snyk/oss/OssServiceTest.kt
@@ -106,6 +106,25 @@ class OssServiceTest : LightPlatformTestCase() {
     }
 
     @Test
+    fun testBuildCliCommandsListDoNotAddAllProjectsTwice() {
+        setupDummyCliFile()
+        val pluginInformation = PluginInformation(
+            integrationName = "INTEGRATION_NAME",
+            integrationVersion = "1.0.0",
+            integrationEnvironment = "INTEGRATION_ENV_RIDER",
+            integrationEnvironmentVersion = "1.0.0"
+        )
+
+        mockPluginInformation(pluginInformation)
+        project.service<SnykProjectSettingsStateService>().additionalParameters =
+            "--file=package.json --configuration-matching='iamaRegex' --all-projects"
+
+        val cliCommands = ossService.buildCliCommandsList_TEST_ONLY(listOf("fake_cli_command"))
+        val allProjectsCliCommands = cliCommands.filter { it == "--all-projects" }
+        assertTrue(allProjectsCliCommands.size == 1)
+    }
+
+    @Test
     fun testGroupVulnerabilities() {
         val cli = ossService
 

--- a/src/integTest/kotlin/snyk/oss/OssServiceTest.kt
+++ b/src/integTest/kotlin/snyk/oss/OssServiceTest.kt
@@ -5,6 +5,7 @@ import com.intellij.testFramework.LightPlatformTestCase
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.verify
 import io.snyk.plugin.cli.ConsoleCommandRunner
@@ -16,7 +17,9 @@ import io.snyk.plugin.resetSettings
 import io.snyk.plugin.services.SnykProjectSettingsStateService
 import io.snyk.plugin.setupDummyCliFile
 import org.junit.Test
+import snyk.PluginInformation
 import snyk.errorHandler.SentryErrorReporter
+import snyk.pluginInfo
 
 class OssServiceTest : LightPlatformTestCase() {
 
@@ -83,6 +86,23 @@ class OssServiceTest : LightPlatformTestCase() {
         assertTrue(cliCommands.contains("--file=package.json"))
         assertTrue(cliCommands.contains("--configuration-matching='iamaRegex'"))
         assertTrue(cliCommands.contains("--sub-project=snyk"))
+    }
+
+    @Test
+    fun testBuildCliCommandsListWithRiderIde() {
+        setupDummyCliFile()
+        val pluginInformation = PluginInformation(
+            integrationName = "INTEGRATION_NAME",
+            integrationVersion = "1.0.0",
+            integrationEnvironment = "INTEGRATION_ENV_RIDER",
+            integrationEnvironmentVersion = "1.0.0"
+        )
+
+        mockPluginInformation(pluginInformation)
+
+        val cliCommands = ossService.buildCliCommandsList_TEST_ONLY(listOf("fake_cli_command"))
+
+        assertTrue(cliCommands.contains("--all-projects"))
     }
 
     @Test
@@ -380,4 +400,9 @@ class OssServiceTest : LightPlatformTestCase() {
 
     private fun getResourceAsString(resourceName: String): String = javaClass.classLoader
         .getResource(resourceName)!!.readText(Charsets.UTF_8)
+
+    private fun mockPluginInformation(pluginInfoMock: PluginInformation) {
+        mockkStatic("snyk.PluginInformationKt")
+        every { pluginInfo } returns pluginInfoMock
+    }
 }

--- a/src/main/kotlin/snyk/oss/OssService.kt
+++ b/src/main/kotlin/snyk/oss/OssService.kt
@@ -33,17 +33,21 @@ class OssService(project: Project) : CliAdapter<OssVulnerabilitiesForFile, OssRe
         options.add("--json")
 
         val additionalParameters = settings.getAdditionalParameters(project)
-        val hasRiderParam = additionalParameters != null &&
-            additionalParameters.contains("RIDER")
+        val hasAllProjectsParam = additionalParameters != null &&
+            additionalParameters.contains(ALL_PROJECTS_PARAM)
 
         if (pluginInfo.integrationEnvironment.contains("RIDER") &&
-            !hasRiderParam) {
-            options.add("--all-projects")
+            !hasAllProjectsParam) {
+            options.add(ALL_PROJECTS_PARAM)
         }
 
         if (additionalParameters != null && additionalParameters.trim().isNotEmpty()) {
             options.addAll(additionalParameters.trim().split(" "))
         }
         return options
+    }
+
+    companion object {
+        const val ALL_PROJECTS_PARAM = "--all-projects"
     }
 }

--- a/src/main/kotlin/snyk/oss/OssService.kt
+++ b/src/main/kotlin/snyk/oss/OssService.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.project.Project
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.services.CliAdapter
 import snyk.common.SnykError
+import snyk.pluginInfo
 
 /**
  * Wrap work with Snyk CLI for OSS (`test` command).
@@ -28,6 +29,10 @@ class OssService(project: Project) : CliAdapter<OssVulnerabilitiesForFile, OssRe
     override fun buildExtraOptions(): List<String> {
         val settings = pluginSettings()
         val options: MutableList<String> = mutableListOf()
+
+        if (pluginInfo.integrationEnvironment.contains("RIDER")) {
+            options.add("--all-projects")
+        }
 
         options.add("--json")
 

--- a/src/main/kotlin/snyk/oss/OssService.kt
+++ b/src/main/kotlin/snyk/oss/OssService.kt
@@ -30,13 +30,16 @@ class OssService(project: Project) : CliAdapter<OssVulnerabilitiesForFile, OssRe
         val settings = pluginSettings()
         val options: MutableList<String> = mutableListOf()
 
-        if (pluginInfo.integrationEnvironment.contains("RIDER")) {
-            options.add("--all-projects")
-        }
-
         options.add("--json")
 
         val additionalParameters = settings.getAdditionalParameters(project)
+        val hasRiderParam = additionalParameters != null &&
+            additionalParameters.contains("RIDER")
+
+        if (pluginInfo.integrationEnvironment.contains("RIDER") &&
+            !hasRiderParam) {
+            options.add("--all-projects")
+        }
 
         if (additionalParameters != null && additionalParameters.trim().isNotEmpty()) {
             options.addAll(additionalParameters.trim().split(" "))


### PR DESCRIPTION
### Description

_This should add the `--all-projects` flag by default for the Rider IDE._

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated

