### PR TITLE
Feat: ignore IaC errors about broken JSON files [ROAD-1201]

### DIFF
--- a/src/integTest/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanelIntegTest.kt
+++ b/src/integTest/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanelIntegTest.kt
@@ -57,6 +57,7 @@ import snyk.container.ui.BaseImageRemediationDetailPanel
 import snyk.container.ui.ContainerImageTreeNode
 import snyk.container.ui.ContainerIssueDetailPanel
 import snyk.container.ui.ContainerIssueTreeNode
+import snyk.iac.IacError
 import snyk.iac.IacIssue
 import snyk.iac.IacIssuesForFile
 import snyk.iac.IacResult
@@ -292,7 +293,7 @@ class SnykToolWindowPanelIntegTest : HeavyPlatformTestCase() {
     fun `test when no IAC supported file found should display special text (not error) in node and description`() {
         mockkObject(SnykBalloonNotificationHelper)
 
-        val snykError = SnykError(SnykToolWindowPanel.NO_IAC_FILES, project.basePath.toString())
+        val snykError = SnykError(SnykToolWindowPanel.NO_IAC_FILES, project.basePath.toString(), IacError.NO_IAC_FILES_CODE)
         val snykErrorControl = SnykError("control", project.basePath.toString())
 
         scanPublisher.scanningIacError(snykErrorControl)

--- a/src/integTest/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanelIntegTest.kt
+++ b/src/integTest/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanelIntegTest.kt
@@ -322,7 +322,7 @@ class SnykToolWindowPanelIntegTest : HeavyPlatformTestCase() {
     }
 
     @Test
-    fun `Ignore JSON parsing failures in IaC scan results`() {
+    fun `test should ignore JSON parsing failures in IaC scan results`() {
         mockkObject(SnykBalloonNotificationHelper)
 
         val error = SnykError("Invalid JSON file", project.basePath.toString(), 1021)

--- a/src/integTest/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanelIntegTest.kt
+++ b/src/integTest/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanelIntegTest.kt
@@ -322,6 +322,20 @@ class SnykToolWindowPanelIntegTest : HeavyPlatformTestCase() {
     }
 
     @Test
+    fun `Ignore JSON parsing failures in IaC scan results`() {
+        mockkObject(SnykBalloonNotificationHelper)
+
+        val error = SnykError("Invalid JSON file", project.basePath.toString(), 1021)
+        val iacResult = IacResult(emptyList(), listOf(error))
+        scanPublisher.scanningIacFinished(iacResult)
+        PlatformTestUtil.dispatchAllEventsInIdeEventQueue()
+        assertEquals(
+            SnykToolWindowPanel.IAC_ROOT_TEXT + SnykToolWindowPanel.NO_ISSUES_FOUND_TEXT,
+            toolWindowPanel.getRootIacIssuesTreeNode().userObject
+        )
+    }
+
+    @Test
     fun `test should display NO_CONTAINER_IMAGES_FOUND after scan when no Container images found`() {
         mockkObject(SnykBalloonNotificationHelper)
 

--- a/src/main/java/snyk/analytics/Identify.java
+++ b/src/main/java/snyk/analytics/Identify.java
@@ -56,7 +56,7 @@ public class Identify extends Event {
     }
 
     /**
-     * when a User record is an actual user or when it’s a “service account”
+     * when a User record is an actual user or when it’s a "service account"
      */
     public Builder accountType(AccountType accountType) {
       this.properties.put("accountType", accountType.getAccountType());

--- a/src/main/kotlin/io/snyk/plugin/cli/CliError.kt
+++ b/src/main/kotlin/io/snyk/plugin/cli/CliError.kt
@@ -6,5 +6,8 @@ data class CliError(
     @SerializedName("error")
     val message: String,
 
-    val path: String
+    val path: String,
+
+    @SerializedName("code")
+    val errorCode: Int? = null
 )

--- a/src/main/kotlin/io/snyk/plugin/cli/CliResult.kt
+++ b/src/main/kotlin/io/snyk/plugin/cli/CliResult.kt
@@ -20,7 +20,7 @@ abstract class CliResult<CliIssues>(
 
     protected abstract fun countBySeverity(severity: Severity): Int?
 
-    fun getFirstError(): SnykError? = errors.firstOrNull()
+    open fun getFirstError(): SnykError? = errors.firstOrNull()
 
     fun criticalSeveritiesCount(): Int = countBySeverity(Severity.CRITICAL) ?: 0
 

--- a/src/main/kotlin/io/snyk/plugin/services/CliAdapter.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/CliAdapter.kt
@@ -45,7 +45,7 @@ abstract class CliAdapter<CliIssues, R : CliResult<CliIssues>>(val project: Proj
 
     private fun getErrorResult(errorMsg: String): R {
         logger.warn(errorMsg)
-        return getProductResult(null, listOf(SnykError(errorMsg, projectPath)))
+        return getProductResult(null, listOf(SnykError(errorMsg,projectPath)))
     }
 
     protected abstract fun getProductResult(cliIssues: List<CliIssues>?, snykErrors: List<SnykError> = emptyList()): R
@@ -94,9 +94,9 @@ abstract class CliAdapter<CliIssues, R : CliResult<CliIssues>>(val project: Proj
             }
             isErrorCliJsonString(rawStr) -> getResultOrError(reportExceptions, rawStr) {
                 // we should catch all exceptions here including JsonParseException, JsonSyntaxException, etc.
-                val cliError = Gson().fromJson(rawStr, CliError::class.java)
+                val cliError: CliError = Gson().fromJson(rawStr, CliError::class.java)
                 // `Gson().fromJson` could put `null` value into not-null field
-                val snykError = SnykError(cliError.message, cliError.path)
+                val snykError = SnykError(cliError.message, cliError.path, cliError.errorCode)
                 return@getResultOrError getProductResult(null, listOf(snykError))
             }
             else -> getErrorResult(rawStr)

--- a/src/main/kotlin/io/snyk/plugin/services/CliAdapter.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/CliAdapter.kt
@@ -45,7 +45,7 @@ abstract class CliAdapter<CliIssues, R : CliResult<CliIssues>>(val project: Proj
 
     private fun getErrorResult(errorMsg: String): R {
         logger.warn(errorMsg)
-        return getProductResult(null, listOf(SnykError(errorMsg,projectPath)))
+        return getProductResult(null, listOf(SnykError(errorMsg, projectPath)))
     }
 
     protected abstract fun getProductResult(cliIssues: List<CliIssues>?, snykErrors: List<SnykError> = emptyList()): R

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
@@ -236,7 +236,6 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
                 override fun scanningIacError(snykError: SnykError) {
                     var iacResultsCount: Int? = null
                     ApplicationManager.getApplication().invokeLater {
-                        // if results are all ignorable error codes, mark as no supported IaC files found, otherwise error
                         if (snykError.code == IacError.NO_IAC_FILES_CODE) {
                             iacResultsCount = NODE_NOT_SUPPORTED_STATE
                         } else {

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
@@ -85,6 +85,7 @@ import snyk.container.ContainerResult
 import snyk.container.ContainerService
 import snyk.container.ui.ContainerImageTreeNode
 import snyk.container.ui.ContainerIssueTreeNode
+import snyk.iac.IacError
 import snyk.iac.IacIssue
 import snyk.iac.IacResult
 import snyk.iac.ui.toolwindow.IacFileTreeNode
@@ -233,7 +234,7 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
                 override fun scanningIacError(snykError: SnykError) {
                     var iacResultsCount: Int? = null
                     ApplicationManager.getApplication().invokeLater {
-                        if (snykError.message.startsWith(NO_IAC_FILES)) {
+                        if (snykError.code == IacError.NO_IAC_FILES_CODE) {
                             iacResultsCount = NODE_NOT_SUPPORTED_STATE
                         } else {
                             SnykBalloonNotificationHelper.showError(snykError.message, project)

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
@@ -100,6 +100,8 @@ import javax.swing.tree.DefaultMutableTreeNode
 import javax.swing.tree.DefaultTreeModel
 import javax.swing.tree.TreePath
 
+private const val FailedToParseJsonErrorCode = 1021
+
 /**
  * Main panel for Snyk tool window.
  */
@@ -817,9 +819,11 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
                 }
             }
             iacResult.errors.forEach { snykError ->
-                rootIacIssuesTreeNode.add(
-                    ErrorTreeNode(snykError, project, navigateToIaCIssue(snykError.path, 0))
-                )
+                if (snykError.code != FailedToParseJsonErrorCode) {
+                    rootIacIssuesTreeNode.add(
+                        ErrorTreeNode(snykError, project, navigateToIaCIssue(snykError.path, 0))
+                    )
+                }
             }
         }
 

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
@@ -186,7 +186,9 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
                 override fun scanningIacFinished(iacResult: IacResult) {
                     ApplicationManager.getApplication().invokeLater {
                         displayIacResults(iacResult)
-                        notifyAboutErrorsIfNeeded(ProductType.IAC, iacResult)
+                        if (iacResult.getVisibleErrors().isNotEmpty()) {
+                            notifyAboutErrorsIfNeeded(ProductType.IAC, iacResult)
+                        }
                         refreshAnnotationsForOpenFiles(project)
                     }
                 }
@@ -234,6 +236,7 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
                 override fun scanningIacError(snykError: SnykError) {
                     var iacResultsCount: Int? = null
                     ApplicationManager.getApplication().invokeLater {
+                        // if results are all ignorable error codes, mark as no supported IaC files found, otherwise error
                         if (snykError.code == IacError.NO_IAC_FILES_CODE) {
                             iacResultsCount = NODE_NOT_SUPPORTED_STATE
                         } else {

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
@@ -100,8 +100,6 @@ import javax.swing.tree.DefaultMutableTreeNode
 import javax.swing.tree.DefaultTreeModel
 import javax.swing.tree.TreePath
 
-private const val FailedToParseJsonErrorCode = 1021
-
 /**
  * Main panel for Snyk tool window.
  */
@@ -818,12 +816,10 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
                         }
                 }
             }
-            iacResult.errors.forEach { snykError ->
-                if (snykError.code != FailedToParseJsonErrorCode) {
-                    rootIacIssuesTreeNode.add(
-                        ErrorTreeNode(snykError, project, navigateToIaCIssue(snykError.path, 0))
-                    )
-                }
+            iacResult.getVisibleErrors().forEach { snykError ->
+                rootIacIssuesTreeNode.add(
+                    ErrorTreeNode(snykError, project, navigateToIaCIssue(snykError.path, 0))
+                )
             }
         }
 

--- a/src/main/kotlin/snyk/common/SnykError.kt
+++ b/src/main/kotlin/snyk/common/SnykError.kt
@@ -2,5 +2,6 @@ package snyk.common
 
 data class SnykError(
     val message: String,
-    val path: String
+    val path: String,
+    val code: Int? = null
 )

--- a/src/main/kotlin/snyk/iac/IacError.kt
+++ b/src/main/kotlin/snyk/iac/IacError.kt
@@ -1,0 +1,7 @@
+package snyk.iac
+
+object IacError {
+    const val NO_IAC_FILES_CODE = 2114 // NoLoadableInput
+    const val INVALID_JSON_FILE_ERROR = 1021
+    const val FAILED_TO_PARSE_INPUT = 2105
+}

--- a/src/main/kotlin/snyk/iac/IacResult.kt
+++ b/src/main/kotlin/snyk/iac/IacResult.kt
@@ -6,7 +6,7 @@ import snyk.common.SnykError
 
 // List of IaC errors that are not relevant for users. E.g. IaC fails to parse a non-IaC file for certain reasons.
 // These should not be surfaced.
-private val IgnorableErrorCodes = intArrayOf(1021, 2105)
+private val IgnorableErrorCodes = intArrayOf(IacError.INVALID_JSON_FILE_ERROR, IacError.FAILED_TO_PARSE_INPUT)
 
 class IacResult(
     allIacVulnerabilities: List<IacIssuesForFile>?,

--- a/src/main/kotlin/snyk/iac/IacResult.kt
+++ b/src/main/kotlin/snyk/iac/IacResult.kt
@@ -26,6 +26,10 @@ class IacResult(
         }
     }
 
+    override fun getFirstError(): SnykError? {
+        return getVisibleErrors().firstOrNull()
+    }
+
     fun getVisibleErrors(): List<SnykError> {
         return errors.filter { it.code == null || !IgnorableErrorCodes.contains(it.code) }
     }

--- a/src/main/kotlin/snyk/iac/IacResult.kt
+++ b/src/main/kotlin/snyk/iac/IacResult.kt
@@ -4,6 +4,10 @@ import io.snyk.plugin.Severity
 import io.snyk.plugin.cli.CliResult
 import snyk.common.SnykError
 
+// List of IaC errors that are not relevant for users. E.g. IaC fails to parse a non-IaC file for certain reasons.
+// These should not be surfaced.
+private val IgnorableErrorCodes = intArrayOf(1021, 2105)
+
 class IacResult(
     allIacVulnerabilities: List<IacIssuesForFile>?,
     errors: List<SnykError> = emptyList()
@@ -20,5 +24,9 @@ class IacResult(
                 .distinctBy { it.id }
                 .size
         }
+    }
+
+    fun getVisibleErrors(): List<SnykError> {
+        return errors.filter { it.code == null || !IgnorableErrorCodes.contains(it.code) }
     }
 }


### PR DESCRIPTION
### Description

Ignore IaC errors about broken JSON syntax

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing
