### PR TITLE
chore: use ubuntu-latest environment for all github workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   gradleValidation:
     name: Validate Gradle Wrapper
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Fetch Sources
         uses: actions/checkout@v2
@@ -50,7 +50,7 @@ jobs:
   pluginVerifier:
     name: Plugin Verifier
     needs: gradleValidation
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Fetch Sources
         uses: actions/checkout@v2

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   detekt:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Fetch Sources
         uses: actions/checkout@v2


### PR DESCRIPTION
### Description

This PR bumps environment to `ubuntu-latest` for all GitHub workflows.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

The warning from actions:
<img width="1207" alt="image" src="https://user-images.githubusercontent.com/60606414/195025086-b54241c4-9fc0-408f-81a1-d523f579f736.png">

