### PR TITLE
fix: authorization header for non-authenticated proxy 

### DIFF
--- a/.github/detekt/detekt-baseline.xml
+++ b/.github/detekt/detekt-baseline.xml
@@ -2,11 +2,12 @@
 <SmellBaseline>
   <ManuallySuppressedIssues>
     <ID>EmptyFunctionBlock:RetrofitClientFactory.kt$RetrofitClientFactory.&lt;no name provided>${}</ID>
-    <ID>ComplexCondition:RetrofitAuthenticator.kt$RetrofitAuthenticator$auth == null || auth.userName.isNullOrBlank() ||
-      auth.password==null || auth.password.isEmpty()
-    </ID>
+
     <ID>ReturnCount:RetrofitAuthenticator.kt$RetrofitAuthenticator$override fun authenticate(route: Route?, response:
       Response): Request
+    </ID>
+    <ID>ComplexCondition:RetrofitAuthenticator.kt$RetrofitAuthenticator$auth == null || auth.userName.isNullOrBlank() ||
+      auth.password == null || auth.password.isEmpty()
     </ID>
   </ManuallySuppressedIssues>
   <CurrentIssues>

--- a/.github/detekt/detekt-baseline.xml
+++ b/.github/detekt/detekt-baseline.xml
@@ -2,6 +2,12 @@
 <SmellBaseline>
   <ManuallySuppressedIssues>
     <ID>EmptyFunctionBlock:RetrofitClientFactory.kt$RetrofitClientFactory.&lt;no name provided>${}</ID>
+    <ID>ComplexCondition:RetrofitAuthenticator.kt$RetrofitAuthenticator$auth == null || auth.userName.isNullOrBlank() ||
+      auth.password==null || auth.password.isEmpty()
+    </ID>
+    <ID>ReturnCount:RetrofitAuthenticator.kt$RetrofitAuthenticator$override fun authenticate(route: Route?, response:
+      Response): Request
+    </ID>
   </ManuallySuppressedIssues>
   <CurrentIssues>
     <ID>ChainWrapping:io.snyk.plugin.services.SnykCliDownloaderService.kt:115</ID>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Snyk Changelog
 
+## [2.4.57]
+
+### Fixed
+
+- Network requests when proxy authentication not required.
+
 ## [2.4.56]
 
 ### Fixed

--- a/src/main/kotlin/io/snyk/plugin/net/RetrofitAuthenticator.kt
+++ b/src/main/kotlin/io/snyk/plugin/net/RetrofitAuthenticator.kt
@@ -10,16 +10,23 @@ import okhttp3.Route
 const val PROXY_AUTHORIZATION_HEADER_NAME = "Proxy-Authorization"
 
 class RetrofitAuthenticator(
+    // injectable httpconfigurable for testing
     private var httpConfigurable: HttpConfigurable? = null
 ) : Authenticator {
     override fun authenticate(route: Route?, response: Response): Request {
         if (httpConfigurable == null) {
             httpConfigurable = HttpConfigurable.getInstance()
         }
-        val prompt = "Snyk: Please enter your proxy credentials for connecting"
-        val auth = httpConfigurable!!.getPromptedAuthentication(response.request.url.host, prompt)
 
-        if (auth.userName == null || auth.password == null) {
+        // if no proxy configuration available, we just return the request
+        if (httpConfigurable?.PROXY_AUTHENTICATION == false) {
+            return response.request
+        }
+
+        val prompt = "Snyk: Please enter your proxy credentials for connecting"
+        val auth = httpConfigurable?.getPromptedAuthentication(response.request.url.host, prompt)
+
+        if (auth == null || auth.userName.isNullOrBlank() || auth.password == null || auth.password.isEmpty()) {
             return response.request
         }
 

--- a/src/test/kotlin/io/snyk/plugin/net/RetrofitAuthenticatorTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/net/RetrofitAuthenticatorTest.kt
@@ -18,6 +18,7 @@ class RetrofitAuthenticatorTest {
         val httpConfigurableMock = mockk<HttpConfigurable>()
         val auth = mockk<PasswordAuthentication>()
         every { httpConfigurableMock.getPromptedAuthentication(any(), any()) } returns auth
+        httpConfigurableMock.PROXY_AUTHENTICATION = true
         every { auth.userName } returns "username"
         every { auth.password } returns "pw".toCharArray()
         val cut = RetrofitAuthenticator(httpConfigurableMock)
@@ -36,5 +37,25 @@ class RetrofitAuthenticatorTest {
         assertNotNull(authHeader)
         assertEquals("Basic dXNlcm5hbWU6cHc=", authHeader)
         assertEquals("dXNlcm5hbWU6cHc=", Base64.encode("username:pw".toByteArray()))
+    }
+
+    @Test
+    fun `No authorization header added for non-authenticated proxy`() {
+        val httpConfigurableMock = mockk<HttpConfigurable>()
+        httpConfigurableMock.PROXY_AUTHENTICATION = false
+        val cut = RetrofitAuthenticator(httpConfigurableMock)
+
+        val route: Route = mockk()
+        val response: Response = Response.Builder()
+            .request(okhttp3.Request.Builder().url("https://example.com").build())
+            .code(200)
+            .protocol(okhttp3.Protocol.HTTP_1_1)
+            .message("")
+            .build()
+
+        val request = cut.authenticate(route, response)
+
+        val authHeader = request!!.headers[PROXY_AUTHORIZATION_HEADER_NAME]
+        assertEquals(null, authHeader)
     }
 }

--- a/src/test/kotlin/io/snyk/plugin/net/RetrofitAuthenticatorTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/net/RetrofitAuthenticatorTest.kt
@@ -6,6 +6,7 @@ import io.mockk.every
 import io.mockk.mockk
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertNotNull
+import junit.framework.TestCase.assertNull
 import okhttp3.Response
 import okhttp3.Route
 import org.junit.Test
@@ -56,6 +57,6 @@ class RetrofitAuthenticatorTest {
         val request = cut.authenticate(route, response)
 
         val authHeader = request!!.headers[PROXY_AUTHORIZATION_HEADER_NAME]
-        assertEquals(null, authHeader)
+        assertNull(authHeader)
     }
 }


### PR DESCRIPTION
### Description

Prevents proxy authentication dialog popup, when proxy doesn't require auth.

```
WARN - #io.snyk.plugin.net.SnykApiClient - Failed to execute 'user/me' network request: auth must not be null
java.lang.IllegalStateException: auth must not be null
	at io.snyk.plugin.net.RetrofitAuthenticator.authenticate(RetrofitAuthenticator.kt:22)
	at okhttp3.internal.connection.RealConnection.createTunnelRequest(RealConnection.kt:519)
	at okhttp3.internal.connection.RealConnection.connectTunnel(RealConnection.kt:258)
	at okhttp3.internal.connection.RealConnection.connect(RealConnection.kt:201)
	at okhttp3.internal.connection.ExchangeFinder.findConnection(ExchangeFinder.kt:226)
 ```

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
