### PR TITLE
fix: calculate file relative path with java instead of jetbrains [SUP-1273]

### DIFF
--- a/src/main/kotlin/snyk/iac/IgnoreButtonActionListener.kt
+++ b/src/main/kotlin/snyk/iac/IgnoreButtonActionListener.kt
@@ -6,7 +6,6 @@ import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.project.calcRelativeToProjectPath
 import com.intellij.psi.PsiFile
 import io.snyk.plugin.ui.SnykBalloonNotificationHelper
 import org.jetbrains.annotations.NotNull
@@ -14,6 +13,7 @@ import snyk.common.IgnoreException
 import snyk.common.IgnoreService
 import java.awt.event.ActionEvent
 import java.awt.event.ActionListener
+import java.nio.file.Paths
 import javax.swing.JButton
 
 class IgnoreButtonActionListener(
@@ -37,9 +37,11 @@ class IgnoreButtonActionListener(
         override fun run(@NotNull progressIndicator: ProgressIndicator) {
             try {
                 val relativeFilePath = if (psiFile != null) {
-                    calcRelativeToProjectPath(psiFile.virtualFile, project)
-                        .replace(".../", "")
-                        .replace("…/", "")
+                    val basePath = project.basePath
+                        ?: throw IgnoreException("Project base path is null or blank. Cannot determine relative path.")
+
+                    val projectBasePath = Paths.get(basePath)
+                    projectBasePath.relativize(psiFile.virtualFile.toNioPath()).toString()
                 } else {
                     "*"
                 }


### PR DESCRIPTION
### Description

The used Jetbrains method didn't provide the path without need to cleanup

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
