### PR TITLE
chore: update URL for Snyk IaC rule with new Site URL (APOLLO11-1173)

### DIFF
--- a/src/integTest/resources/iac-test-results/fargate.json
+++ b/src/integTest/resources/iac-test-results/fargate.json
@@ -47,7 +47,7 @@
         "resolve": "Set `Properties.ImageScanningConfiguration` attribute to `true`"
       },
       "lineNumber": 23,
-      "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-61",
+      "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-61",
       "path": [
         "[DocId:0]",
         "Resources[EcrDockerRepository]",
@@ -79,7 +79,7 @@
         "resolve": "Set `Properties.VersioningConfiguration.Status` attribute to `Enabled`"
       },
       "lineNumber": 23,
-      "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-124",
+      "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-124",
       "path": [
         "[DocId:0]",
         "Resources[CodePipelineArtifactBucket]",
@@ -115,7 +115,7 @@
         "resolve": "Set `Properties.PublicAccessBlockConfiguration.BlockPublicAcls` attribute to `true`"
       },
       "lineNumber": 23,
-      "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-95",
+      "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-95",
       "path": [
         "[DocId:0]",
         "Resources[DefaultContainerBucket]",
@@ -151,7 +151,7 @@
         "resolve": "Set `Properties.PublicAccessBlockConfiguration.BlockPublicAcls` attribute to `true`"
       },
       "lineNumber": 23,
-      "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-95",
+      "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-95",
       "path": [
         "[DocId:0]",
         "Resources[CodePipelineArtifactBucket]",
@@ -185,7 +185,7 @@
         "resolve": "Set `Properties.EncryptionConfiguration.KmsKey` attribute to customer managed KMS key"
       },
       "lineNumber": 23,
-      "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-418",
+      "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-418",
       "path": [
         "[DocId:0]",
         "Resources[EcrDockerRepository]",
@@ -221,7 +221,7 @@
         "resolve": "Set `Properties.PublicAccessBlockConfiguration.BlockPublicPolicy` attribute to `true`"
       },
       "lineNumber": 23,
-      "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-96",
+      "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-96",
       "path": [
         "[DocId:0]",
         "Resources[DefaultContainerBucket]",
@@ -254,7 +254,7 @@
         "resolve": "Set `Properties.LoadBalancerAttributes.Key` to `routing.http.drop_invalid_header_fields.enabled` and `Properties.LoadBalancerAttributes.Value` to `true`"
       },
       "lineNumber": 23,
-      "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-405",
+      "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-405",
       "path": [
         "[DocId:0]",
         "Resources[ApplicationLoadBalancer]",
@@ -286,7 +286,7 @@
         "resolve": "Set `Properties.Scheme` attribute to `internal`"
       },
       "lineNumber": 569,
-      "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-48",
+      "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-48",
       "path": [
         "[DocId:0]",
         "Resources",
@@ -319,7 +319,7 @@
         "resolve": "Set `Properties.ImageTagMutability` attribute to `IMMUTABLE`"
       },
       "lineNumber": 23,
-      "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-126",
+      "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-126",
       "path": [
         "[DocId:0]",
         "Resources[EcrDockerRepository]",
@@ -351,7 +351,7 @@
         "resolve": "Set `Properties.VersioningConfiguration.Status` attribute to `Enabled`"
       },
       "lineNumber": 23,
-      "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-124",
+      "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-124",
       "path": [
         "[DocId:0]",
         "Resources[DefaultContainerBucket]",
@@ -384,7 +384,7 @@
         "resolve": "Set `KmsMasterKeyId` attribute to KMS key for example `alias/aws/sns`"
       },
       "lineNumber": 893,
-      "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-55",
+      "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-55",
       "path": [
         "[DocId:0]",
         "Resources",
@@ -420,7 +420,7 @@
         "resolve": "Set `Properties.PublicAccessBlockConfiguration.BlockPublicPolicy` attribute to `true`"
       },
       "lineNumber": 23,
-      "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-96",
+      "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-96",
       "path": [
         "[DocId:0]",
         "Resources[CodePipelineArtifactBucket]",
@@ -456,7 +456,7 @@
         "resolve": "Set `Properties.PublicAccessBlockConfiguration.IgnorePublicAcls` attribute to `true`"
       },
       "lineNumber": 23,
-      "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-97",
+      "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-97",
       "path": [
         "[DocId:0]",
         "Resources[DefaultContainerBucket]",
@@ -490,7 +490,7 @@
         "resolve": "Set `Properties.KmsMasterKeyId` attribute to a customer managed key id "
       },
       "lineNumber": 23,
-      "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-422",
+      "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-422",
       "path": [
         "[DocId:0]",
         "Resources[LoadBalancerAlarmTopic]",
@@ -525,7 +525,7 @@
         "resolve": "Set `Properties.PublicAccessBlockConfiguration.IgnorePublicAcls` attribute to `true`"
       },
       "lineNumber": 23,
-      "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-97",
+      "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-97",
       "path": [
         "[DocId:0]",
         "Resources[CodePipelineArtifactBucket]",
@@ -561,7 +561,7 @@
         "resolve": "Set `Properties.PublicAccessBlockConfiguration.RestrictPublicBuckets` attribute to `true`"
       },
       "lineNumber": 23,
-      "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-98",
+      "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-98",
       "path": [
         "[DocId:0]",
         "Resources[DefaultContainerBucket]",
@@ -595,7 +595,7 @@
         "resolve": "Set `Properties.KmsKeyId` attribute with customer managed key id"
       },
       "lineNumber": 23,
-      "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-415",
+      "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-415",
       "path": [
         "[DocId:0]",
         "Resources[DefaultLogGroup]",
@@ -630,7 +630,7 @@
         "resolve": "Set `Properties.PublicAccessBlockConfiguration.RestrictPublicBuckets` attribute to `true`"
       },
       "lineNumber": 23,
-      "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-98",
+      "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-98",
       "path": [
         "[DocId:0]",
         "Resources[CodePipelineArtifactBucket]",
@@ -663,7 +663,7 @@
         "resolve": "Set `Properties.ClusterSettings.Name` attribute to `containerInsights`, and `Properties.ClusterSettings.Value` to `enabled`"
       },
       "lineNumber": 23,
-      "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-128",
+      "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-128",
       "path": [
         "[DocId:0]",
         "Resources[FargateEcsCluster]",

--- a/src/integTest/resources/iac-test-results/infrastructure-as-code-goof.json
+++ b/src/integTest/resources/iac-test-results/infrastructure-as-code-goof.json
@@ -51,7 +51,7 @@
           "resolve": "Set `BlockDeviceMappings.Encrypted` attribute of root device to `true`"
         },
         "lineNumber": 291,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-53",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-53",
         "path": [
           "[DocId:0]",
           "Resources",
@@ -112,7 +112,7 @@
           "resolve": "Set `Properties.KmsMasterKeyId` attribute to a customer managed key id "
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-422",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-422",
         "path": [
           "[DocId:0]",
           "Resources[DatabaseAlarmTopic]",
@@ -144,7 +144,7 @@
           "resolve": "Set `Properties.StorageEncrypted` attribute to `true`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-201",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-201",
         "path": [
           "[DocId:0]",
           "Resources[AuroraInstance1]",
@@ -176,7 +176,7 @@
           "resolve": "Set `Properties.EnableIAMDatabaseAuthentication` to `true`."
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-414",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-414",
         "path": [
           "[DocId:0]",
           "Resources[AuroraInstance0]",
@@ -209,7 +209,7 @@
           "resolve": "Set `Properties.StorageEncrypted` attribute to `true`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-439",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-439",
         "path": [
           "[DocId:0]",
           "Resources[AuroraCluster]",
@@ -241,7 +241,7 @@
           "resolve": "Set `KmsMasterKeyId` attribute to KMS key for example `alias/aws/sns`"
         },
         "lineNumber": 183,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-55",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-55",
         "path": [
           "[DocId:0]",
           "Resources",
@@ -274,7 +274,7 @@
           "resolve": "Set `Properties.StorageEncrypted` attribute to `true`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-201",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-201",
         "path": [
           "[DocId:0]",
           "Resources[AuroraInstance0]",
@@ -306,7 +306,7 @@
           "resolve": "Set `Properties.EnableIAMDatabaseAuthentication` to `true`."
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-414",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-414",
         "path": [
           "[DocId:0]",
           "Resources[AuroraInstance1]",
@@ -365,7 +365,7 @@
           "resolve": "Set `DisableApiTermination` attribute with value `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-426",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-426",
         "path": [
           "[DocId:0]",
           "Resources[BastionHost]",
@@ -400,7 +400,7 @@
           "resolve": "Set `BlockDeviceMappings.Encrypted` attribute of root device to `true`"
         },
         "lineNumber": 212,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-53",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-53",
         "path": [
           "[DocId:0]",
           "Resources",
@@ -434,7 +434,7 @@
           "resolve": "Set `Properties.KmsKeyId` attribute with customer managed key id"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-415",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-415",
         "path": [
           "[DocId:0]",
           "Resources[BastionSecureLogGroup]",
@@ -493,7 +493,7 @@
           "resolve": "Set `KmsMasterKeyId` attribute to KMS key for example `alias/aws/sns`"
         },
         "lineNumber": 38,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-55",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-55",
         "path": [
           "[DocId:0]",
           "Resources",
@@ -527,7 +527,7 @@
           "resolve": "Set `Properties.KmsMasterKeyId` attribute to a customer managed key id "
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-422",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-422",
         "path": [
           "[DocId:0]",
           "Resources[BillingAlarmTopic]",
@@ -586,7 +586,7 @@
           "resolve": "Set `KmsMasterKeyId` attribute to KMS key for example `alias/aws/sns`"
         },
         "lineNumber": 203,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-55",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-55",
         "path": [
           "[DocId:0]",
           "Resources",
@@ -620,7 +620,7 @@
           "resolve": "Set `Properties.KmsMasterKeyId` attribute to a customer managed key id "
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-422",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-422",
         "path": [
           "[DocId:0]",
           "Resources[DatabaseAlarmTopic]",
@@ -652,7 +652,7 @@
           "resolve": "Set `Properties.StorageEncrypted` attribute to `true`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-201",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-201",
         "path": [
           "[DocId:0]",
           "Resources[Database]",
@@ -684,7 +684,7 @@
           "resolve": "Set `Properties.EnableIAMDatabaseAuthentication` to `true`."
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-414",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-414",
         "path": [
           "[DocId:0]",
           "Resources[Database]",
@@ -743,7 +743,7 @@
           "resolve": "Set `Actions` and `Resources` attributes to limited subset, e.g `Actions: ['s3:Create*']`"
         },
         "lineNumber": -1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-119",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-119",
         "path": [
           "[DocId:0]",
           "Resources[AppPolicies]",
@@ -802,7 +802,7 @@
           "resolve": "Set `Properties.SnapshotRetentionLimit` to `1` or more"
         },
         "lineNumber": 16,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-407",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-407",
         "path": [
           "[DocId:0]",
           "Resources[ElastiCacheCluster]",
@@ -861,7 +861,7 @@
           "resolve": "Set `Properties.ImageScanningConfiguration` attribute to `true`"
         },
         "lineNumber": -1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-61",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-61",
         "path": [
           "[DocId:0]",
           "Resources[EcrDockerRepository]",
@@ -893,7 +893,7 @@
           "resolve": "Set `Properties.VersioningConfiguration.Status` attribute to `Enabled`"
         },
         "lineNumber": -1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-124",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-124",
         "path": [
           "[DocId:0]",
           "Resources[CodePipelineArtifactBucket]",
@@ -929,7 +929,7 @@
           "resolve": "Set `Properties.PublicAccessBlockConfiguration.BlockPublicPolicy` attribute to `true`"
         },
         "lineNumber": -1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-96",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-96",
         "path": [
           "[DocId:0]",
           "Resources[CodePipelineArtifactBucket]",
@@ -965,7 +965,7 @@
           "resolve": "Set `Properties.PublicAccessBlockConfiguration.IgnorePublicAcls` attribute to `true`"
         },
         "lineNumber": -1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-97",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-97",
         "path": [
           "[DocId:0]",
           "Resources[CodePipelineArtifactBucket]",
@@ -999,7 +999,7 @@
           "resolve": "Set `Properties.KmsKeyId` attribute with customer managed key id"
         },
         "lineNumber": -1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-415",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-415",
         "path": [
           "[DocId:0]",
           "Resources[LogGroup]",
@@ -1034,7 +1034,7 @@
           "resolve": "Set `Properties.PublicAccessBlockConfiguration.BlockPublicAcls` attribute to `true`"
         },
         "lineNumber": -1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-95",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-95",
         "path": [
           "[DocId:0]",
           "Resources[CodePipelineArtifactBucket]",
@@ -1068,7 +1068,7 @@
           "resolve": "Set `Properties.EncryptionConfiguration.KmsKey` attribute to customer managed KMS key"
         },
         "lineNumber": -1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-418",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-418",
         "path": [
           "[DocId:0]",
           "Resources[EcrDockerRepository]",
@@ -1101,7 +1101,7 @@
           "resolve": "Set `Properties.ImageTagMutability` attribute to `IMMUTABLE`"
         },
         "lineNumber": -1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-126",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-126",
         "path": [
           "[DocId:0]",
           "Resources[EcrDockerRepository]",
@@ -1136,7 +1136,7 @@
           "resolve": "Set `Properties.PublicAccessBlockConfiguration.RestrictPublicBuckets` attribute to `true`"
         },
         "lineNumber": -1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-98",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-98",
         "path": [
           "[DocId:0]",
           "Resources[CodePipelineArtifactBucket]",
@@ -1196,7 +1196,7 @@
           "resolve": "Set `Properties.ImageScanningConfiguration` attribute to `true`"
         },
         "lineNumber": 23,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-61",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-61",
         "path": [
           "[DocId:0]",
           "Resources[EcrDockerRepository]",
@@ -1228,7 +1228,7 @@
           "resolve": "Set `Properties.VersioningConfiguration.Status` attribute to `Enabled`"
         },
         "lineNumber": 23,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-124",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-124",
         "path": [
           "[DocId:0]",
           "Resources[CodePipelineArtifactBucket]",
@@ -1264,7 +1264,7 @@
           "resolve": "Set `Properties.PublicAccessBlockConfiguration.BlockPublicAcls` attribute to `true`"
         },
         "lineNumber": 23,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-95",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-95",
         "path": [
           "[DocId:0]",
           "Resources[DefaultContainerBucket]",
@@ -1300,7 +1300,7 @@
           "resolve": "Set `Properties.PublicAccessBlockConfiguration.BlockPublicAcls` attribute to `true`"
         },
         "lineNumber": 23,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-95",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-95",
         "path": [
           "[DocId:0]",
           "Resources[CodePipelineArtifactBucket]",
@@ -1334,7 +1334,7 @@
           "resolve": "Set `Properties.EncryptionConfiguration.KmsKey` attribute to customer managed KMS key"
         },
         "lineNumber": 23,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-418",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-418",
         "path": [
           "[DocId:0]",
           "Resources[EcrDockerRepository]",
@@ -1370,7 +1370,7 @@
           "resolve": "Set `Properties.PublicAccessBlockConfiguration.BlockPublicPolicy` attribute to `true`"
         },
         "lineNumber": 23,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-96",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-96",
         "path": [
           "[DocId:0]",
           "Resources[DefaultContainerBucket]",
@@ -1403,7 +1403,7 @@
           "resolve": "Set `Properties.LoadBalancerAttributes.Key` to `routing.http.drop_invalid_header_fields.enabled` and `Properties.LoadBalancerAttributes.Value` to `true`"
         },
         "lineNumber": 23,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-405",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-405",
         "path": [
           "[DocId:0]",
           "Resources[ApplicationLoadBalancer]",
@@ -1435,7 +1435,7 @@
           "resolve": "Set `Properties.Scheme` attribute to `internal`"
         },
         "lineNumber": 569,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-48",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-48",
         "path": [
           "[DocId:0]",
           "Resources",
@@ -1468,7 +1468,7 @@
           "resolve": "Set `Properties.ImageTagMutability` attribute to `IMMUTABLE`"
         },
         "lineNumber": 23,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-126",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-126",
         "path": [
           "[DocId:0]",
           "Resources[EcrDockerRepository]",
@@ -1500,7 +1500,7 @@
           "resolve": "Set `Properties.VersioningConfiguration.Status` attribute to `Enabled`"
         },
         "lineNumber": 23,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-124",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-124",
         "path": [
           "[DocId:0]",
           "Resources[DefaultContainerBucket]",
@@ -1533,7 +1533,7 @@
           "resolve": "Set `KmsMasterKeyId` attribute to KMS key for example `alias/aws/sns`"
         },
         "lineNumber": 893,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-55",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-55",
         "path": [
           "[DocId:0]",
           "Resources",
@@ -1569,7 +1569,7 @@
           "resolve": "Set `Properties.PublicAccessBlockConfiguration.BlockPublicPolicy` attribute to `true`"
         },
         "lineNumber": 23,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-96",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-96",
         "path": [
           "[DocId:0]",
           "Resources[CodePipelineArtifactBucket]",
@@ -1605,7 +1605,7 @@
           "resolve": "Set `Properties.PublicAccessBlockConfiguration.IgnorePublicAcls` attribute to `true`"
         },
         "lineNumber": 23,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-97",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-97",
         "path": [
           "[DocId:0]",
           "Resources[DefaultContainerBucket]",
@@ -1639,7 +1639,7 @@
           "resolve": "Set `Properties.KmsMasterKeyId` attribute to a customer managed key id "
         },
         "lineNumber": 23,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-422",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-422",
         "path": [
           "[DocId:0]",
           "Resources[LoadBalancerAlarmTopic]",
@@ -1674,7 +1674,7 @@
           "resolve": "Set `Properties.PublicAccessBlockConfiguration.IgnorePublicAcls` attribute to `true`"
         },
         "lineNumber": 23,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-97",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-97",
         "path": [
           "[DocId:0]",
           "Resources[CodePipelineArtifactBucket]",
@@ -1710,7 +1710,7 @@
           "resolve": "Set `Properties.PublicAccessBlockConfiguration.RestrictPublicBuckets` attribute to `true`"
         },
         "lineNumber": 23,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-98",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-98",
         "path": [
           "[DocId:0]",
           "Resources[DefaultContainerBucket]",
@@ -1744,7 +1744,7 @@
           "resolve": "Set `Properties.KmsKeyId` attribute with customer managed key id"
         },
         "lineNumber": 23,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-415",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-415",
         "path": [
           "[DocId:0]",
           "Resources[DefaultLogGroup]",
@@ -1779,7 +1779,7 @@
           "resolve": "Set `Properties.PublicAccessBlockConfiguration.RestrictPublicBuckets` attribute to `true`"
         },
         "lineNumber": 23,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-98",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-98",
         "path": [
           "[DocId:0]",
           "Resources[CodePipelineArtifactBucket]",
@@ -1812,7 +1812,7 @@
           "resolve": "Set `Properties.ClusterSettings.Name` attribute to `containerInsights`, and `Properties.ClusterSettings.Value` to `enabled`"
         },
         "lineNumber": 23,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-128",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-128",
         "path": [
           "[DocId:0]",
           "Resources[FargateEcsCluster]",
@@ -1874,7 +1874,7 @@
           "resolve": "Set `BlockDeviceMappings.Encrypted` attribute of root device to `true`"
         },
         "lineNumber": 486,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-53",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-53",
         "path": [
           "[DocId:0]",
           "Resources",
@@ -1907,7 +1907,7 @@
           "resolve": "Set `DisableApiTermination` attribute with value `true`"
         },
         "lineNumber": 2,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-426",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-426",
         "path": [
           "[DocId:0]",
           "Resources[EC2Instance]",
@@ -1967,7 +1967,7 @@
           "resolve": "Set `Properties.SecurityGroupEgress.CidrIp` attribute to specific ranges e.g. `192.168.1.0/24`"
         },
         "lineNumber": 2,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-73",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-73",
         "path": [
           "[DocId:0]",
           "Resources[BastionSecurityGroup]",
@@ -2000,7 +2000,7 @@
           "resolve": "Set `Properties.SecurityGroupIngress.CidrIp` attribute with a more restrictive IP, for example `192.16.0.0/24`"
         },
         "lineNumber": 254,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-1",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-1",
         "path": [
           "[DocId:0]",
           "Resources",
@@ -2035,7 +2035,7 @@
           "resolve": "Set `Properties.SecurityGroupEgress.CidrIp` attribute to specific ranges e.g. `192.168.1.0/24`"
         },
         "lineNumber": 2,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-72",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-72",
         "path": [
           "[DocId:0]",
           "Resources[BastionSecurityGroup]",
@@ -2068,7 +2068,7 @@
           "resolve": "Set `Properties.SecurityGroupEgress.CidrIp` attribute to specific ranges e.g. `192.168.1.0/24`"
         },
         "lineNumber": 2,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-73",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-73",
         "path": [
           "[DocId:0]",
           "Resources[BastionSecurityGroup]",
@@ -2103,7 +2103,7 @@
           "resolve": "Set `Properties.SecurityGroupEgress.CidrIp` attribute to specific ranges e.g. `192.168.1.0/24`"
         },
         "lineNumber": 2,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-72",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-72",
         "path": [
           "[DocId:0]",
           "Resources[BastionSecurityGroup]",
@@ -2136,7 +2136,7 @@
           "resolve": "Set `Properties.SecurityGroupEgress.CidrIp` attribute to specific ranges e.g. `192.168.1.0/24`"
         },
         "lineNumber": 2,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-73",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-73",
         "path": [
           "[DocId:0]",
           "Resources[DbSecurityGroup]",
@@ -2171,7 +2171,7 @@
           "resolve": "Set `Properties.SecurityGroupEgress.CidrIp` attribute to specific ranges e.g. `192.168.1.0/24`"
         },
         "lineNumber": 2,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-72",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-72",
         "path": [
           "[DocId:0]",
           "Resources[DbSecurityGroup]",
@@ -2204,7 +2204,7 @@
           "resolve": "Set `Properties.SecurityGroupEgress.CidrIp` attribute to specific ranges e.g. `192.168.1.0/24`"
         },
         "lineNumber": 2,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-73",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-73",
         "path": [
           "[DocId:0]",
           "Resources[BastionSecurityGroup]",
@@ -2239,7 +2239,7 @@
           "resolve": "Set `Properties.SecurityGroupEgress.CidrIp` attribute to specific ranges e.g. `192.168.1.0/24`"
         },
         "lineNumber": 2,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-72",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-72",
         "path": [
           "[DocId:0]",
           "Resources[BastionSecurityGroup]",
@@ -2273,7 +2273,7 @@
           "resolve": "Set `Properties.SecurityGroupEgress.CidrIp` attribute to specific ranges e.g. `192.168.1.0/24`"
         },
         "lineNumber": 2,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-72",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-72",
         "path": [
           "[DocId:0]",
           "Resources[DbSecurityGroup]",
@@ -2306,7 +2306,7 @@
           "resolve": "Set `Properties.SecurityGroupEgress.CidrIp` attribute to specific ranges e.g. `192.168.1.0/24`"
         },
         "lineNumber": 2,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-73",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-73",
         "path": [
           "[DocId:0]",
           "Resources[DbSecurityGroup]",
@@ -2391,7 +2391,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 16,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -2428,7 +2428,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 16,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -2464,7 +2464,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -2499,7 +2499,7 @@
           "resolve": "Set `imagePullPolicy` attribute to `Always`"
         },
         "lineNumber": 16,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-42",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-42",
         "path": [
           "[DocId:0]",
           "spec",
@@ -2532,7 +2532,7 @@
           "resolve": "Set `securityContext.runAsNonRoot` to `true`"
         },
         "lineNumber": 16,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-10",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-10",
         "path": [
           "[DocId:0]",
           "input",
@@ -2566,7 +2566,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 16,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -2602,7 +2602,7 @@
           "resolve": "Set `securityContext.readOnlyRootFilesystem` to `true`"
         },
         "lineNumber": 16,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-8",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-8",
         "path": [
           "[DocId:0]",
           "input",
@@ -2637,7 +2637,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 16,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -2698,7 +2698,7 @@
           "resolve": "Set `loadBalancerSourceRanges` attribute value to specific IP addresses"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-15",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-15",
         "path": [
           "[DocId:0]",
           "service",
@@ -2756,7 +2756,7 @@
           "resolve": "Set `securityContext.runAsNonRoot` to `true`"
         },
         "lineNumber": 27,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-10",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-10",
         "path": [
           "[DocId:0]",
           "input",
@@ -2791,7 +2791,7 @@
           "resolve": "Set `imagePullPolicy` attribute to `Always`"
         },
         "lineNumber": 16,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-42",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-42",
         "path": [
           "[DocId:0]",
           "spec",
@@ -2823,7 +2823,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 27,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -2859,7 +2859,7 @@
           "resolve": "Set `securityContext.readOnlyRootFilesystem` to `true`"
         },
         "lineNumber": 27,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-8",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-8",
         "path": [
           "[DocId:0]",
           "input",
@@ -2894,7 +2894,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 27,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -2929,7 +2929,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -2964,7 +2964,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 16,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -3001,7 +3001,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 16,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -3037,7 +3037,7 @@
           "resolve": "Remove `securityContext.privileged` attribute, or set value to `false`"
         },
         "lineNumber": 28,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-1",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-1",
         "path": [
           "[DocId:0]",
           "input",
@@ -3098,7 +3098,7 @@
           "resolve": "Set `loadBalancerSourceRanges` attribute value to specific IP addresses"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-15",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-15",
         "path": [
           "[DocId:0]",
           "service",
@@ -3156,7 +3156,7 @@
           "resolve": "Set `securityContext.runAsNonRoot` to `true`"
         },
         "lineNumber": 18,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-10",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-10",
         "path": [
           "[DocId:0]",
           "input",
@@ -3190,7 +3190,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 18,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -3226,7 +3226,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -3261,7 +3261,7 @@
           "resolve": "Set `imagePullPolicy` attribute to `Always`"
         },
         "lineNumber": 18,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-42",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-42",
         "path": [
           "[DocId:0]",
           "spec",
@@ -3294,7 +3294,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 18,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -3330,7 +3330,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 18,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -3366,7 +3366,7 @@
           "resolve": "Set `securityContext.readOnlyRootFilesystem` to `true`"
         },
         "lineNumber": 18,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-8",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-8",
         "path": [
           "[DocId:0]",
           "input",
@@ -3401,7 +3401,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 18,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -3463,7 +3463,7 @@
           "resolve": "Set `loadBalancerSourceRanges` attribute value to specific IP addresses"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-15",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-15",
         "path": [
           "[DocId:0]",
           "service",
@@ -3521,7 +3521,7 @@
           "resolve": "Set only the necessary permissions required"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-44",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-44",
         "path": [
           "[DocId:0]",
           "clusterrole",
@@ -3552,7 +3552,7 @@
           "resolve": "Set only the necessary permissions required"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-44",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-44",
         "path": [
           "[DocId:0]",
           "clusterrole",
@@ -3610,7 +3610,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 16,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -3647,7 +3647,7 @@
           "resolve": "Add `livenessProbe` attribute"
         },
         "lineNumber": 16,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-41",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-41",
         "path": [
           "[DocId:0]",
           "spec",
@@ -3681,7 +3681,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 16,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -3717,7 +3717,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -3752,7 +3752,7 @@
           "resolve": "Set `imagePullPolicy` attribute to `Always`"
         },
         "lineNumber": 16,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-42",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-42",
         "path": [
           "[DocId:0]",
           "spec",
@@ -3785,7 +3785,7 @@
           "resolve": "Set `securityContext.runAsNonRoot` to `true`"
         },
         "lineNumber": 16,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-10",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-10",
         "path": [
           "[DocId:0]",
           "input",
@@ -3819,7 +3819,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 16,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -3855,7 +3855,7 @@
           "resolve": "Set `securityContext.readOnlyRootFilesystem` to `true`"
         },
         "lineNumber": 16,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-8",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-8",
         "path": [
           "[DocId:0]",
           "input",
@@ -3890,7 +3890,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 16,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -3951,7 +3951,7 @@
           "resolve": "Set `loadBalancerSourceRanges` attribute value to specific IP addresses"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-15",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-15",
         "path": [
           "[DocId:0]",
           "service",
@@ -4009,7 +4009,7 @@
           "resolve": "Set `securityContext.runAsNonRoot` to `true`"
         },
         "lineNumber": 26,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-10",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-10",
         "path": [
           "[DocId:0]",
           "input",
@@ -4043,7 +4043,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 26,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -4079,7 +4079,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -4114,7 +4114,7 @@
           "resolve": "Remove `securityContext.privileged` attribute, or set value to `false`"
         },
         "lineNumber": 27,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-1",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-1",
         "path": [
           "[DocId:0]",
           "input",
@@ -4149,7 +4149,7 @@
           "resolve": "Set `imagePullPolicy` attribute to `Always`"
         },
         "lineNumber": 16,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-42",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-42",
         "path": [
           "[DocId:0]",
           "spec",
@@ -4182,7 +4182,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 26,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -4218,7 +4218,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 16,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -4254,7 +4254,7 @@
           "resolve": "Set `securityContext.readOnlyRootFilesystem` to `true`"
         },
         "lineNumber": 26,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-8",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-8",
         "path": [
           "[DocId:0]",
           "input",
@@ -4289,7 +4289,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 16,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -4351,7 +4351,7 @@
           "resolve": "Set `loadBalancerSourceRanges` attribute value to specific IP addresses"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-15",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-15",
         "path": [
           "[DocId:0]",
           "service",
@@ -4435,7 +4435,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -4469,7 +4469,7 @@
           "resolve": "Remove ssh from `ports` array"
         },
         "lineNumber": 21,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-34",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-34",
         "path": [
           "[DocId:0]",
           "spec",
@@ -4505,7 +4505,7 @@
           "resolve": "Remove `hostNetwork` attribute, or set value to `false`"
         },
         "lineNumber": 11,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-14",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-14",
         "path": [
           "[DocId:0]",
           "input",
@@ -4540,7 +4540,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 41,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -4576,7 +4576,7 @@
           "resolve": "Remove `hostAliases` attribute"
         },
         "lineNumber": 15,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-12",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-12",
         "path": [
           "[DocId:0]",
           "input",
@@ -4610,7 +4610,7 @@
           "resolve": "Remove `hostPath` volume mount"
         },
         "lineNumber": 48,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-37",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-37",
         "path": [
           "[DocId:0]",
           "spec",
@@ -4647,7 +4647,7 @@
           "resolve": "Remove `hostIPC` attribute, or set value to `false`"
         },
         "lineNumber": 12,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-13",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-13",
         "path": [
           "[DocId:0]",
           "input",
@@ -4681,7 +4681,7 @@
           "resolve": "Remove `mountPropagation` attribute, or set value to `None`"
         },
         "lineNumber": 30,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-38",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-38",
         "path": [
           "[DocId:0]",
           "spec",
@@ -4715,7 +4715,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 34,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -4753,7 +4753,7 @@
           "resolve": "Remove `securityContext.privileged` attribute, or set value to `false`"
         },
         "lineNumber": 39,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-1",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-1",
         "path": [
           "[DocId:0]",
           "input",
@@ -4790,7 +4790,7 @@
           "resolve": "Remove `CAP_SYS_ADMIN` from `securityContext.capabilities.add` list"
         },
         "lineNumber": 36,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-7",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-7",
         "path": [
           "[DocId:0]",
           "input",
@@ -4829,7 +4829,7 @@
           "resolve": "Remove `securityContext.seLinuxOptions`"
         },
         "lineNumber": 42,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-33",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-33",
         "path": [
           "[DocId:0]",
           "spec",
@@ -4865,7 +4865,7 @@
           "resolve": "Remove `docker.sock` hostPath volume"
         },
         "lineNumber": 51,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-2",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-2",
         "path": [
           "[DocId:0]",
           "input",
@@ -4901,7 +4901,7 @@
           "resolve": "Set `securityContext.RunAsUser` value"
         },
         "lineNumber": 38,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-11",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-11",
         "path": [
           "[DocId:0]",
           "input",
@@ -4937,7 +4937,7 @@
           "resolve": "Remove `hostPID` attribute, or set value to `false`"
         },
         "lineNumber": 13,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-3",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-3",
         "path": [
           "[DocId:0]",
           "input",
@@ -4970,7 +4970,7 @@
           "resolve": "Reduce `ports` count to 2"
         },
         "lineNumber": 21,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-36",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-36",
         "path": [
           "[DocId:0]",
           "spec",
@@ -5005,7 +5005,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 19,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -5044,7 +5044,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 19,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -5109,7 +5109,7 @@
           "resolve": "Remove `securityContext.privileged` attribute, or set value to `false`"
         },
         "lineNumber": 40,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-1",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-1",
         "path": [
           "[DocId:0]",
           "input",
@@ -5144,7 +5144,7 @@
           "resolve": "Remove `hostNetwork` attribute, or set value to `false`"
         },
         "lineNumber": 21,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-14",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-14",
         "path": [
           "[DocId:0]",
           "input",
@@ -5177,7 +5177,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -5210,7 +5210,7 @@
           "resolve": "Reduce `ports` count to 2"
         },
         "lineNumber": 28,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-36",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-36",
         "path": [
           "[DocId:0]",
           "spec",
@@ -5242,7 +5242,7 @@
           "resolve": "Remove `hostAliases` attribute"
         },
         "lineNumber": 18,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-12",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-12",
         "path": [
           "[DocId:0]",
           "input",
@@ -5274,7 +5274,7 @@
           "resolve": "Remove `hostPath` volume mount"
         },
         "lineNumber": 53,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-37",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-37",
         "path": [
           "[DocId:0]",
           "spec",
@@ -5309,7 +5309,7 @@
           "resolve": "Remove `hostIPC` attribute, or set value to `false`"
         },
         "lineNumber": 22,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-13",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-13",
         "path": [
           "[DocId:0]",
           "input",
@@ -5341,7 +5341,7 @@
           "resolve": "Set `securityContext.RunAsUser` value"
         },
         "lineNumber": 37,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-11",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-11",
         "path": [
           "[DocId:0]",
           "input",
@@ -5376,7 +5376,7 @@
           "resolve": "Remove `docker.sock` hostPath volume"
         },
         "lineNumber": 56,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-2",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-2",
         "path": [
           "[DocId:0]",
           "input",
@@ -5410,7 +5410,7 @@
           "resolve": "Remove ssh from `ports` array"
         },
         "lineNumber": 28,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-34",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-34",
         "path": [
           "[DocId:0]",
           "spec",
@@ -5444,7 +5444,7 @@
           "resolve": "Remove `CAP_SYS_ADMIN` from `securityContext.capabilities.add` list"
         },
         "lineNumber": 34,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-7",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-7",
         "path": [
           "[DocId:0]",
           "input",
@@ -5481,7 +5481,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 25,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -5516,7 +5516,7 @@
           "resolve": "Remove `mountPropagation` attribute, or set value to `None`"
         },
         "lineNumber": 43,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-38",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-38",
         "path": [
           "[DocId:0]",
           "spec",
@@ -5550,7 +5550,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 25,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -5585,7 +5585,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 32,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -5620,7 +5620,7 @@
           "resolve": "Remove `hostPID` attribute, or set value to `false`"
         },
         "lineNumber": 23,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-3",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-3",
         "path": [
           "[DocId:0]",
           "input",
@@ -5653,7 +5653,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 41,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -5688,7 +5688,7 @@
           "resolve": "Remove `securityContext.seLinuxOptions`"
         },
         "lineNumber": 38,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-33",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-33",
         "path": [
           "[DocId:0]",
           "spec",
@@ -5750,7 +5750,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 52,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -5785,7 +5785,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 79,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -5820,7 +5820,7 @@
           "resolve": "Set `securityContext.RunAsUser` value"
         },
         "lineNumber": 77,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-11",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-11",
         "path": [
           "[DocId:0]",
           "input",
@@ -5854,7 +5854,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 37,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -5889,7 +5889,7 @@
           "resolve": "Remove `hostAliases` attribute"
         },
         "lineNumber": 27,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-12",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-12",
         "path": [
           "[DocId:0]",
           "input",
@@ -5922,7 +5922,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -5957,7 +5957,7 @@
           "resolve": "Remove `CAP_SYS_ADMIN` from `securityContext.capabilities.add` list"
         },
         "lineNumber": 83,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-7",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-7",
         "path": [
           "[DocId:0]",
           "input",
@@ -5994,7 +5994,7 @@
           "resolve": "Remove `securityContext.privileged` attribute, or set value to `false`"
         },
         "lineNumber": 78,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-1",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-1",
         "path": [
           "[DocId:0]",
           "input",
@@ -6029,7 +6029,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 52,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -6065,7 +6065,7 @@
           "resolve": "Remove `docker.sock` hostPath volume"
         },
         "lineNumber": 87,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-2",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-2",
         "path": [
           "[DocId:0]",
           "input",
@@ -6100,7 +6100,7 @@
           "resolve": "Set `imagePullPolicy` attribute to `Always`"
         },
         "lineNumber": 39,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-42",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-42",
         "path": [
           "[DocId:0]",
           "spec",
@@ -6133,7 +6133,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 37,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -6168,7 +6168,7 @@
           "resolve": "Set `imagePullPolicy` attribute to `Always`"
         },
         "lineNumber": 56,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-42",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-42",
         "path": [
           "[DocId:0]",
           "spec",
@@ -6201,7 +6201,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 69,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -6237,7 +6237,7 @@
           "resolve": "Set `securityContext.readOnlyRootFilesystem` to `true`"
         },
         "lineNumber": 37,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-8",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-8",
         "path": [
           "[DocId:0]",
           "input",
@@ -6273,7 +6273,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 69,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -6309,7 +6309,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -6344,7 +6344,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 75,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -6378,7 +6378,7 @@
           "resolve": "Remove `hostPID` attribute, or set value to `false`"
         },
         "lineNumber": 35,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-3",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-3",
         "path": [
           "[DocId:0]",
           "input",
@@ -6411,7 +6411,7 @@
           "resolve": "Set `securityContext.runAsNonRoot` to `true`"
         },
         "lineNumber": 37,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-10",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-10",
         "path": [
           "[DocId:0]",
           "input",
@@ -6474,7 +6474,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 53,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -6509,7 +6509,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 80,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -6544,7 +6544,7 @@
           "resolve": "Set `securityContext.RunAsUser` value"
         },
         "lineNumber": 78,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-11",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-11",
         "path": [
           "[DocId:0]",
           "input",
@@ -6578,7 +6578,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 38,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -6613,7 +6613,7 @@
           "resolve": "Remove `hostAliases` attribute"
         },
         "lineNumber": 28,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-12",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-12",
         "path": [
           "[DocId:0]",
           "input",
@@ -6646,7 +6646,7 @@
           "resolve": "Remove `CAP_SYS_ADMIN` from `securityContext.capabilities.add` list"
         },
         "lineNumber": 84,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-7",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-7",
         "path": [
           "[DocId:0]",
           "input",
@@ -6683,7 +6683,7 @@
           "resolve": "Remove `securityContext.privileged` attribute, or set value to `false`"
         },
         "lineNumber": 79,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-1",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-1",
         "path": [
           "[DocId:0]",
           "input",
@@ -6718,7 +6718,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 53,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -6754,7 +6754,7 @@
           "resolve": "Remove `docker.sock` hostPath volume"
         },
         "lineNumber": 88,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-2",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-2",
         "path": [
           "[DocId:0]",
           "input",
@@ -6789,7 +6789,7 @@
           "resolve": "Set `imagePullPolicy` attribute to `Always`"
         },
         "lineNumber": 40,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-42",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-42",
         "path": [
           "[DocId:0]",
           "spec",
@@ -6822,7 +6822,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 38,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -6857,7 +6857,7 @@
           "resolve": "Set `imagePullPolicy` attribute to `Always`"
         },
         "lineNumber": 57,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-42",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-42",
         "path": [
           "[DocId:0]",
           "spec",
@@ -6890,7 +6890,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 70,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -6926,7 +6926,7 @@
           "resolve": "Set `securityContext.readOnlyRootFilesystem` to `true`"
         },
         "lineNumber": 38,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-8",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-8",
         "path": [
           "[DocId:0]",
           "input",
@@ -6962,7 +6962,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 70,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -6998,7 +6998,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 76,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -7032,7 +7032,7 @@
           "resolve": "Remove `hostPID` attribute, or set value to `false`"
         },
         "lineNumber": 36,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-3",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-3",
         "path": [
           "[DocId:0]",
           "input",
@@ -7065,7 +7065,7 @@
           "resolve": "Set `securityContext.runAsNonRoot` to `true`"
         },
         "lineNumber": 38,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-10",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-10",
         "path": [
           "[DocId:0]",
           "input",
@@ -7128,7 +7128,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 50,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -7163,7 +7163,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 77,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -7198,7 +7198,7 @@
           "resolve": "Set `securityContext.RunAsUser` value"
         },
         "lineNumber": 75,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-11",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-11",
         "path": [
           "[DocId:0]",
           "input",
@@ -7232,7 +7232,7 @@
           "resolve": "Remove `hostPath` volume mount"
         },
         "lineNumber": 85,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-37",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-37",
         "path": [
           "[DocId:0]",
           "spec",
@@ -7265,7 +7265,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 35,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -7300,7 +7300,7 @@
           "resolve": "Remove `hostAliases` attribute"
         },
         "lineNumber": 25,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-12",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-12",
         "path": [
           "[DocId:0]",
           "input",
@@ -7333,7 +7333,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -7368,7 +7368,7 @@
           "resolve": "Remove `CAP_SYS_ADMIN` from `securityContext.capabilities.add` list"
         },
         "lineNumber": 81,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-7",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-7",
         "path": [
           "[DocId:0]",
           "input",
@@ -7405,7 +7405,7 @@
           "resolve": "Remove `securityContext.privileged` attribute, or set value to `false`"
         },
         "lineNumber": 76,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-1",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-1",
         "path": [
           "[DocId:0]",
           "input",
@@ -7440,7 +7440,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 50,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -7476,7 +7476,7 @@
           "resolve": "Remove `docker.sock` hostPath volume"
         },
         "lineNumber": 88,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-2",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-2",
         "path": [
           "[DocId:0]",
           "input",
@@ -7511,7 +7511,7 @@
           "resolve": "Set `imagePullPolicy` attribute to `Always`"
         },
         "lineNumber": 37,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-42",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-42",
         "path": [
           "[DocId:0]",
           "spec",
@@ -7544,7 +7544,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 35,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -7579,7 +7579,7 @@
           "resolve": "Set `imagePullPolicy` attribute to `Always`"
         },
         "lineNumber": 54,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-42",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-42",
         "path": [
           "[DocId:0]",
           "spec",
@@ -7612,7 +7612,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 67,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -7648,7 +7648,7 @@
           "resolve": "Set `securityContext.readOnlyRootFilesystem` to `true`"
         },
         "lineNumber": 35,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-8",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-8",
         "path": [
           "[DocId:0]",
           "input",
@@ -7684,7 +7684,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 67,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -7720,7 +7720,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -7755,7 +7755,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 73,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -7789,7 +7789,7 @@
           "resolve": "Remove `hostPID` attribute, or set value to `false`"
         },
         "lineNumber": 33,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-3",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-3",
         "path": [
           "[DocId:0]",
           "input",
@@ -7822,7 +7822,7 @@
           "resolve": "Set `securityContext.runAsNonRoot` to `true`"
         },
         "lineNumber": 35,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-10",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-10",
         "path": [
           "[DocId:0]",
           "input",
@@ -7885,7 +7885,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 18,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -7920,7 +7920,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 21,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -7955,7 +7955,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 18,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -7991,7 +7991,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -8026,7 +8026,7 @@
           "resolve": "Set `securityContext.readOnlyRootFilesystem` to `true`"
         },
         "lineNumber": 21,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-8",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-8",
         "path": [
           "[DocId:0]",
           "input",
@@ -8061,7 +8061,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 18,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -8098,7 +8098,7 @@
           "resolve": "Add `livenessProbe` attribute"
         },
         "lineNumber": 18,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-41",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-41",
         "path": [
           "[DocId:0]",
           "spec",
@@ -8131,7 +8131,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 18,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -8166,7 +8166,7 @@
           "resolve": "Set `imagePullPolicy` attribute to `Always`"
         },
         "lineNumber": 23,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-42",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-42",
         "path": [
           "[DocId:0]",
           "spec",
@@ -8199,7 +8199,7 @@
           "resolve": "Set `securityContext.runAsNonRoot` to `true`"
         },
         "lineNumber": 21,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-10",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-10",
         "path": [
           "[DocId:0]",
           "input",
@@ -8234,7 +8234,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 21,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -8270,7 +8270,7 @@
           "resolve": "Set `securityContext.readOnlyRootFilesystem` to `true`"
         },
         "lineNumber": 18,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-8",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-8",
         "path": [
           "[DocId:0]",
           "input",
@@ -8306,7 +8306,7 @@
           "resolve": "Add `livenessProbe` attribute"
         },
         "lineNumber": 21,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-41",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-41",
         "path": [
           "[DocId:0]",
           "spec",
@@ -8340,7 +8340,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 21,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -8376,7 +8376,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -8411,7 +8411,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 21,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -8446,7 +8446,7 @@
           "resolve": "Set `securityContext.runAsNonRoot` to `true`"
         },
         "lineNumber": 18,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-10",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-10",
         "path": [
           "[DocId:0]",
           "input",
@@ -8482,7 +8482,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 18,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -8518,7 +8518,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 18,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -8555,7 +8555,7 @@
           "resolve": "Add `livenessProbe` attribute"
         },
         "lineNumber": 18,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-41",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-41",
         "path": [
           "[DocId:0]",
           "spec",
@@ -8588,7 +8588,7 @@
           "resolve": "Set `imagePullPolicy` attribute to `Always`"
         },
         "lineNumber": 20,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-42",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-42",
         "path": [
           "[DocId:0]",
           "spec",
@@ -8621,7 +8621,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 18,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -8655,7 +8655,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 18,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -8691,7 +8691,7 @@
           "resolve": "Set `securityContext.readOnlyRootFilesystem` to `true`"
         },
         "lineNumber": 18,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-8",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-8",
         "path": [
           "[DocId:0]",
           "input",
@@ -8726,7 +8726,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -8761,7 +8761,7 @@
           "resolve": "Set `securityContext.runAsNonRoot` to `true`"
         },
         "lineNumber": 18,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-10",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-10",
         "path": [
           "[DocId:0]",
           "input",
@@ -8797,7 +8797,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 18,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -8833,7 +8833,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 18,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -8870,7 +8870,7 @@
           "resolve": "Add `livenessProbe` attribute"
         },
         "lineNumber": 18,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-41",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-41",
         "path": [
           "[DocId:0]",
           "spec",
@@ -8903,7 +8903,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 18,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -8937,7 +8937,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 18,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -8973,7 +8973,7 @@
           "resolve": "Set `securityContext.readOnlyRootFilesystem` to `true`"
         },
         "lineNumber": 18,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-8",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-8",
         "path": [
           "[DocId:0]",
           "input",
@@ -9008,7 +9008,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -9043,7 +9043,7 @@
           "resolve": "Set `securityContext.runAsNonRoot` to `true`"
         },
         "lineNumber": 18,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-10",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-10",
         "path": [
           "[DocId:0]",
           "input",
@@ -9106,7 +9106,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 19,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -9142,7 +9142,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 19,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -9179,7 +9179,7 @@
           "resolve": "Add `livenessProbe` attribute"
         },
         "lineNumber": 19,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-41",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-41",
         "path": [
           "[DocId:0]",
           "spec",
@@ -9212,7 +9212,7 @@
           "resolve": "Set `imagePullPolicy` attribute to `Always`"
         },
         "lineNumber": 21,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-42",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-42",
         "path": [
           "[DocId:0]",
           "spec",
@@ -9245,7 +9245,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 19,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -9279,7 +9279,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 19,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -9315,7 +9315,7 @@
           "resolve": "Set `securityContext.readOnlyRootFilesystem` to `true`"
         },
         "lineNumber": 19,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-8",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-8",
         "path": [
           "[DocId:0]",
           "input",
@@ -9350,7 +9350,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -9385,7 +9385,7 @@
           "resolve": "Set `securityContext.runAsNonRoot` to `true`"
         },
         "lineNumber": 19,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-10",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-10",
         "path": [
           "[DocId:0]",
           "input",
@@ -9445,7 +9445,7 @@
           "resolve": "Reduce `ports` count to 2"
         },
         "lineNumber": 23,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-36",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-36",
         "path": [
           "[DocId:0]",
           "spec",
@@ -9478,7 +9478,7 @@
           "resolve": "Set `securityContext.runAsNonRoot` to `true`"
         },
         "lineNumber": 20,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-10",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-10",
         "path": [
           "[DocId:0]",
           "input",
@@ -9513,7 +9513,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 20,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -9550,7 +9550,7 @@
           "resolve": "Add `livenessProbe` attribute"
         },
         "lineNumber": 20,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-41",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-41",
         "path": [
           "[DocId:0]",
           "spec",
@@ -9584,7 +9584,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 20,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -9619,7 +9619,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 20,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -9655,7 +9655,7 @@
           "resolve": "Set `securityContext.readOnlyRootFilesystem` to `true`"
         },
         "lineNumber": 20,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-8",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-8",
         "path": [
           "[DocId:0]",
           "input",
@@ -9690,7 +9690,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 20,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -9725,7 +9725,7 @@
           "resolve": "Set `imagePullPolicy` attribute to `Always`"
         },
         "lineNumber": 20,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-42",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-42",
         "path": [
           "[DocId:0]",
           "spec",
@@ -9786,7 +9786,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 50,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -9821,7 +9821,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 78,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -9856,7 +9856,7 @@
           "resolve": "Set `securityContext.RunAsUser` value"
         },
         "lineNumber": 76,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-11",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-11",
         "path": [
           "[DocId:0]",
           "input",
@@ -9890,7 +9890,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 35,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -9925,7 +9925,7 @@
           "resolve": "Remove `hostAliases` attribute"
         },
         "lineNumber": 25,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-12",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-12",
         "path": [
           "[DocId:0]",
           "input",
@@ -9958,7 +9958,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -9993,7 +9993,7 @@
           "resolve": "Remove `CAP_SYS_ADMIN` from `securityContext.capabilities.add` list"
         },
         "lineNumber": 82,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-7",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-7",
         "path": [
           "[DocId:0]",
           "input",
@@ -10030,7 +10030,7 @@
           "resolve": "Remove `securityContext.seLinuxOptions`"
         },
         "lineNumber": 71,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-33",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-33",
         "path": [
           "[DocId:0]",
           "spec",
@@ -10064,7 +10064,7 @@
           "resolve": "Remove `securityContext.privileged` attribute, or set value to `false`"
         },
         "lineNumber": 77,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-1",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-1",
         "path": [
           "[DocId:0]",
           "input",
@@ -10099,7 +10099,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 50,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -10135,7 +10135,7 @@
           "resolve": "Remove `docker.sock` hostPath volume"
         },
         "lineNumber": 86,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-2",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-2",
         "path": [
           "[DocId:0]",
           "input",
@@ -10170,7 +10170,7 @@
           "resolve": "Set `imagePullPolicy` attribute to `Always`"
         },
         "lineNumber": 37,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-42",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-42",
         "path": [
           "[DocId:0]",
           "spec",
@@ -10203,7 +10203,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 35,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -10238,7 +10238,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -10273,7 +10273,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 66,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -10309,7 +10309,7 @@
           "resolve": "Set `securityContext.readOnlyRootFilesystem` to `true`"
         },
         "lineNumber": 35,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-8",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-8",
         "path": [
           "[DocId:0]",
           "input",
@@ -10344,7 +10344,7 @@
           "resolve": "Set `imagePullPolicy` attribute to `Always`"
         },
         "lineNumber": 53,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-42",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-42",
         "path": [
           "[DocId:0]",
           "spec",
@@ -10378,7 +10378,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 66,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -10414,7 +10414,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 74,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -10448,7 +10448,7 @@
           "resolve": "Remove `hostPID` attribute, or set value to `false`"
         },
         "lineNumber": 33,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-3",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-3",
         "path": [
           "[DocId:0]",
           "input",
@@ -10481,7 +10481,7 @@
           "resolve": "Set `securityContext.runAsNonRoot` to `true`"
         },
         "lineNumber": 35,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-10",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-10",
         "path": [
           "[DocId:0]",
           "input",
@@ -10544,7 +10544,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 53,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -10579,7 +10579,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 79,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -10614,7 +10614,7 @@
           "resolve": "Set `securityContext.RunAsUser` value"
         },
         "lineNumber": 77,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-11",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-11",
         "path": [
           "[DocId:0]",
           "input",
@@ -10648,7 +10648,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 35,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -10683,7 +10683,7 @@
           "resolve": "Remove `hostAliases` attribute"
         },
         "lineNumber": 25,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-12",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-12",
         "path": [
           "[DocId:0]",
           "input",
@@ -10716,7 +10716,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -10751,7 +10751,7 @@
           "resolve": "Remove `CAP_SYS_ADMIN` from `securityContext.capabilities.add` list"
         },
         "lineNumber": 83,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-7",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-7",
         "path": [
           "[DocId:0]",
           "input",
@@ -10788,7 +10788,7 @@
           "resolve": "Remove `securityContext.privileged` attribute, or set value to `false`"
         },
         "lineNumber": 78,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-1",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-1",
         "path": [
           "[DocId:0]",
           "input",
@@ -10823,7 +10823,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 53,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -10859,7 +10859,7 @@
           "resolve": "Remove `docker.sock` hostPath volume"
         },
         "lineNumber": 87,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-2",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-2",
         "path": [
           "[DocId:0]",
           "input",
@@ -10894,7 +10894,7 @@
           "resolve": "Set `imagePullPolicy` attribute to `Always`"
         },
         "lineNumber": 37,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-42",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-42",
         "path": [
           "[DocId:0]",
           "spec",
@@ -10927,7 +10927,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 35,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -10962,7 +10962,7 @@
           "resolve": "Set `imagePullPolicy` attribute to `Always`"
         },
         "lineNumber": 56,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-42",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-42",
         "path": [
           "[DocId:0]",
           "spec",
@@ -10994,7 +10994,7 @@
           "resolve": "Remove ssh from `ports` array"
         },
         "lineNumber": 39,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-34",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-34",
         "path": [
           "[DocId:0]",
           "spec",
@@ -11028,7 +11028,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 69,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -11064,7 +11064,7 @@
           "resolve": "Set `securityContext.readOnlyRootFilesystem` to `true`"
         },
         "lineNumber": 35,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-8",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-8",
         "path": [
           "[DocId:0]",
           "input",
@@ -11100,7 +11100,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 69,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -11136,7 +11136,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -11171,7 +11171,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 75,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -11205,7 +11205,7 @@
           "resolve": "Remove `hostPID` attribute, or set value to `false`"
         },
         "lineNumber": 33,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-3",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-3",
         "path": [
           "[DocId:0]",
           "input",
@@ -11238,7 +11238,7 @@
           "resolve": "Set `securityContext.runAsNonRoot` to `true`"
         },
         "lineNumber": 35,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-10",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-10",
         "path": [
           "[DocId:0]",
           "input",
@@ -11301,7 +11301,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 50,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -11336,7 +11336,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 81,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -11371,7 +11371,7 @@
           "resolve": "Set `securityContext.RunAsUser` value"
         },
         "lineNumber": 79,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-11",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-11",
         "path": [
           "[DocId:0]",
           "input",
@@ -11405,7 +11405,7 @@
           "resolve": "Remove `mountPropagation` attribute, or set value to `None`"
         },
         "lineNumber": 56,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-38",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-38",
         "path": [
           "[DocId:0]",
           "spec",
@@ -11437,7 +11437,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 35,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -11472,7 +11472,7 @@
           "resolve": "Remove `hostAliases` attribute"
         },
         "lineNumber": 25,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-12",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-12",
         "path": [
           "[DocId:0]",
           "input",
@@ -11505,7 +11505,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -11540,7 +11540,7 @@
           "resolve": "Remove `CAP_SYS_ADMIN` from `securityContext.capabilities.add` list"
         },
         "lineNumber": 85,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-7",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-7",
         "path": [
           "[DocId:0]",
           "input",
@@ -11577,7 +11577,7 @@
           "resolve": "Remove `securityContext.privileged` attribute, or set value to `false`"
         },
         "lineNumber": 80,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-1",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-1",
         "path": [
           "[DocId:0]",
           "input",
@@ -11612,7 +11612,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 50,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -11648,7 +11648,7 @@
           "resolve": "Remove `docker.sock` hostPath volume"
         },
         "lineNumber": 92,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-2",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-2",
         "path": [
           "[DocId:0]",
           "input",
@@ -11683,7 +11683,7 @@
           "resolve": "Set `imagePullPolicy` attribute to `Always`"
         },
         "lineNumber": 37,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-42",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-42",
         "path": [
           "[DocId:0]",
           "spec",
@@ -11716,7 +11716,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 35,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -11751,7 +11751,7 @@
           "resolve": "Set `imagePullPolicy` attribute to `Always`"
         },
         "lineNumber": 54,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-42",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-42",
         "path": [
           "[DocId:0]",
           "spec",
@@ -11784,7 +11784,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 71,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -11820,7 +11820,7 @@
           "resolve": "Set `securityContext.readOnlyRootFilesystem` to `true`"
         },
         "lineNumber": 35,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-8",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-8",
         "path": [
           "[DocId:0]",
           "input",
@@ -11856,7 +11856,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 71,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -11892,7 +11892,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -11927,7 +11927,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 77,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -11961,7 +11961,7 @@
           "resolve": "Remove `hostPID` attribute, or set value to `false`"
         },
         "lineNumber": 33,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-3",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-3",
         "path": [
           "[DocId:0]",
           "input",
@@ -11994,7 +11994,7 @@
           "resolve": "Set `securityContext.runAsNonRoot` to `true`"
         },
         "lineNumber": 35,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-10",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-10",
         "path": [
           "[DocId:0]",
           "input",
@@ -12057,7 +12057,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 50,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -12092,7 +12092,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 77,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -12127,7 +12127,7 @@
           "resolve": "Set `securityContext.RunAsUser` value"
         },
         "lineNumber": 75,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-11",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-11",
         "path": [
           "[DocId:0]",
           "input",
@@ -12161,7 +12161,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 35,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -12196,7 +12196,7 @@
           "resolve": "Remove `hostAliases` attribute"
         },
         "lineNumber": 25,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-12",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-12",
         "path": [
           "[DocId:0]",
           "input",
@@ -12229,7 +12229,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -12264,7 +12264,7 @@
           "resolve": "Remove `CAP_SYS_ADMIN` from `securityContext.capabilities.add` list"
         },
         "lineNumber": 81,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-7",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-7",
         "path": [
           "[DocId:0]",
           "input",
@@ -12301,7 +12301,7 @@
           "resolve": "Remove `securityContext.privileged` attribute, or set value to `false`"
         },
         "lineNumber": 76,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-1",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-1",
         "path": [
           "[DocId:0]",
           "input",
@@ -12336,7 +12336,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 50,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -12372,7 +12372,7 @@
           "resolve": "Remove `docker.sock` hostPath volume"
         },
         "lineNumber": 85,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-2",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-2",
         "path": [
           "[DocId:0]",
           "input",
@@ -12407,7 +12407,7 @@
           "resolve": "Set `imagePullPolicy` attribute to `Always`"
         },
         "lineNumber": 37,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-42",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-42",
         "path": [
           "[DocId:0]",
           "spec",
@@ -12440,7 +12440,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 35,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -12475,7 +12475,7 @@
           "resolve": "Set `imagePullPolicy` attribute to `Always`"
         },
         "lineNumber": 54,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-42",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-42",
         "path": [
           "[DocId:0]",
           "spec",
@@ -12508,7 +12508,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 67,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -12544,7 +12544,7 @@
           "resolve": "Set `securityContext.readOnlyRootFilesystem` to `true`"
         },
         "lineNumber": 35,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-8",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-8",
         "path": [
           "[DocId:0]",
           "input",
@@ -12580,7 +12580,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 67,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -12616,7 +12616,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -12651,7 +12651,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 73,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -12685,7 +12685,7 @@
           "resolve": "Remove `hostPID` attribute, or set value to `false`"
         },
         "lineNumber": 33,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-3",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-3",
         "path": [
           "[DocId:0]",
           "input",
@@ -12718,7 +12718,7 @@
           "resolve": "Set `securityContext.runAsNonRoot` to `true`"
         },
         "lineNumber": 35,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-10",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-10",
         "path": [
           "[DocId:0]",
           "input",
@@ -12780,7 +12780,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -12814,7 +12814,7 @@
           "resolve": "Set `securityContext.RunAsUser` value"
         },
         "lineNumber": 29,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-11",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-11",
         "path": [
           "[DocId:0]",
           "input",
@@ -12849,7 +12849,7 @@
           "resolve": "Remove `hostNetwork` attribute, or set value to `false`"
         },
         "lineNumber": 8,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-14",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-14",
         "path": [
           "[DocId:0]",
           "input",
@@ -12881,7 +12881,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 24,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -12916,7 +12916,7 @@
           "resolve": "Remove `hostAliases` attribute"
         },
         "lineNumber": 12,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-12",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-12",
         "path": [
           "[DocId:0]",
           "input",
@@ -12948,7 +12948,7 @@
           "resolve": "Remove `hostPath` volume mount"
         },
         "lineNumber": 42,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-37",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-37",
         "path": [
           "[DocId:0]",
           "spec",
@@ -12981,7 +12981,7 @@
           "resolve": "Remove `mountPropagation` attribute, or set value to `None`"
         },
         "lineNumber": 35,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-38",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-38",
         "path": [
           "[DocId:0]",
           "spec",
@@ -13014,7 +13014,7 @@
           "resolve": "Remove `CAP_SYS_ADMIN` from `securityContext.capabilities.add` list"
         },
         "lineNumber": 26,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-7",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-7",
         "path": [
           "[DocId:0]",
           "input",
@@ -13052,7 +13052,7 @@
           "resolve": "Remove `hostIPC` attribute, or set value to `false`"
         },
         "lineNumber": 9,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-13",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-13",
         "path": [
           "[DocId:0]",
           "input",
@@ -13085,7 +13085,7 @@
           "resolve": "Remove `docker.sock` hostPath volume"
         },
         "lineNumber": 45,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-2",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-2",
         "path": [
           "[DocId:0]",
           "input",
@@ -13120,7 +13120,7 @@
           "resolve": "Remove `securityContext.privileged` attribute, or set value to `false`"
         },
         "lineNumber": 32,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-1",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-1",
         "path": [
           "[DocId:0]",
           "input",
@@ -13155,7 +13155,7 @@
           "resolve": "Remove `securityContext.seLinuxOptions`"
         },
         "lineNumber": 30,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-33",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-33",
         "path": [
           "[DocId:0]",
           "spec",
@@ -13189,7 +13189,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 33,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -13222,7 +13222,7 @@
           "resolve": "Reduce `ports` count to 2"
         },
         "lineNumber": 20,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-36",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-36",
         "path": [
           "[DocId:0]",
           "spec",
@@ -13254,7 +13254,7 @@
           "resolve": "Remove `hostPID` attribute, or set value to `false`"
         },
         "lineNumber": 10,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-3",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-3",
         "path": [
           "[DocId:0]",
           "input",
@@ -13288,7 +13288,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 16,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -13324,7 +13324,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 16,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -13359,7 +13359,7 @@
           "resolve": "Remove ssh from `ports` array"
         },
         "lineNumber": 20,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-34",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-34",
         "path": [
           "[DocId:0]",
           "spec",
@@ -13420,7 +13420,7 @@
           "resolve": "Set `securityContext.runAsNonRoot` to `true`"
         },
         "lineNumber": 12,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-10",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-10",
         "path": [
           "[DocId:0]",
           "input",
@@ -13455,7 +13455,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -13490,7 +13490,7 @@
           "resolve": "Remove `CAP_SYS_ADMIN` from `securityContext.capabilities.add` list"
         },
         "lineNumber": 12,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-7",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-7",
         "path": [
           "[DocId:0]",
           "input",
@@ -13527,7 +13527,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 12,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -13564,7 +13564,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 12,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -13599,7 +13599,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 12,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -13635,7 +13635,7 @@
           "resolve": "Set `securityContext.readOnlyRootFilesystem` to `true`"
         },
         "lineNumber": 12,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-8",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-8",
         "path": [
           "[DocId:0]",
           "input",
@@ -13670,7 +13670,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 12,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -13705,7 +13705,7 @@
           "resolve": "Remove `securityContext.privileged` attribute, or set value to `false`"
         },
         "lineNumber": 12,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-1",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-1",
         "path": [
           "[DocId:0]",
           "input",
@@ -13740,7 +13740,7 @@
           "resolve": "Remove `docker.sock` hostPath volume"
         },
         "lineNumber": 12,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-2",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-2",
         "path": [
           "[DocId:0]",
           "input",
@@ -13775,7 +13775,7 @@
           "resolve": "Set `imagePullPolicy` attribute to `Always`"
         },
         "lineNumber": 12,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-42",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-42",
         "path": [
           "[DocId:0]",
           "spec",
@@ -13807,7 +13807,7 @@
           "resolve": "Remove `hostPID` attribute, or set value to `false`"
         },
         "lineNumber": 12,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-3",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-3",
         "path": [
           "[DocId:0]",
           "input",
@@ -13866,7 +13866,7 @@
           "resolve": "Add specific `to` attributes"
         },
         "lineNumber": 8,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-26",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-26",
         "path": [
           "[DocId:0]",
           "input",
@@ -13896,7 +13896,7 @@
           "resolve": "Add specific `to` attributes"
         },
         "lineNumber": 8,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-26",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-26",
         "path": [
           "[DocId:0]",
           "input",
@@ -13926,7 +13926,7 @@
           "resolve": "Add specific `from` attributes"
         },
         "lineNumber": 8,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-25",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-25",
         "path": [
           "[DocId:0]",
           "input",
@@ -13956,7 +13956,7 @@
           "resolve": "Add specific `to` attributes"
         },
         "lineNumber": 8,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-26",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-26",
         "path": [
           "[DocId:0]",
           "input",
@@ -13986,7 +13986,7 @@
           "resolve": "Add specific `from` attributes"
         },
         "lineNumber": 8,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-25",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-25",
         "path": [
           "[DocId:0]",
           "input",
@@ -14016,7 +14016,7 @@
           "resolve": "Add specific `from` attributes"
         },
         "lineNumber": 8,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-25",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-25",
         "path": [
           "[DocId:0]",
           "input",
@@ -14046,7 +14046,7 @@
           "resolve": "Add specific `from` attributes"
         },
         "lineNumber": 8,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-25",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-25",
         "path": [
           "[DocId:0]",
           "input",
@@ -14076,7 +14076,7 @@
           "resolve": "Add specific `from` attributes"
         },
         "lineNumber": 8,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-25",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-25",
         "path": [
           "[DocId:0]",
           "input",
@@ -14106,7 +14106,7 @@
           "resolve": "Add specific `from` attributes"
         },
         "lineNumber": 8,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-25",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-25",
         "path": [
           "[DocId:0]",
           "input",
@@ -14136,7 +14136,7 @@
           "resolve": "Add specific `from` attributes"
         },
         "lineNumber": 8,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-25",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-25",
         "path": [
           "[DocId:0]",
           "input",
@@ -14166,7 +14166,7 @@
           "resolve": "Add specific `from` attributes"
         },
         "lineNumber": 8,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-25",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-25",
         "path": [
           "[DocId:0]",
           "input",
@@ -14224,7 +14224,7 @@
           "resolve": "Set `securityContext.readOnlyRootFilesystem` to `true`"
         },
         "lineNumber": 28,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-8",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-8",
         "path": [
           "[DocId:0]",
           "input",
@@ -14257,7 +14257,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 28,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -14290,7 +14290,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -14325,7 +14325,7 @@
           "resolve": "Set `imagePullPolicy` attribute to `Always`"
         },
         "lineNumber": 21,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-42",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-42",
         "path": [
           "[DocId:0]",
           "spec",
@@ -14356,7 +14356,7 @@
           "resolve": "Set `securityContext.runAsNonRoot` to `true`"
         },
         "lineNumber": 28,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-10",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-10",
         "path": [
           "[DocId:0]",
           "input",
@@ -14390,7 +14390,7 @@
           "resolve": "Add `livenessProbe` attribute"
         },
         "lineNumber": 21,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-41",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-41",
         "path": [
           "[DocId:0]",
           "spec",
@@ -14420,7 +14420,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 30,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -14454,7 +14454,7 @@
           "resolve": "Remove `securityContext.privileged` attribute, or set value to `false`"
         },
         "lineNumber": 29,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-1",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-1",
         "path": [
           "[DocId:0]",
           "input",
@@ -14488,7 +14488,7 @@
           "resolve": "Remove `hostIPC` attribute, or set value to `false`"
         },
         "lineNumber": 8,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-13",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-13",
         "path": [
           "[DocId:0]",
           "input",
@@ -14519,7 +14519,7 @@
           "resolve": "Remove `CAP_SYS_ADMIN` from `securityContext.capabilities.add` list"
         },
         "lineNumber": 34,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-7",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-7",
         "path": [
           "[DocId:0]",
           "input",
@@ -14553,7 +14553,7 @@
           "resolve": "Remove `hostAliases` attribute"
         },
         "lineNumber": 12,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-12",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-12",
         "path": [
           "[DocId:0]",
           "input",
@@ -14584,7 +14584,7 @@
           "resolve": "Remove `docker.sock` hostPath volume"
         },
         "lineNumber": 41,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-2",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-2",
         "path": [
           "[DocId:0]",
           "input",
@@ -14616,7 +14616,7 @@
           "resolve": "Remove `hostPath` volume mount"
         },
         "lineNumber": 38,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-37",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-37",
         "path": [
           "[DocId:0]",
           "spec",
@@ -14648,7 +14648,7 @@
           "resolve": "Remove `hostNetwork` attribute, or set value to `false`"
         },
         "lineNumber": 10,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-14",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-14",
         "path": [
           "[DocId:0]",
           "input",
@@ -14679,7 +14679,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 24,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -14712,7 +14712,7 @@
           "resolve": "Remove `hostPID` attribute, or set value to `false`"
         },
         "lineNumber": 9,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-3",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-3",
         "path": [
           "[DocId:0]",
           "input",
@@ -14744,7 +14744,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 24,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -14806,7 +14806,7 @@
           "resolve": "Add `livenessProbe` attribute"
         },
         "lineNumber": 12,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-41",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-41",
         "path": [
           "[DocId:0]",
           "spec",
@@ -14837,7 +14837,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 23,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -14870,7 +14870,7 @@
           "resolve": "Set `securityContext.runAsNonRoot` to `true`"
         },
         "lineNumber": 23,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-10",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-10",
         "path": [
           "[DocId:0]",
           "input",
@@ -14902,7 +14902,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 23,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -14936,7 +14936,7 @@
           "resolve": "Set `securityContext.readOnlyRootFilesystem` to `true`"
         },
         "lineNumber": 23,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-8",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-8",
         "path": [
           "[DocId:0]",
           "input",
@@ -14969,7 +14969,7 @@
           "resolve": "Remove `securityContext.privileged` attribute, or set value to `false`"
         },
         "lineNumber": 24,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-1",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-1",
         "path": [
           "[DocId:0]",
           "input",
@@ -15002,7 +15002,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -15035,7 +15035,7 @@
           "resolve": "Reduce `ports` count to 2"
         },
         "lineNumber": 26,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-36",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-36",
         "path": [
           "[DocId:0]",
           "spec",
@@ -15092,7 +15092,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 9,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -15126,7 +15126,7 @@
           "resolve": "Set `securityContext.readOnlyRootFilesystem` to `true`"
         },
         "lineNumber": 9,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-8",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-8",
         "path": [
           "[DocId:0]",
           "input",
@@ -15160,7 +15160,7 @@
           "resolve": "Add `livenessProbe` attribute"
         },
         "lineNumber": 9,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-41",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-41",
         "path": [
           "[DocId:0]",
           "spec",
@@ -15191,7 +15191,7 @@
           "resolve": "Set `imagePullPolicy` attribute to `Always`"
         },
         "lineNumber": 9,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-42",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-42",
         "path": [
           "[DocId:0]",
           "spec",
@@ -15223,7 +15223,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 9,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -15257,7 +15257,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 9,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -15291,7 +15291,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 9,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -15324,7 +15324,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -15359,7 +15359,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -15394,7 +15394,7 @@
           "resolve": "Set `imagePullPolicy` attribute to `Always`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-42",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-42",
         "path": [
           "[DocId:0]",
           "spec",
@@ -15424,7 +15424,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -15458,7 +15458,7 @@
           "resolve": "Set `securityContext.readOnlyRootFilesystem` to `true`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-8",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-8",
         "path": [
           "[DocId:0]",
           "input",
@@ -15491,7 +15491,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -15525,7 +15525,7 @@
           "resolve": "Add `livenessProbe` attribute"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-41",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-41",
         "path": [
           "[DocId:0]",
           "spec",
@@ -15556,7 +15556,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -15591,7 +15591,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -15626,7 +15626,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -15660,7 +15660,7 @@
           "resolve": "Set `securityContext.readOnlyRootFilesystem` to `true`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-8",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-8",
         "path": [
           "[DocId:0]",
           "input",
@@ -15693,7 +15693,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -15727,7 +15727,7 @@
           "resolve": "Add `livenessProbe` attribute"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-41",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-41",
         "path": [
           "[DocId:0]",
           "spec",
@@ -15758,7 +15758,7 @@
           "resolve": "Set `imagePullPolicy` attribute to `Always`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-42",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-42",
         "path": [
           "[DocId:0]",
           "spec",
@@ -15788,7 +15788,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -15822,7 +15822,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -15857,7 +15857,7 @@
           "resolve": "Set `securityContext.runAsNonRoot` to `true`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-10",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-10",
         "path": [
           "[DocId:0]",
           "input",
@@ -15890,7 +15890,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -15923,7 +15923,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -15957,7 +15957,7 @@
           "resolve": "Set `securityContext.readOnlyRootFilesystem` to `true`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-8",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-8",
         "path": [
           "[DocId:0]",
           "input",
@@ -15991,7 +15991,7 @@
           "resolve": "Add `livenessProbe` attribute"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-41",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-41",
         "path": [
           "[DocId:0]",
           "spec",
@@ -16022,7 +16022,7 @@
           "resolve": "Set `imagePullPolicy` attribute to `Always`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-42",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-42",
         "path": [
           "[DocId:0]",
           "spec",
@@ -16053,7 +16053,7 @@
           "resolve": "Set `securityContext.runAsNonRoot` to `true`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-10",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-10",
         "path": [
           "[DocId:0]",
           "input",
@@ -16086,7 +16086,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -16122,7 +16122,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -16156,7 +16156,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -16190,7 +16190,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -16223,7 +16223,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -16258,7 +16258,7 @@
           "resolve": "Set `securityContext.runAsNonRoot` to `true`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-10",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-10",
         "path": [
           "[DocId:0]",
           "input",
@@ -16291,7 +16291,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -16325,7 +16325,7 @@
           "resolve": "Set `imagePullPolicy` attribute to `Always`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-42",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-42",
         "path": [
           "[DocId:0]",
           "spec",
@@ -16357,7 +16357,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -16390,7 +16390,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -16424,7 +16424,7 @@
           "resolve": "Set `securityContext.readOnlyRootFilesystem` to `true`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-8",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-8",
         "path": [
           "[DocId:0]",
           "input",
@@ -16457,7 +16457,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -16491,7 +16491,7 @@
           "resolve": "Add `livenessProbe` attribute"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-41",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-41",
         "path": [
           "[DocId:0]",
           "spec",
@@ -16522,7 +16522,7 @@
           "resolve": "Set `securityContext.runAsNonRoot` to `true`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-10",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-10",
         "path": [
           "[DocId:0]",
           "input",
@@ -16556,7 +16556,7 @@
           "resolve": "Add `livenessProbe` attribute"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-41",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-41",
         "path": [
           "[DocId:0]",
           "spec",
@@ -16588,7 +16588,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -16622,7 +16622,7 @@
           "resolve": "Set `securityContext.readOnlyRootFilesystem` to `true`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-8",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-8",
         "path": [
           "[DocId:0]",
           "input",
@@ -16655,7 +16655,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -16690,7 +16690,7 @@
           "resolve": "Set `imagePullPolicy` attribute to `Always`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-42",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-42",
         "path": [
           "[DocId:0]",
           "spec",
@@ -16720,7 +16720,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -16754,7 +16754,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -16788,7 +16788,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -16821,7 +16821,7 @@
           "resolve": "Set `imagePullPolicy` attribute to `Always`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-42",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-42",
         "path": [
           "[DocId:0]",
           "spec",
@@ -16852,7 +16852,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -16887,7 +16887,7 @@
           "resolve": "Set `securityContext.runAsNonRoot` to `true`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-10",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-10",
         "path": [
           "[DocId:0]",
           "input",
@@ -16919,7 +16919,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -16953,7 +16953,7 @@
           "resolve": "Set `securityContext.readOnlyRootFilesystem` to `true`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-8",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-8",
         "path": [
           "[DocId:0]",
           "input",
@@ -16986,7 +16986,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -17019,7 +17019,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -17054,7 +17054,7 @@
           "resolve": "Add `livenessProbe` attribute"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-41",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-41",
         "path": [
           "[DocId:0]",
           "spec",
@@ -17086,7 +17086,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -17147,7 +17147,7 @@
           "resolve": "Set `securityContext.readOnlyRootFilesystem` to `true`"
         },
         "lineNumber": 28,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-8",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-8",
         "path": [
           "[DocId:0]",
           "input",
@@ -17180,7 +17180,7 @@
           "resolve": "Remove `securityContext.privileged` attribute, or set value to `false`"
         },
         "lineNumber": 31,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-1",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-1",
         "path": [
           "[DocId:0]",
           "input",
@@ -17213,7 +17213,7 @@
           "resolve": "Remove `securityContext.seLinuxOptions`"
         },
         "lineNumber": 29,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-33",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-33",
         "path": [
           "[DocId:0]",
           "spec",
@@ -17245,7 +17245,7 @@
           "resolve": "Remove `CAP_SYS_ADMIN` from `securityContext.capabilities.add` list"
         },
         "lineNumber": 36,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-7",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-7",
         "path": [
           "[DocId:0]",
           "input",
@@ -17280,7 +17280,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 24,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -17314,7 +17314,7 @@
           "resolve": "Set `imagePullPolicy` attribute to `Always`"
         },
         "lineNumber": 21,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-42",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-42",
         "path": [
           "[DocId:0]",
           "spec",
@@ -17345,7 +17345,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 28,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -17378,7 +17378,7 @@
           "resolve": "Set `securityContext.runAsNonRoot` to `true`"
         },
         "lineNumber": 28,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-10",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-10",
         "path": [
           "[DocId:0]",
           "input",
@@ -17412,7 +17412,7 @@
           "resolve": "Remove `hostIPC` attribute, or set value to `false`"
         },
         "lineNumber": 8,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-13",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-13",
         "path": [
           "[DocId:0]",
           "input",
@@ -17444,7 +17444,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 24,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -17477,7 +17477,7 @@
           "resolve": "Remove `hostAliases` attribute"
         },
         "lineNumber": 12,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-12",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-12",
         "path": [
           "[DocId:0]",
           "input",
@@ -17508,7 +17508,7 @@
           "resolve": "Remove `docker.sock` hostPath volume"
         },
         "lineNumber": 40,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-2",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-2",
         "path": [
           "[DocId:0]",
           "input",
@@ -17541,7 +17541,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -17575,7 +17575,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 32,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -17610,7 +17610,7 @@
           "resolve": "Add `livenessProbe` attribute"
         },
         "lineNumber": 21,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-41",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-41",
         "path": [
           "[DocId:0]",
           "spec",
@@ -17641,7 +17641,7 @@
           "resolve": "Remove `hostNetwork` attribute, or set value to `false`"
         },
         "lineNumber": 10,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-14",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-14",
         "path": [
           "[DocId:0]",
           "input",
@@ -17671,7 +17671,7 @@
           "resolve": "Remove `hostPID` attribute, or set value to `false`"
         },
         "lineNumber": 9,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-3",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-3",
         "path": [
           "[DocId:0]",
           "input",
@@ -17728,7 +17728,7 @@
           "resolve": "Remove ssh from `ports` array"
         },
         "lineNumber": 25,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-34",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-34",
         "path": [
           "[DocId:0]",
           "spec",
@@ -17760,7 +17760,7 @@
           "resolve": "Set `securityContext.readOnlyRootFilesystem` to `true`"
         },
         "lineNumber": 32,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-8",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-8",
         "path": [
           "[DocId:0]",
           "input",
@@ -17793,7 +17793,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 32,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -17826,7 +17826,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -17861,7 +17861,7 @@
           "resolve": "Set `imagePullPolicy` attribute to `Always`"
         },
         "lineNumber": 21,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-42",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-42",
         "path": [
           "[DocId:0]",
           "spec",
@@ -17892,7 +17892,7 @@
           "resolve": "Set `securityContext.runAsNonRoot` to `true`"
         },
         "lineNumber": 32,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-10",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-10",
         "path": [
           "[DocId:0]",
           "input",
@@ -17926,7 +17926,7 @@
           "resolve": "Add `livenessProbe` attribute"
         },
         "lineNumber": 21,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-41",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-41",
         "path": [
           "[DocId:0]",
           "spec",
@@ -17956,7 +17956,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 34,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -17990,7 +17990,7 @@
           "resolve": "Remove `securityContext.privileged` attribute, or set value to `false`"
         },
         "lineNumber": 33,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-1",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-1",
         "path": [
           "[DocId:0]",
           "input",
@@ -18024,7 +18024,7 @@
           "resolve": "Remove `hostIPC` attribute, or set value to `false`"
         },
         "lineNumber": 8,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-13",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-13",
         "path": [
           "[DocId:0]",
           "input",
@@ -18055,7 +18055,7 @@
           "resolve": "Remove `CAP_SYS_ADMIN` from `securityContext.capabilities.add` list"
         },
         "lineNumber": 38,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-7",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-7",
         "path": [
           "[DocId:0]",
           "input",
@@ -18089,7 +18089,7 @@
           "resolve": "Remove `hostAliases` attribute"
         },
         "lineNumber": 12,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-12",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-12",
         "path": [
           "[DocId:0]",
           "input",
@@ -18120,7 +18120,7 @@
           "resolve": "Remove `docker.sock` hostPath volume"
         },
         "lineNumber": 42,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-2",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-2",
         "path": [
           "[DocId:0]",
           "input",
@@ -18153,7 +18153,7 @@
           "resolve": "Remove `hostNetwork` attribute, or set value to `false`"
         },
         "lineNumber": 10,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-14",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-14",
         "path": [
           "[DocId:0]",
           "input",
@@ -18184,7 +18184,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 28,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -18217,7 +18217,7 @@
           "resolve": "Remove `hostPID` attribute, or set value to `false`"
         },
         "lineNumber": 9,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-3",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-3",
         "path": [
           "[DocId:0]",
           "input",
@@ -18249,7 +18249,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 28,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -18310,7 +18310,7 @@
           "resolve": "Set `securityContext.readOnlyRootFilesystem` to `true`"
         },
         "lineNumber": 32,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-8",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-8",
         "path": [
           "[DocId:0]",
           "input",
@@ -18343,7 +18343,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 32,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -18376,7 +18376,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -18411,7 +18411,7 @@
           "resolve": "Set `imagePullPolicy` attribute to `Always`"
         },
         "lineNumber": 21,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-42",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-42",
         "path": [
           "[DocId:0]",
           "spec",
@@ -18442,7 +18442,7 @@
           "resolve": "Set `securityContext.runAsNonRoot` to `true`"
         },
         "lineNumber": 32,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-10",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-10",
         "path": [
           "[DocId:0]",
           "input",
@@ -18474,7 +18474,7 @@
           "resolve": "Remove `mountPropagation` attribute, or set value to `None`"
         },
         "lineNumber": 25,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-38",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-38",
         "path": [
           "[DocId:0]",
           "spec",
@@ -18506,7 +18506,7 @@
           "resolve": "Add `livenessProbe` attribute"
         },
         "lineNumber": 21,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-41",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-41",
         "path": [
           "[DocId:0]",
           "spec",
@@ -18536,7 +18536,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 34,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -18570,7 +18570,7 @@
           "resolve": "Remove `securityContext.privileged` attribute, or set value to `false`"
         },
         "lineNumber": 33,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-1",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-1",
         "path": [
           "[DocId:0]",
           "input",
@@ -18604,7 +18604,7 @@
           "resolve": "Remove `hostIPC` attribute, or set value to `false`"
         },
         "lineNumber": 8,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-13",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-13",
         "path": [
           "[DocId:0]",
           "input",
@@ -18635,7 +18635,7 @@
           "resolve": "Remove `CAP_SYS_ADMIN` from `securityContext.capabilities.add` list"
         },
         "lineNumber": 38,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-7",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-7",
         "path": [
           "[DocId:0]",
           "input",
@@ -18669,7 +18669,7 @@
           "resolve": "Remove `hostAliases` attribute"
         },
         "lineNumber": 12,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-12",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-12",
         "path": [
           "[DocId:0]",
           "input",
@@ -18700,7 +18700,7 @@
           "resolve": "Remove `docker.sock` hostPath volume"
         },
         "lineNumber": 42,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-2",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-2",
         "path": [
           "[DocId:0]",
           "input",
@@ -18733,7 +18733,7 @@
           "resolve": "Remove `hostNetwork` attribute, or set value to `false`"
         },
         "lineNumber": 10,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-14",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-14",
         "path": [
           "[DocId:0]",
           "input",
@@ -18764,7 +18764,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 28,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -18797,7 +18797,7 @@
           "resolve": "Remove `hostPID` attribute, or set value to `false`"
         },
         "lineNumber": 9,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-3",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-3",
         "path": [
           "[DocId:0]",
           "input",
@@ -18829,7 +18829,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 28,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -18890,7 +18890,7 @@
           "resolve": "Set `securityContext.readOnlyRootFilesystem` to `true`"
         },
         "lineNumber": 28,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-8",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-8",
         "path": [
           "[DocId:0]",
           "input",
@@ -18923,7 +18923,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 28,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -18956,7 +18956,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -18991,7 +18991,7 @@
           "resolve": "Set `imagePullPolicy` attribute to `Always`"
         },
         "lineNumber": 21,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-42",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-42",
         "path": [
           "[DocId:0]",
           "spec",
@@ -19022,7 +19022,7 @@
           "resolve": "Set `securityContext.runAsNonRoot` to `true`"
         },
         "lineNumber": 28,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-10",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-10",
         "path": [
           "[DocId:0]",
           "input",
@@ -19056,7 +19056,7 @@
           "resolve": "Add `livenessProbe` attribute"
         },
         "lineNumber": 21,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-41",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-41",
         "path": [
           "[DocId:0]",
           "spec",
@@ -19086,7 +19086,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 30,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -19120,7 +19120,7 @@
           "resolve": "Remove `securityContext.privileged` attribute, or set value to `false`"
         },
         "lineNumber": 29,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-1",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-1",
         "path": [
           "[DocId:0]",
           "input",
@@ -19154,7 +19154,7 @@
           "resolve": "Remove `hostIPC` attribute, or set value to `false`"
         },
         "lineNumber": 8,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-13",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-13",
         "path": [
           "[DocId:0]",
           "input",
@@ -19185,7 +19185,7 @@
           "resolve": "Remove `CAP_SYS_ADMIN` from `securityContext.capabilities.add` list"
         },
         "lineNumber": 34,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-7",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-7",
         "path": [
           "[DocId:0]",
           "input",
@@ -19219,7 +19219,7 @@
           "resolve": "Remove `hostAliases` attribute"
         },
         "lineNumber": 12,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-12",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-12",
         "path": [
           "[DocId:0]",
           "input",
@@ -19250,7 +19250,7 @@
           "resolve": "Remove `docker.sock` hostPath volume"
         },
         "lineNumber": 38,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-2",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-2",
         "path": [
           "[DocId:0]",
           "input",
@@ -19283,7 +19283,7 @@
           "resolve": "Remove `hostNetwork` attribute, or set value to `false`"
         },
         "lineNumber": 10,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-14",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-14",
         "path": [
           "[DocId:0]",
           "input",
@@ -19314,7 +19314,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 24,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -19347,7 +19347,7 @@
           "resolve": "Remove `hostPID` attribute, or set value to `false`"
         },
         "lineNumber": 9,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-3",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-3",
         "path": [
           "[DocId:0]",
           "input",
@@ -19379,7 +19379,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 24,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -19440,7 +19440,7 @@
           "resolve": "Remove `privileged` attribute, or set vault to `false`"
         },
         "lineNumber": 8,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-16",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-16",
         "path": [
           "[DocId:0]",
           "input",
@@ -19470,7 +19470,7 @@
           "resolve": "Set `allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-17",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-17",
         "path": [
           "[DocId:0]",
           "input",
@@ -19500,7 +19500,7 @@
           "resolve": "Set `defaultAllowPrivilegeEscalation` value to `false`"
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-18",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-18",
         "path": [
           "[DocId:0]",
           "input",
@@ -19530,7 +19530,7 @@
           "resolve": "Remove `hostPID` attribute, or set value to `false`"
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-19",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-19",
         "path": [
           "[DocId:0]",
           "input",
@@ -19560,7 +19560,7 @@
           "resolve": "Remove the `hostIPC` attribute, or set value to `false`"
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-20",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-20",
         "path": [
           "[DocId:0]",
           "input",
@@ -19590,7 +19590,7 @@
           "resolve": "Remove `hostNetwork` attribute, or set value to `false`"
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-21",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-21",
         "path": [
           "[DocId:0]",
           "input",
@@ -19620,7 +19620,7 @@
           "resolve": "Set `runAsUser` to `MustRunAsNonRoot`, or exclude UID `0` from `MustRunAs` range"
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-22",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-22",
         "path": [
           "[DocId:0]",
           "input",
@@ -19651,7 +19651,7 @@
           "resolve": "Set `runAsUser` to `MustRunAsNonRoot`, or exclude UID `0` from `MustRunAs` range"
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-22",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-22",
         "path": [
           "[DocId:0]",
           "input",
@@ -19683,7 +19683,7 @@
           "resolve": "Remove `allowedCapabilities` attribute, or set value to `[]`"
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-23",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-23",
         "path": [
           "[DocId:0]",
           "input",
@@ -19714,7 +19714,7 @@
           "resolve": "Remove `allowedCapabilities` attribute, or set value to `[]`"
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-23",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-23",
         "path": [
           "[DocId:0]",
           "input",
@@ -19745,7 +19745,7 @@
           "resolve": "Remove `allowedCapabilities` attribute, or set value to `[]`"
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-23",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-23",
         "path": [
           "[DocId:0]",
           "input",
@@ -19776,7 +19776,7 @@
           "resolve": "Remove `allowedCapabilities` attribute, or set value to `[]`"
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-23",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-23",
         "path": [
           "[DocId:0]",
           "input",
@@ -19806,7 +19806,7 @@
           "resolve": "Add `ALL` or `NET_RAW` to  `requiredDropCapabilities` attribute"
         },
         "lineNumber": 10,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-24",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-24",
         "path": [
           "[DocId:0]",
           "input",
@@ -19836,7 +19836,7 @@
           "resolve": "Add `ALL` or `NET_RAW` to  `requiredDropCapabilities` attribute"
         },
         "lineNumber": 10,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-24",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-24",
         "path": [
           "[DocId:0]",
           "input",
@@ -19866,7 +19866,7 @@
           "resolve": "Add `ALL` or `NET_RAW` to  `requiredDropCapabilities` attribute"
         },
         "lineNumber": 10,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-24",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-24",
         "path": [
           "[DocId:0]",
           "input",
@@ -19896,7 +19896,7 @@
           "resolve": "Set `runAsGroup` to `MustRunAs` to range which does not include GID `0`"
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-27",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-27",
         "path": [
           "[DocId:0]",
           "input",
@@ -19927,7 +19927,7 @@
           "resolve": "Set `runAsGroup` to `MustRunAs` to range which does not include GID `0`"
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-27",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-27",
         "path": [
           "[DocId:0]",
           "input",
@@ -19959,7 +19959,7 @@
           "resolve": "Set `seccomp.security.alpha.kubernetes.io/allowedProfileNames` to `runtime/default` only"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-28",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-28",
         "path": [
           "[DocId:0]",
           "input",
@@ -19994,7 +19994,7 @@
           "resolve": "Set `seccomp.security.alpha.kubernetes.io/allowedProfileNames` to `runtime/default` only"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-28",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-28",
         "path": [
           "[DocId:0]",
           "input",
@@ -20029,7 +20029,7 @@
           "resolve": "Set `seccomp.security.alpha.kubernetes.io/defaultProfileName` annotation to `runtime/default`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-29",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-29",
         "path": [
           "[DocId:0]",
           "input",
@@ -20064,7 +20064,7 @@
           "resolve": "Set value to specific volume types, or remove the attribute"
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-30",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-30",
         "path": [
           "[DocId:0]",
           "input",
@@ -20094,7 +20094,7 @@
           "resolve": "Set `apparmor.security.beta.kubernetes.io/defaultProfileNam` annotation to `runtime/default`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-31",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-31",
         "path": [
           "[DocId:0]",
           "input",
@@ -20128,7 +20128,7 @@
           "resolve": "Set `apparmor.security.beta.kubernetes.io/defaultProfileNam` annotation to `runtime/default`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-31",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-31",
         "path": [
           "[DocId:0]",
           "input",
@@ -20190,7 +20190,7 @@
           "resolve": "Remove `securityContext.privileged` attribute, or set value to `false`"
         },
         "lineNumber": 44,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-1",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-1",
         "path": [
           "[DocId:0]",
           "input",
@@ -20225,7 +20225,7 @@
           "resolve": "Remove `hostNetwork` attribute, or set value to `false`"
         },
         "lineNumber": 19,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-14",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-14",
         "path": [
           "[DocId:0]",
           "input",
@@ -20258,7 +20258,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -20293,7 +20293,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 27,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -20330,7 +20330,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 27,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -20365,7 +20365,7 @@
           "resolve": "Remove `hostAliases` attribute"
         },
         "lineNumber": 23,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-12",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-12",
         "path": [
           "[DocId:0]",
           "input",
@@ -20397,7 +20397,7 @@
           "resolve": "Remove `hostPath` volume mount"
         },
         "lineNumber": 51,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-37",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-37",
         "path": [
           "[DocId:0]",
           "spec",
@@ -20431,7 +20431,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 45,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -20467,7 +20467,7 @@
           "resolve": "Remove `hostIPC` attribute, or set value to `false`"
         },
         "lineNumber": 20,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-13",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-13",
         "path": [
           "[DocId:0]",
           "input",
@@ -20499,7 +20499,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 38,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -20534,7 +20534,7 @@
           "resolve": "Set `securityContext.RunAsUser` value"
         },
         "lineNumber": 42,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-11",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-11",
         "path": [
           "[DocId:0]",
           "input",
@@ -20569,7 +20569,7 @@
           "resolve": "Remove `docker.sock` hostPath volume"
         },
         "lineNumber": 54,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-2",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-2",
         "path": [
           "[DocId:0]",
           "input",
@@ -20603,7 +20603,7 @@
           "resolve": "Remove ssh from `ports` array"
         },
         "lineNumber": 34,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-34",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-34",
         "path": [
           "[DocId:0]",
           "spec",
@@ -20636,7 +20636,7 @@
           "resolve": "Remove `mountPropagation` attribute, or set value to `None`"
         },
         "lineNumber": 30,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-38",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-38",
         "path": [
           "[DocId:0]",
           "spec",
@@ -20667,7 +20667,7 @@
           "resolve": "Reduce `ports` count to 2"
         },
         "lineNumber": 34,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-36",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-36",
         "path": [
           "[DocId:0]",
           "spec",
@@ -20699,7 +20699,7 @@
           "resolve": "Remove `hostPID` attribute, or set value to `false`"
         },
         "lineNumber": 21,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-3",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-3",
         "path": [
           "[DocId:0]",
           "input",
@@ -20732,7 +20732,7 @@
           "resolve": "Remove `CAP_SYS_ADMIN` from `securityContext.capabilities.add` list"
         },
         "lineNumber": 40,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-7",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-7",
         "path": [
           "[DocId:0]",
           "input",
@@ -20769,7 +20769,7 @@
           "resolve": "Remove `securityContext.seLinuxOptions`"
         },
         "lineNumber": 46,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-33",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-33",
         "path": [
           "[DocId:0]",
           "spec",
@@ -20829,7 +20829,7 @@
           "resolve": "Remove `mountPropagation` attribute, or set value to `None`"
         },
         "lineNumber": 37,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-38",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-38",
         "path": [
           "[DocId:0]",
           "spec",
@@ -20862,7 +20862,7 @@
           "resolve": "Remove `securityContext.privileged` attribute, or set value to `false`"
         },
         "lineNumber": 31,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-1",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-1",
         "path": [
           "[DocId:0]",
           "input",
@@ -20897,7 +20897,7 @@
           "resolve": "Remove `hostNetwork` attribute, or set value to `false`"
         },
         "lineNumber": 15,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-14",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-14",
         "path": [
           "[DocId:0]",
           "input",
@@ -20930,7 +20930,7 @@
           "resolve": "Remove `securityContext.seLinuxOptions`"
         },
         "lineNumber": 33,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-33",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-33",
         "path": [
           "[DocId:0]",
           "spec",
@@ -20963,7 +20963,7 @@
           "resolve": "Remove `hostAliases` attribute"
         },
         "lineNumber": 19,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-12",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-12",
         "path": [
           "[DocId:0]",
           "input",
@@ -20995,7 +20995,7 @@
           "resolve": "Remove `hostPath` volume mount"
         },
         "lineNumber": 47,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-37",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-37",
         "path": [
           "[DocId:0]",
           "spec",
@@ -21030,7 +21030,7 @@
           "resolve": "Remove `hostIPC` attribute, or set value to `false`"
         },
         "lineNumber": 16,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-13",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-13",
         "path": [
           "[DocId:0]",
           "input",
@@ -21061,7 +21061,7 @@
           "resolve": "Reduce `ports` count to 2"
         },
         "lineNumber": 41,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-36",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-36",
         "path": [
           "[DocId:0]",
           "spec",
@@ -21093,7 +21093,7 @@
           "resolve": "Set `securityContext.RunAsUser` value"
         },
         "lineNumber": 30,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-11",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-11",
         "path": [
           "[DocId:0]",
           "input",
@@ -21128,7 +21128,7 @@
           "resolve": "Remove `docker.sock` hostPath volume"
         },
         "lineNumber": 50,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-2",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-2",
         "path": [
           "[DocId:0]",
           "input",
@@ -21163,7 +21163,7 @@
           "resolve": "Remove `CAP_SYS_ADMIN` from `securityContext.capabilities.add` list"
         },
         "lineNumber": 27,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-7",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-7",
         "path": [
           "[DocId:0]",
           "input",
@@ -21200,7 +21200,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 23,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -21237,7 +21237,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 23,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -21272,7 +21272,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 25,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -21307,7 +21307,7 @@
           "resolve": "Remove `hostPID` attribute, or set value to `false`"
         },
         "lineNumber": 17,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-3",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-3",
         "path": [
           "[DocId:0]",
           "input",
@@ -21340,7 +21340,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -21375,7 +21375,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 32,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -21409,7 +21409,7 @@
           "resolve": "Remove ssh from `ports` array"
         },
         "lineNumber": 41,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-34",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-34",
         "path": [
           "[DocId:0]",
           "spec",
@@ -21469,7 +21469,7 @@
           "resolve": "Set `loadBalancerSourceRanges` attribute value to specific IP addresses"
         },
         "lineNumber": 2,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-15",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-15",
         "path": [
           "[DocId:0]",
           "service",
@@ -21526,7 +21526,7 @@
           "resolve": "Remove `mountPropagation` attribute, or set value to `None`"
         },
         "lineNumber": 44,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-38",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-38",
         "path": [
           "[DocId:0]",
           "spec",
@@ -21559,7 +21559,7 @@
           "resolve": "Remove `securityContext.privileged` attribute, or set value to `false`"
         },
         "lineNumber": 34,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-1",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-1",
         "path": [
           "[DocId:0]",
           "input",
@@ -21594,7 +21594,7 @@
           "resolve": "Remove `hostNetwork` attribute, or set value to `false`"
         },
         "lineNumber": 17,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-14",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-14",
         "path": [
           "[DocId:0]",
           "input",
@@ -21627,7 +21627,7 @@
           "resolve": "Remove `securityContext.seLinuxOptions`"
         },
         "lineNumber": 36,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-33",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-33",
         "path": [
           "[DocId:0]",
           "spec",
@@ -21660,7 +21660,7 @@
           "resolve": "Remove `hostAliases` attribute"
         },
         "lineNumber": 21,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-12",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-12",
         "path": [
           "[DocId:0]",
           "input",
@@ -21692,7 +21692,7 @@
           "resolve": "Remove `hostPath` volume mount"
         },
         "lineNumber": 50,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-37",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-37",
         "path": [
           "[DocId:0]",
           "spec",
@@ -21727,7 +21727,7 @@
           "resolve": "Remove `hostIPC` attribute, or set value to `false`"
         },
         "lineNumber": 18,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-13",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-13",
         "path": [
           "[DocId:0]",
           "input",
@@ -21758,7 +21758,7 @@
           "resolve": "Reduce `ports` count to 2"
         },
         "lineNumber": 39,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-36",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-36",
         "path": [
           "[DocId:0]",
           "spec",
@@ -21790,7 +21790,7 @@
           "resolve": "Set `securityContext.RunAsUser` value"
         },
         "lineNumber": 33,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-11",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-11",
         "path": [
           "[DocId:0]",
           "input",
@@ -21825,7 +21825,7 @@
           "resolve": "Remove `docker.sock` hostPath volume"
         },
         "lineNumber": 53,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-2",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-2",
         "path": [
           "[DocId:0]",
           "input",
@@ -21860,7 +21860,7 @@
           "resolve": "Remove `CAP_SYS_ADMIN` from `securityContext.capabilities.add` list"
         },
         "lineNumber": 30,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-7",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-7",
         "path": [
           "[DocId:0]",
           "input",
@@ -21897,7 +21897,7 @@
           "resolve": "Set `resources.limits.memory` value"
         },
         "lineNumber": 25,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-4",
         "path": [
           "[DocId:0]",
           "input",
@@ -21934,7 +21934,7 @@
           "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
         },
         "lineNumber": 25,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-5",
         "path": [
           "[DocId:0]",
           "input",
@@ -21969,7 +21969,7 @@
           "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
         },
         "lineNumber": 28,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-6",
         "path": [
           "[DocId:0]",
           "input",
@@ -22004,7 +22004,7 @@
           "resolve": "Remove `hostPID` attribute, or set value to `false`"
         },
         "lineNumber": 19,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-3",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-3",
         "path": [
           "[DocId:0]",
           "input",
@@ -22037,7 +22037,7 @@
           "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-32",
         "path": [
           "[DocId:0]",
           "metadata",
@@ -22072,7 +22072,7 @@
           "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
         },
         "lineNumber": 35,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-9",
         "path": [
           "[DocId:0]",
           "input",
@@ -22106,7 +22106,7 @@
           "resolve": "Remove ssh from `ports` array"
         },
         "lineNumber": 39,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-34",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-34",
         "path": [
           "[DocId:0]",
           "spec",
@@ -22168,7 +22168,7 @@
           "resolve": "Set `security_policy` attribute to `TLS_1_2`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-63",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-63",
         "path": [
           "resource",
           "aws_api_gateway_domain_name[denied]",
@@ -22279,7 +22279,7 @@
           "resolve": "Set `authorization` attribute to value other than `NONE`"
         },
         "lineNumber": 18,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-99",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-99",
         "path": [
           "resource",
           "aws_api_gateway_method[denied_4]",
@@ -22311,7 +22311,7 @@
           "resolve": "Set `authorization` attribute to value other than `NONE`"
         },
         "lineNumber": 8,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-99",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-99",
         "path": [
           "resource",
           "aws_api_gateway_method[denied_2]",
@@ -22343,7 +22343,7 @@
           "resolve": "Set `authorization` attribute to value other than `NONE`"
         },
         "lineNumber": 23,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-99",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-99",
         "path": [
           "resource",
           "aws_api_gateway_method[denied_5]",
@@ -22375,7 +22375,7 @@
           "resolve": "Set `authorization` attribute to value other than `NONE`"
         },
         "lineNumber": 13,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-99",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-99",
         "path": [
           "resource",
           "aws_api_gateway_method[denied_3]",
@@ -22407,7 +22407,7 @@
           "resolve": "Set `authorization` attribute to value other than `NONE`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-99",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-99",
         "path": [
           "resource",
           "aws_api_gateway_method[denied]",
@@ -22439,7 +22439,7 @@
           "resolve": "Set `authorization` attribute to value other than `NONE`"
         },
         "lineNumber": 28,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-99",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-99",
         "path": [
           "resource",
           "aws_api_gateway_method[denied_6]",
@@ -22497,7 +22497,7 @@
           "resolve": "Set `access_log_settings` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-138",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-138",
         "path": [
           "resource",
           "aws_api_gateway_stage[allowed]",
@@ -22557,7 +22557,7 @@
           "resolve": "Set `xray_tracing_enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-129",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-129",
         "path": [
           "resource",
           "aws_api_gateway_stage[denied]",
@@ -22590,7 +22590,7 @@
           "resolve": "Set `xray_tracing_enabled` attribute to `true`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-129",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-129",
         "path": [
           "resource",
           "aws_api_gateway_stage[denied_2]",
@@ -22621,7 +22621,7 @@
           "resolve": "Set `access_log_settings` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-138",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-138",
         "path": [
           "resource",
           "aws_api_gateway_stage[denied]",
@@ -22652,7 +22652,7 @@
           "resolve": "Set `access_log_settings` attribute"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-138",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-138",
         "path": [
           "resource",
           "aws_api_gateway_stage[denied_2]",
@@ -22738,7 +22738,7 @@
           "resolve": "Set `configuration.enforce_workgroup_configuration` attribute to `true`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-113",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-113",
         "path": [
           "resource",
           "aws_athena_workgroup[denied]",
@@ -22823,7 +22823,7 @@
           "resolve": "Set `artifacts.encryption_disabled` or `secondary_artifacts.encryption_disabled` attributes to `false`, or remove the attribute from configuration"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-111",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-111",
         "path": [
           "resource",
           "aws_codebuild_project[denied]",
@@ -22855,7 +22855,7 @@
           "resolve": "Set `artifacts.encryption_disabled` or `secondary_artifacts.encryption_disabled` attributes to `false`, or remove the attribute from configuration"
         },
         "lineNumber": 39,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-111",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-111",
         "path": [
           "resource",
           "aws_codebuild_project[denied_5]",
@@ -22887,7 +22887,7 @@
           "resolve": "Set `artifacts.encryption_disabled` or `secondary_artifacts.encryption_disabled` attributes to `false`, or remove the attribute from configuration"
         },
         "lineNumber": 11,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-111",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-111",
         "path": [
           "resource",
           "aws_codebuild_project[denied_2]",
@@ -22919,7 +22919,7 @@
           "resolve": "Set `artifacts.encryption_disabled` or `secondary_artifacts.encryption_disabled` attributes to `false`, or remove the attribute from configuration"
         },
         "lineNumber": 15,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-111",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-111",
         "path": [
           "resource",
           "aws_codebuild_project[denied_3]",
@@ -22951,7 +22951,7 @@
           "resolve": "Set `artifacts.encryption_disabled` or `secondary_artifacts.encryption_disabled` attributes to `false`, or remove the attribute from configuration"
         },
         "lineNumber": 26,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-111",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-111",
         "path": [
           "resource",
           "aws_codebuild_project[denied_4]",
@@ -23010,7 +23010,7 @@
           "resolve": "Set `disable_api_termination` attribute  with value `true`"
         },
         "lineNumber": 13,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-426",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-426",
         "path": [
           "resource",
           "aws_instance[allowed_3]",
@@ -23044,7 +23044,7 @@
           "resolve": "Set `root_block_device.encrypted` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-53",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-53",
         "path": [
           "resource",
           "aws_instance[allowed]",
@@ -23076,7 +23076,7 @@
           "resolve": "Set `disable_api_termination` attribute  with value `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-426",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-426",
         "path": [
           "resource",
           "aws_instance[allowed]",
@@ -23110,7 +23110,7 @@
           "resolve": "Set `root_block_device.encrypted` attribute to `true`"
         },
         "lineNumber": 13,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-53",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-53",
         "path": [
           "resource",
           "aws_instance[allowed_3]",
@@ -23142,7 +23142,7 @@
           "resolve": "Set `disable_api_termination` attribute  with value `true`"
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-426",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-426",
         "path": [
           "resource",
           "aws_instance[allowed_2]",
@@ -23176,7 +23176,7 @@
           "resolve": "Set `root_block_device.encrypted` attribute to `true`"
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-53",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-53",
         "path": [
           "resource",
           "aws_instance[allowed_2]",
@@ -23235,7 +23235,7 @@
           "resolve": "Set `disable_api_termination` attribute  with value `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-426",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-426",
         "path": [
           "resource",
           "aws_instance[denied]",
@@ -23265,7 +23265,7 @@
           "resolve": "Set `metadata_options.http_tokens` attribute to `required`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-130",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-130",
         "path": [
           "resource",
           "aws_instance[denied_2]",
@@ -23295,7 +23295,7 @@
           "resolve": "Set `metadata_options.http_tokens` attribute to `required`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-130",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-130",
         "path": [
           "resource",
           "aws_instance[denied]",
@@ -23326,7 +23326,7 @@
           "resolve": "Set `disable_api_termination` attribute  with value `true`"
         },
         "lineNumber": 10,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-426",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-426",
         "path": [
           "resource",
           "aws_instance[denied_3]",
@@ -23360,7 +23360,7 @@
           "resolve": "Set `root_block_device.encrypted` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-53",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-53",
         "path": [
           "resource",
           "aws_instance[denied]",
@@ -23395,7 +23395,7 @@
           "resolve": "Set `root_block_device.encrypted` attribute to `true`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-53",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-53",
         "path": [
           "resource",
           "aws_instance[denied_2]",
@@ -23430,7 +23430,7 @@
           "resolve": "Set `root_block_device.encrypted` attribute to `true`"
         },
         "lineNumber": 10,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-53",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-53",
         "path": [
           "resource",
           "aws_instance[denied_3]",
@@ -23462,7 +23462,7 @@
           "resolve": "Set `disable_api_termination` attribute  with value `true`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-426",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-426",
         "path": [
           "resource",
           "aws_instance[denied_2]",
@@ -23492,7 +23492,7 @@
           "resolve": "Set `metadata_options.http_tokens` attribute to `required`"
         },
         "lineNumber": 11,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-130",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-130",
         "path": [
           "resource",
           "aws_instance[denied_3]",
@@ -23576,7 +23576,7 @@
           "resolve": "Set `statement.principal` attribute of policy document to specific accounts only e.g. `arn:aws:iam::account-id:root`"
         },
         "lineNumber": 26,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-93",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-93",
         "path": [
           "resource",
           "aws_ecr_repository_policy[denied_2]",
@@ -23608,7 +23608,7 @@
           "resolve": "Set `statement.principal` attribute of policy document to specific accounts only e.g. `arn:aws:iam::account-id:root`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-93",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-93",
         "path": [
           "resource",
           "aws_ecr_repository_policy[denied]",
@@ -23693,7 +23693,7 @@
           "resolve": "Set `settings.name` attribute to `containerInsights`, and `settings.value` to `enabled`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-128",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-128",
         "path": [
           "resource",
           "aws_ecs_cluster[denied]",
@@ -23724,7 +23724,7 @@
           "resolve": "Set `settings.name` attribute to `containerInsights`, and `settings.value` to `enabled`"
         },
         "lineNumber": 11,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-128",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-128",
         "path": [
           "resource",
           "aws_ecs_cluster[denied_3]",
@@ -23755,7 +23755,7 @@
           "resolve": "Set `settings.name` attribute to `containerInsights`, and `settings.value` to `enabled`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-128",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-128",
         "path": [
           "resource",
           "aws_ecs_cluster[denied_2]",
@@ -23809,7 +23809,7 @@
           "resolve": "Set `enabled_cluster_log_types` attribute to `['api;, 'audit', 'authenticator', 'controllerManager', 'scheduler' ]`"
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-131",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-131",
         "path": [
           "resource",
           "aws_eks_cluster[allowed_2]",
@@ -23836,7 +23836,7 @@
           "resolve": "Set `enabled_cluster_log_types` attribute to `['api;, 'audit', 'authenticator', 'controllerManager', 'scheduler' ]`"
         },
         "lineNumber": 13,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-131",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-131",
         "path": [
           "resource",
           "aws_eks_cluster[allowed_3]",
@@ -23868,7 +23868,7 @@
           "resolve": "Set the `encryption_config` object with the relevant `provider` & `resources`."
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-107",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-107",
         "path": [
           "resource",
           "aws_eks_cluster[allowed_2]",
@@ -23900,7 +23900,7 @@
           "resolve": "Set the `encryption_config` object with the relevant `provider` & `resources`."
         },
         "lineNumber": 13,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-107",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-107",
         "path": [
           "resource",
           "aws_eks_cluster[allowed_3]",
@@ -23927,7 +23927,7 @@
           "resolve": "Set `enabled_cluster_log_types` attribute to `['api;, 'audit', 'authenticator', 'controllerManager', 'scheduler' ]`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-131",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-131",
         "path": [
           "resource",
           "aws_eks_cluster[allowed]",
@@ -23959,7 +23959,7 @@
           "resolve": "Set the `encryption_config` object with the relevant `provider` & `resources`."
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-107",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-107",
         "path": [
           "resource",
           "aws_eks_cluster[allowed]",
@@ -24013,7 +24013,7 @@
           "resolve": "Set `enabled_cluster_log_types` attribute to `['api;, 'audit', 'authenticator', 'controllerManager', 'scheduler' ]`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-131",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-131",
         "path": [
           "resource",
           "aws_eks_cluster[denied]",
@@ -24040,7 +24040,7 @@
           "resolve": "Set `enabled_cluster_log_types` attribute to `['api;, 'audit', 'authenticator', 'controllerManager', 'scheduler' ]`"
         },
         "lineNumber": 18,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-131",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-131",
         "path": [
           "resource",
           "aws_eks_cluster[denied_4]",
@@ -24072,7 +24072,7 @@
           "resolve": "Set the `encryption_config` object with the relevant `provider` & `resources`."
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-107",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-107",
         "path": [
           "resource",
           "aws_eks_cluster[denied]",
@@ -24099,7 +24099,7 @@
           "resolve": "Set `vpc_config.public_access_cidrs` attribute to specific net address e.g. `192.168.0.0/24`, or set `vpc_config.endpoint_public_access` attribute to `false`"
         },
         "lineNumber": 2,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-94",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-94",
         "path": [
           "resource",
           "aws_eks_cluster[denied]",
@@ -24131,7 +24131,7 @@
           "resolve": "Set the `encryption_config` object with the relevant `provider` & `resources`."
         },
         "lineNumber": 18,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-107",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-107",
         "path": [
           "resource",
           "aws_eks_cluster[denied_4]",
@@ -24158,7 +24158,7 @@
           "resolve": "Set `vpc_config.public_access_cidrs` attribute to specific net address e.g. `192.168.0.0/24`, or set `vpc_config.endpoint_public_access` attribute to `false`"
         },
         "lineNumber": 13,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-94",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-94",
         "path": [
           "resource",
           "aws_eks_cluster[denied_3]",
@@ -24185,7 +24185,7 @@
           "resolve": "Set `vpc_config.public_access_cidrs` attribute to specific net address e.g. `192.168.0.0/24`, or set `vpc_config.endpoint_public_access` attribute to `false`"
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-94",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-94",
         "path": [
           "resource",
           "aws_eks_cluster[denied_2]",
@@ -24212,7 +24212,7 @@
           "resolve": "Set `vpc_config.public_access_cidrs` attribute to specific net address e.g. `192.168.0.0/24`, or set `vpc_config.endpoint_public_access` attribute to `false`"
         },
         "lineNumber": 19,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-94",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-94",
         "path": [
           "resource",
           "aws_eks_cluster[denied_4]",
@@ -24239,7 +24239,7 @@
           "resolve": "Set `enabled_cluster_log_types` attribute to `['api;, 'audit', 'authenticator', 'controllerManager', 'scheduler' ]`"
         },
         "lineNumber": 12,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-131",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-131",
         "path": [
           "resource",
           "aws_eks_cluster[denied_3]",
@@ -24266,7 +24266,7 @@
           "resolve": "Set `enabled_cluster_log_types` attribute to `['api;, 'audit', 'authenticator', 'controllerManager', 'scheduler' ]`"
         },
         "lineNumber": 6,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-131",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-131",
         "path": [
           "resource",
           "aws_eks_cluster[denied_2]",
@@ -24298,7 +24298,7 @@
           "resolve": "Set the `encryption_config` object with the relevant `provider` & `resources`."
         },
         "lineNumber": 12,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-107",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-107",
         "path": [
           "resource",
           "aws_eks_cluster[denied_3]",
@@ -24330,7 +24330,7 @@
           "resolve": "Set the `encryption_config` object with the relevant `provider` & `resources`."
         },
         "lineNumber": 6,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-107",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-107",
         "path": [
           "resource",
           "aws_eks_cluster[denied_2]",
@@ -24388,7 +24388,7 @@
           "resolve": "Set `tracing_config.mode` attribute to `Active` or `PassThrough`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-133",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-133",
         "path": [
           "resource",
           "aws_lambda_function[allowed_2]",
@@ -24419,7 +24419,7 @@
           "resolve": "Set `tracing_config.mode` attribute to `Active` or `PassThrough`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-133",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-133",
         "path": [
           "resource",
           "aws_lambda_function[allowed]",
@@ -24477,7 +24477,7 @@
           "resolve": "Remove secret value from `environment` definition"
         },
         "lineNumber": 26,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-122",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-122",
         "path": [
           "resource",
           "aws_lambda_function[denied_4]",
@@ -24509,7 +24509,7 @@
           "resolve": "Set `tracing_config.mode` attribute to `Active` or `PassThrough`"
         },
         "lineNumber": 9,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-133",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-133",
         "path": [
           "resource",
           "aws_lambda_function[denied_2]",
@@ -24540,7 +24540,7 @@
           "resolve": "Remove secret value from `environment` definition"
         },
         "lineNumber": 43,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-122",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-122",
         "path": [
           "resource",
           "aws_lambda_function[denied_6]",
@@ -24572,7 +24572,7 @@
           "resolve": "Set `tracing_config.mode` attribute to `Active` or `PassThrough`"
         },
         "lineNumber": 33,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-133",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-133",
         "path": [
           "resource",
           "aws_lambda_function[denied_5]",
@@ -24603,7 +24603,7 @@
           "resolve": "Remove secret value from `environment` definition"
         },
         "lineNumber": 43,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-122",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-122",
         "path": [
           "resource",
           "aws_lambda_function[denied_6]",
@@ -24635,7 +24635,7 @@
           "resolve": "Remove secret value from `environment` definition"
         },
         "lineNumber": 18,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-122",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-122",
         "path": [
           "resource",
           "aws_lambda_function[denied_3]",
@@ -24667,7 +24667,7 @@
           "resolve": "Set `tracing_config.mode` attribute to `Active` or `PassThrough`"
         },
         "lineNumber": 42,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-133",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-133",
         "path": [
           "resource",
           "aws_lambda_function[denied_6]",
@@ -24698,7 +24698,7 @@
           "resolve": "Remove secret value from `environment` definition"
         },
         "lineNumber": 10,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-122",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-122",
         "path": [
           "resource",
           "aws_lambda_function[denied_2]",
@@ -24730,7 +24730,7 @@
           "resolve": "Set `tracing_config.mode` attribute to `Active` or `PassThrough`"
         },
         "lineNumber": 17,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-133",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-133",
         "path": [
           "resource",
           "aws_lambda_function[denied_3]",
@@ -24761,7 +24761,7 @@
           "resolve": "Set `tracing_config.mode` attribute to `Active` or `PassThrough`"
         },
         "lineNumber": 25,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-133",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-133",
         "path": [
           "resource",
           "aws_lambda_function[denied_4]",
@@ -24792,7 +24792,7 @@
           "resolve": "Set `tracing_config.mode` attribute to `Active` or `PassThrough`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-133",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-133",
         "path": [
           "resource",
           "aws_lambda_function[denied]",
@@ -24823,7 +24823,7 @@
           "resolve": "Remove secret value from `environment` definition"
         },
         "lineNumber": 34,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-122",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-122",
         "path": [
           "resource",
           "aws_lambda_function[denied_5]",
@@ -24855,7 +24855,7 @@
           "resolve": "Remove secret value from `environment` definition"
         },
         "lineNumber": 2,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-122",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-122",
         "path": [
           "resource",
           "aws_lambda_function[denied]",
@@ -24914,7 +24914,7 @@
           "resolve": "Set `logging_config` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-142",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-142",
         "path": [
           "resource",
           "aws_cloudfront_distribution[denied]",
@@ -24946,7 +24946,7 @@
           "resolve": "Set `web_acl_id` attribute to existing AWS WAF acl ARN"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-75",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-75",
         "path": [
           "resource",
           "aws_cloudfront_distribution[denied]",
@@ -25004,7 +25004,7 @@
           "resolve": "Set `logging_config` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-142",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-142",
         "path": [
           "resource",
           "aws_cloudfront_distribution[allowed]",
@@ -25062,7 +25062,7 @@
           "resolve": "Set `logging_config` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-142",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-142",
         "path": [
           "resource",
           "aws_cloudfront_distribution[cloudfront]",
@@ -25094,7 +25094,7 @@
           "resolve": "Set `web_acl_id` attribute to existing AWS WAF acl ARN"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-75",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-75",
         "path": [
           "resource",
           "aws_cloudfront_distribution[cloudfront]",
@@ -25153,7 +25153,7 @@
           "resolve": "Set `default_cache_behavior.viewer_protocol_policy` attribute to `redirect-to-https` or `https-only`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-57",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-57",
         "path": [
           "resource",
           "aws_cloudfront_distribution[cloudfront]",
@@ -25185,7 +25185,7 @@
           "resolve": "Set `logging_config` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-142",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-142",
         "path": [
           "resource",
           "aws_cloudfront_distribution[cloudfront]",
@@ -25217,7 +25217,7 @@
           "resolve": "Set `web_acl_id` attribute to existing AWS WAF acl ARN"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-75",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-75",
         "path": [
           "resource",
           "aws_cloudfront_distribution[cloudfront]",
@@ -25276,7 +25276,7 @@
           "resolve": "Set `viewer_certificate.minimum_protocol_version` attribute to `TLSv1.2_2019`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-58",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-58",
         "path": [
           "resource",
           "aws_cloudfront_distribution[cloudfront]",
@@ -25308,7 +25308,7 @@
           "resolve": "Set `logging_config` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-142",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-142",
         "path": [
           "resource",
           "aws_cloudfront_distribution[cloudfront]",
@@ -25340,7 +25340,7 @@
           "resolve": "Set `web_acl_id` attribute to existing AWS WAF acl ARN"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-75",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-75",
         "path": [
           "resource",
           "aws_cloudfront_distribution[cloudfront]",
@@ -25398,7 +25398,7 @@
           "resolve": "Set `logging_config` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-142",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-142",
         "path": [
           "resource",
           "aws_cloudfront_distribution[default]",
@@ -25430,7 +25430,7 @@
           "resolve": "Set `web_acl_id` attribute to existing AWS WAF acl ARN"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-75",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-75",
         "path": [
           "resource",
           "aws_cloudfront_distribution[default]",
@@ -25462,7 +25462,7 @@
           "resolve": "Set `web_acl_id` attribute to existing AWS WAF acl ARN"
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-75",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-75",
         "path": [
           "resource",
           "aws_cloudfront_distribution[tls]",
@@ -25493,7 +25493,7 @@
           "resolve": "Set `logging_config` attribute"
         },
         "lineNumber": 15,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-142",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-142",
         "path": [
           "resource",
           "aws_cloudfront_distribution[required]",
@@ -25525,7 +25525,7 @@
           "resolve": "Set `web_acl_id` attribute to existing AWS WAF acl ARN"
         },
         "lineNumber": 15,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-75",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-75",
         "path": [
           "resource",
           "aws_cloudfront_distribution[required]",
@@ -25556,7 +25556,7 @@
           "resolve": "Set `logging_config` attribute"
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-142",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-142",
         "path": [
           "resource",
           "aws_cloudfront_distribution[tls]",
@@ -25615,7 +25615,7 @@
           "resolve": "Set `encryption_configuration.kms_key` attribute to customer managed KMS key"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-418",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-418",
         "path": [
           "resource",
           "aws_ecr_repository[allowed]",
@@ -25646,7 +25646,7 @@
           "resolve": "Set `image_tag_mutability` attribute to `IMMUTABLE`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-126",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-126",
         "path": [
           "resource",
           "aws_ecr_repository[allowed]",
@@ -25730,7 +25730,7 @@
           "resolve": "Remove secret value from `environment` map"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-52",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-52",
         "path": [
           "resource",
           "aws_ecs_task_definition[service]",
@@ -25789,7 +25789,7 @@
           "resolve": "Set `transit_encryption_enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-214",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-214",
         "path": [
           "resource",
           "aws_elasticache_replication_group[allowed]",
@@ -25848,7 +25848,7 @@
           "resolve": "Set `at_rest_encryption_enabled` attribute to `true`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-71",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-71",
         "path": [
           "resource",
           "aws_elasticache_replication_group[denied_2]",
@@ -25879,7 +25879,7 @@
           "resolve": "Set `transit_encryption_enabled` attribute to `true`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-214",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-214",
         "path": [
           "resource",
           "aws_elasticache_replication_group[denied_2]",
@@ -25910,7 +25910,7 @@
           "resolve": "Set `transit_encryption_enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-214",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-214",
         "path": [
           "resource",
           "aws_elasticache_replication_group[denied]",
@@ -25942,7 +25942,7 @@
           "resolve": "Set `at_rest_encryption_enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-71",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-71",
         "path": [
           "resource",
           "aws_elasticache_replication_group[denied]",
@@ -26000,7 +26000,7 @@
           "resolve": "Set `node_to_node_encryption.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-66",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-66",
         "path": [
           "resource",
           "aws_elasticsearch_domain[allowed]",
@@ -26033,7 +26033,7 @@
           "resolve": "Set `domain_endpoint_options.tls_security_policy` attribute to `Policy-Min-TLS-1-2-2019-07`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-68",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-68",
         "path": [
           "resource",
           "aws_elasticsearch_domain[allowed]",
@@ -26065,7 +26065,7 @@
           "resolve": "Set `log_publishing_options` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-140",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-140",
         "path": [
           "resource",
           "aws_elasticsearch_domain[allowed]"
@@ -26096,7 +26096,7 @@
           "resolve": "Set `encrypt_at_rest.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-64",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-64",
         "path": [
           "resource",
           "aws_elasticsearch_domain[allowed]",
@@ -26127,7 +26127,7 @@
           "resolve": "Set `domain_endpoint_options.enforce_https` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-67",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-67",
         "path": [
           "resource",
           "aws_elasticsearch_domain[allowed]",
@@ -26186,7 +26186,7 @@
           "resolve": "Set `node_to_node_encryption.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-66",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-66",
         "path": [
           "resource",
           "aws_elasticsearch_domain[allowed]",
@@ -26219,7 +26219,7 @@
           "resolve": "Set `domain_endpoint_options.tls_security_policy` attribute to `Policy-Min-TLS-1-2-2019-07`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-68",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-68",
         "path": [
           "resource",
           "aws_elasticsearch_domain[allowed]",
@@ -26251,7 +26251,7 @@
           "resolve": "Set `log_publishing_options` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-140",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-140",
         "path": [
           "resource",
           "aws_elasticsearch_domain[allowed]"
@@ -26281,7 +26281,7 @@
           "resolve": "Set `domain_endpoint_options.enforce_https` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-67",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-67",
         "path": [
           "resource",
           "aws_elasticsearch_domain[allowed]",
@@ -26340,7 +26340,7 @@
           "resolve": "Set `node_to_node_encryption.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-66",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-66",
         "path": [
           "resource",
           "aws_elasticsearch_domain[allowed]",
@@ -26373,7 +26373,7 @@
           "resolve": "Set `domain_endpoint_options.tls_security_policy` attribute to `Policy-Min-TLS-1-2-2019-07`"
         },
         "lineNumber": 2,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-68",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-68",
         "path": [
           "resource",
           "aws_elasticsearch_domain[allowed]",
@@ -26405,7 +26405,7 @@
           "resolve": "Set `log_publishing_options` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-140",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-140",
         "path": [
           "resource",
           "aws_elasticsearch_domain[allowed]"
@@ -26436,7 +26436,7 @@
           "resolve": "Set `cluster_config.instance_type` attribute to supported instance type e.g. `c5.large.elasticsearch`, and set `encrypt_at_rest.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-65",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-65",
         "path": [
           "resource",
           "aws_elasticsearch_domain[allowed]",
@@ -26495,7 +26495,7 @@
           "resolve": "Set `log_publishing_options` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-140",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-140",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied]"
@@ -26525,7 +26525,7 @@
           "resolve": "Set `log_publishing_options` attribute"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-140",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-140",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied_2]"
@@ -26556,7 +26556,7 @@
           "resolve": "Set `cluster_config.instance_type` attribute to supported instance type e.g. `c5.large.elasticsearch`, and set `encrypt_at_rest.enabled` attribute to `true`"
         },
         "lineNumber": 6,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-65",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-65",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied_2]",
@@ -26590,7 +26590,7 @@
           "resolve": "Set `domain_endpoint_options.tls_security_policy` attribute to `Policy-Min-TLS-1-2-2019-07`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-68",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-68",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied_2]",
@@ -26622,7 +26622,7 @@
           "resolve": "Set `node_to_node_encryption.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-66",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-66",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied]",
@@ -26653,7 +26653,7 @@
           "resolve": "Set `domain_endpoint_options.enforce_https` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-67",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-67",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied]",
@@ -26685,7 +26685,7 @@
           "resolve": "Set `node_to_node_encryption.enabled` attribute to `true`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-66",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-66",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied_2]",
@@ -26717,7 +26717,7 @@
           "resolve": "Set `cluster_config.instance_type` attribute to supported instance type e.g. `c5.large.elasticsearch`, and set `encrypt_at_rest.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-65",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-65",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied]",
@@ -26749,7 +26749,7 @@
           "resolve": "Set `domain_endpoint_options.enforce_https` attribute to `true`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-67",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-67",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied_2]",
@@ -26783,7 +26783,7 @@
           "resolve": "Set `domain_endpoint_options.tls_security_policy` attribute to `Policy-Min-TLS-1-2-2019-07`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-68",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-68",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied]",
@@ -26844,7 +26844,7 @@
           "resolve": "Set `domain_endpoint_options.tls_security_policy` attribute to `Policy-Min-TLS-1-2-2019-07`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-68",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-68",
         "path": [
           "resource",
           "aws_elasticsearch_domain[allowed]",
@@ -26876,7 +26876,7 @@
           "resolve": "Set `log_publishing_options` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-140",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-140",
         "path": [
           "resource",
           "aws_elasticsearch_domain[allowed]"
@@ -26906,7 +26906,7 @@
           "resolve": "Set `domain_endpoint_options.enforce_https` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-67",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-67",
         "path": [
           "resource",
           "aws_elasticsearch_domain[allowed]",
@@ -26939,7 +26939,7 @@
           "resolve": "Set `cluster_config.instance_type` attribute to supported instance type e.g. `c5.large.elasticsearch`, and set `encrypt_at_rest.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-65",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-65",
         "path": [
           "resource",
           "aws_elasticsearch_domain[allowed]",
@@ -26998,7 +26998,7 @@
           "resolve": "Set `log_publishing_options` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-140",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-140",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied]"
@@ -27028,7 +27028,7 @@
           "resolve": "Set `log_publishing_options` attribute"
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-140",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-140",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied_2]"
@@ -27059,7 +27059,7 @@
           "resolve": "Set `encrypt_at_rest.enabled` attribute to `true`"
         },
         "lineNumber": 12,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-64",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-64",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied_2]",
@@ -27092,7 +27092,7 @@
           "resolve": "Set `domain_endpoint_options.tls_security_policy` attribute to `Policy-Min-TLS-1-2-2019-07`"
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-68",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-68",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied_2]",
@@ -27124,7 +27124,7 @@
           "resolve": "Set `node_to_node_encryption.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-66",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-66",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied]",
@@ -27155,7 +27155,7 @@
           "resolve": "Set `domain_endpoint_options.enforce_https` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-67",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-67",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied]",
@@ -27188,7 +27188,7 @@
           "resolve": "Set `encrypt_at_rest.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-64",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-64",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied]",
@@ -27219,7 +27219,7 @@
           "resolve": "Set `node_to_node_encryption.enabled` attribute to `true`"
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-66",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-66",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied_2]",
@@ -27250,7 +27250,7 @@
           "resolve": "Set `domain_endpoint_options.enforce_https` attribute to `true`"
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-67",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-67",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied_2]",
@@ -27284,7 +27284,7 @@
           "resolve": "Set `domain_endpoint_options.tls_security_policy` attribute to `Policy-Min-TLS-1-2-2019-07`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-68",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-68",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied]",
@@ -27343,7 +27343,7 @@
           "resolve": "Set `log_publishing_options` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-140",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-140",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied]"
@@ -27373,7 +27373,7 @@
           "resolve": "Set `log_publishing_options` attribute"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-140",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-140",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied_2]"
@@ -27404,7 +27404,7 @@
           "resolve": "Set `cluster_config.instance_type` attribute to supported instance type e.g. `c5.large.elasticsearch`, and set `encrypt_at_rest.enabled` attribute to `true`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-65",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-65",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied_2]",
@@ -27438,7 +27438,7 @@
           "resolve": "Set `domain_endpoint_options.tls_security_policy` attribute to `Policy-Min-TLS-1-2-2019-07`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-68",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-68",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied_2]",
@@ -27470,7 +27470,7 @@
           "resolve": "Set `node_to_node_encryption.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-66",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-66",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied]",
@@ -27501,7 +27501,7 @@
           "resolve": "Set `domain_endpoint_options.enforce_https` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-67",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-67",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied]",
@@ -27533,7 +27533,7 @@
           "resolve": "Set `node_to_node_encryption.enabled` attribute to `true`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-66",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-66",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied_2]",
@@ -27565,7 +27565,7 @@
           "resolve": "Set `cluster_config.instance_type` attribute to supported instance type e.g. `c5.large.elasticsearch`, and set `encrypt_at_rest.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-65",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-65",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied]",
@@ -27597,7 +27597,7 @@
           "resolve": "Set `domain_endpoint_options.enforce_https` attribute to `true`"
         },
         "lineNumber": 6,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-67",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-67",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied_2]",
@@ -27631,7 +27631,7 @@
           "resolve": "Set `domain_endpoint_options.tls_security_policy` attribute to `Policy-Min-TLS-1-2-2019-07`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-68",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-68",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied]",
@@ -27690,7 +27690,7 @@
           "resolve": "Set `log_publishing_options` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-140",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-140",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied]"
@@ -27720,7 +27720,7 @@
           "resolve": "Set `log_publishing_options` attribute"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-140",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-140",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied_2]"
@@ -27751,7 +27751,7 @@
           "resolve": "Set `cluster_config.instance_type` attribute to supported instance type e.g. `c5.large.elasticsearch`, and set `encrypt_at_rest.enabled` attribute to `true`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-65",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-65",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied_2]",
@@ -27785,7 +27785,7 @@
           "resolve": "Set `domain_endpoint_options.tls_security_policy` attribute to `Policy-Min-TLS-1-2-2019-07`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-68",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-68",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied_2]",
@@ -27817,7 +27817,7 @@
           "resolve": "Set `node_to_node_encryption.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-66",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-66",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied]",
@@ -27848,7 +27848,7 @@
           "resolve": "Set `domain_endpoint_options.enforce_https` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-67",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-67",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied]",
@@ -27880,7 +27880,7 @@
           "resolve": "Set `node_to_node_encryption.enabled` attribute to `true`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-66",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-66",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied_2]",
@@ -27912,7 +27912,7 @@
           "resolve": "Set `cluster_config.instance_type` attribute to supported instance type e.g. `c5.large.elasticsearch`, and set `encrypt_at_rest.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-65",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-65",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied]",
@@ -27944,7 +27944,7 @@
           "resolve": "Set `domain_endpoint_options.enforce_https` attribute to `true`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-67",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-67",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied_2]",
@@ -27978,7 +27978,7 @@
           "resolve": "Set `domain_endpoint_options.tls_security_policy` attribute to `Policy-Min-TLS-1-2-2019-07`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-68",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-68",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied]",
@@ -28037,7 +28037,7 @@
           "resolve": "Set `log_publishing_options` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-140",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-140",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied]"
@@ -28067,7 +28067,7 @@
           "resolve": "Set `log_publishing_options` attribute"
         },
         "lineNumber": 8,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-140",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-140",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied_2]"
@@ -28098,7 +28098,7 @@
           "resolve": "Set `cluster_config.instance_type` attribute to supported instance type e.g. `c5.large.elasticsearch`, and set `encrypt_at_rest.enabled` attribute to `true`"
         },
         "lineNumber": 8,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-65",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-65",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied_2]",
@@ -28132,7 +28132,7 @@
           "resolve": "Set `domain_endpoint_options.tls_security_policy` attribute to `Policy-Min-TLS-1-2-2019-07`"
         },
         "lineNumber": 9,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-68",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-68",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied_2]",
@@ -28164,7 +28164,7 @@
           "resolve": "Set `node_to_node_encryption.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-66",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-66",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied]",
@@ -28195,7 +28195,7 @@
           "resolve": "Set `node_to_node_encryption.enabled` attribute to `true`"
         },
         "lineNumber": 8,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-66",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-66",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied_2]",
@@ -28227,7 +28227,7 @@
           "resolve": "Set `cluster_config.instance_type` attribute to supported instance type e.g. `c5.large.elasticsearch`, and set `encrypt_at_rest.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-65",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-65",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied]",
@@ -28261,7 +28261,7 @@
           "resolve": "Set `domain_endpoint_options.tls_security_policy` attribute to `Policy-Min-TLS-1-2-2019-07`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-68",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-68",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied]",
@@ -28320,7 +28320,7 @@
           "resolve": "Set `node_to_node_encryption.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-66",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-66",
         "path": [
           "resource",
           "aws_elasticsearch_domain[allowed]",
@@ -28351,7 +28351,7 @@
           "resolve": "Set `log_publishing_options` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-140",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-140",
         "path": [
           "resource",
           "aws_elasticsearch_domain[allowed]"
@@ -28382,7 +28382,7 @@
           "resolve": "Set `cluster_config.instance_type` attribute to supported instance type e.g. `c5.large.elasticsearch`, and set `encrypt_at_rest.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-65",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-65",
         "path": [
           "resource",
           "aws_elasticsearch_domain[allowed]",
@@ -28469,7 +28469,7 @@
           "resolve": "Set `statement.action` attribute to specific actions e.g. `s3:ListBucket`"
         },
         "lineNumber": 2,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-69",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-69",
         "path": [
           "data",
           "aws_iam_policy_document[denied]",
@@ -28526,7 +28526,7 @@
           "resolve": "Set `metadata_options.http_tokens` attribute to `required`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-130",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-130",
         "path": [
           "resource",
           "aws_instance[unencrypted]",
@@ -28557,7 +28557,7 @@
           "resolve": "Set `disable_api_termination` attribute  with value `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-426",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-426",
         "path": [
           "resource",
           "aws_instance[unencrypted]",
@@ -28591,7 +28591,7 @@
           "resolve": "Set `root_block_device.encrypted` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-53",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-53",
         "path": [
           "resource",
           "aws_instance[unencrypted]",
@@ -28676,7 +28676,7 @@
           "resolve": "Set `encryption_type` attribute to `KMS`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-62",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-62",
         "path": [
           "resource",
           "aws_kinesis_stream[denied]",
@@ -28707,7 +28707,7 @@
           "resolve": "Set `encryption_type` attribute to `KMS`"
         },
         "lineNumber": 6,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-62",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-62",
         "path": [
           "resource",
           "aws_kinesis_stream[denied_2]",
@@ -28768,7 +28768,7 @@
           "resolve": "Set `root_block_device.encrypted` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-53",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-53",
         "path": [
           "resource",
           "aws_launch_configuration[unencrypted]",
@@ -28827,7 +28827,7 @@
           "resolve": "Set at least one of available `logging_info.broker_logs` attributes to `enabled`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-139",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-139",
         "path": [
           "resource",
           "aws_msk_cluster[client_both]",
@@ -28858,7 +28858,7 @@
           "resolve": "Set `encryption_info.encryption_in_transit.client_broker` attribute to `TLS`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-59",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-59",
         "path": [
           "resource",
           "aws_msk_cluster[client_both]",
@@ -28918,7 +28918,7 @@
           "resolve": "Set at least one of available `logging_info.broker_logs` attributes to `enabled`"
         },
         "lineNumber": 9,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-139",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-139",
         "path": [
           "resource",
           "aws_msk_cluster[in_cluster]",
@@ -28949,7 +28949,7 @@
           "resolve": "Set at least one of available `logging_info.broker_logs` attributes to `enabled`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-139",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-139",
         "path": [
           "resource",
           "aws_msk_cluster[client_plaintext]",
@@ -28980,7 +28980,7 @@
           "resolve": "Set `encryption_info.encryption_in_transit.client_broker` attribute to `TLS`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-59",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-59",
         "path": [
           "resource",
           "aws_msk_cluster[client_plaintext]",
@@ -29013,7 +29013,7 @@
           "resolve": "Set `encryption_info.encryption_in_transit.in_cluster` attribute to `true`"
         },
         "lineNumber": 12,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-60",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-60",
         "path": [
           "resource",
           "aws_msk_cluster[in_cluster]",
@@ -29073,7 +29073,7 @@
           "resolve": "Set at least one of available `logging_info.broker_logs` attributes to `enabled`"
         },
         "lineNumber": 17,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-139",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-139",
         "path": [
           "resource",
           "aws_msk_cluster[in_cluster]",
@@ -29104,7 +29104,7 @@
           "resolve": "Set at least one of available `logging_info.broker_logs` attributes to `enabled`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-139",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-139",
         "path": [
           "resource",
           "aws_msk_cluster[client_tls]",
@@ -29135,7 +29135,7 @@
           "resolve": "Set at least one of available `logging_info.broker_logs` attributes to `enabled`"
         },
         "lineNumber": 12,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-139",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-139",
         "path": [
           "resource",
           "aws_msk_cluster[tls]",
@@ -29166,7 +29166,7 @@
           "resolve": "Set at least one of available `logging_info.broker_logs` attributes to `enabled`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-139",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-139",
         "path": [
           "resource",
           "aws_msk_cluster[default]",
@@ -29224,7 +29224,7 @@
           "resolve": "Set `image_scanning_configuration.scan_on_push` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-61",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-61",
         "path": [
           "resource",
           "aws_ecr_repository[denied]",
@@ -29256,7 +29256,7 @@
           "resolve": "Set `encryption_configuration.kms_key` attribute to customer managed KMS key"
         },
         "lineNumber": 6,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-418",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-418",
         "path": [
           "resource",
           "aws_ecr_repository[denied_2]",
@@ -29287,7 +29287,7 @@
           "resolve": "Set `image_tag_mutability` attribute to `IMMUTABLE`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-126",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-126",
         "path": [
           "resource",
           "aws_ecr_repository[denied]",
@@ -29318,7 +29318,7 @@
           "resolve": "Set `image_scanning_configuration.scan_on_push` attribute to `true`"
         },
         "lineNumber": 10,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-61",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-61",
         "path": [
           "resource",
           "aws_ecr_repository[denied_2]",
@@ -29350,7 +29350,7 @@
           "resolve": "Set `encryption_configuration.kms_key` attribute to customer managed KMS key"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-418",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-418",
         "path": [
           "resource",
           "aws_ecr_repository[denied]",
@@ -29381,7 +29381,7 @@
           "resolve": "Set `image_tag_mutability` attribute to `IMMUTABLE`"
         },
         "lineNumber": 8,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-126",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-126",
         "path": [
           "resource",
           "aws_ecr_repository[denied_2]",
@@ -29442,7 +29442,7 @@
           "resolve": "Set `root_block_device.encrypted` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-53",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-53",
         "path": [
           "resource",
           "aws_instance[private]",
@@ -29477,7 +29477,7 @@
           "resolve": "Set `root_block_device.encrypted` attribute to `true`"
         },
         "lineNumber": 11,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-53",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-53",
         "path": [
           "resource",
           "aws_launch_configuration[private]",
@@ -29508,7 +29508,7 @@
           "resolve": "Set `metadata_options.http_tokens` attribute to `required`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-130",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-130",
         "path": [
           "resource",
           "aws_instance[private]",
@@ -29539,7 +29539,7 @@
           "resolve": "Set `disable_api_termination` attribute  with value `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-426",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-426",
         "path": [
           "resource",
           "aws_instance[private]",
@@ -29573,7 +29573,7 @@
           "resolve": "Set `root_block_device.encrypted` attribute to `true`"
         },
         "lineNumber": 28,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-53",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-53",
         "path": [
           "resource",
           "aws_spot_fleet_request[private]",
@@ -29636,7 +29636,7 @@
           "resolve": "Set `root_block_device.encrypted` attribute to `true`"
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-53",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-53",
         "path": [
           "resource",
           "aws_spot_instance_request[unencrypted]",
@@ -29718,7 +29718,7 @@
           "resolve": "Set access credentials via environment variables, and remove `access_key` and `secret_key` attributes from the configuration"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-74",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-74",
         "path": [
           "provider[aws]"
         ]
@@ -29772,7 +29772,7 @@
           "resolve": "Set `publicly_accessible` attribute to `false`"
         },
         "lineNumber": 2,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-50",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-50",
         "path": [
           "resource",
           "aws_db_instance[db]",
@@ -29801,7 +29801,7 @@
           "resolve": "Set `publicly_accessible` attribute to `false`"
         },
         "lineNumber": 68,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-50",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-50",
         "path": [
           "resource",
           "aws_neptune_cluster_instance[neptune]",
@@ -29830,7 +29830,7 @@
           "resolve": "Set `publicly_accessible` attribute to `false`"
         },
         "lineNumber": 39,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-50",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-50",
         "path": [
           "resource",
           "aws_docdb_cluster_instance[docdb]",
@@ -29861,7 +29861,7 @@
           "resolve": "Set `storage_encrypted` attribute to true"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-201",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-201",
         "path": [
           "resource",
           "aws_db_instance[db]",
@@ -29890,7 +29890,7 @@
           "resolve": "Set `publicly_accessible` attribute to `false`"
         },
         "lineNumber": 82,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-50",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-50",
         "path": [
           "resource",
           "aws_rds_cluster_instance[rds]",
@@ -29921,7 +29921,7 @@
           "resolve": "Set `logging.enabled` attribute to `true`"
         },
         "lineNumber": 85,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-136",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-136",
         "path": [
           "resource",
           "aws_redshift_cluster[redshift]",
@@ -29952,7 +29952,7 @@
           "resolve": "Set `logs.general` attribute to `true`"
         },
         "lineNumber": 45,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-132",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-132",
         "path": [
           "resource",
           "aws_mq_broker[mq]",
@@ -29981,7 +29981,7 @@
           "resolve": "Set `publicly_accessible` attribute to `false`"
         },
         "lineNumber": 58,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-50",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-50",
         "path": [
           "resource",
           "aws_mq_broker[mq]",
@@ -30012,7 +30012,7 @@
           "resolve": "Set `iam_database_authentication_enabled` to `true`."
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-414",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-414",
         "path": [
           "resource",
           "aws_db_instance[db]",
@@ -30044,7 +30044,7 @@
           "resolve": "Set `encrypted` attribute to `true`."
         },
         "lineNumber": 85,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-108",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-108",
         "path": [
           "resource",
           "aws_redshift_cluster[redshift]",
@@ -30073,7 +30073,7 @@
           "resolve": "Set `publicly_accessible` attribute to `false`"
         },
         "lineNumber": 23,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-50",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-50",
         "path": [
           "resource",
           "aws_dms_replication_instance[db]",
@@ -30102,7 +30102,7 @@
           "resolve": "Set `publicly_accessible` attribute to `false`"
         },
         "lineNumber": 92,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-50",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-50",
         "path": [
           "resource",
           "aws_redshift_cluster[redshift]",
@@ -30160,7 +30160,7 @@
           "resolve": "Set `iam_database_authentication_enabled` to `true`."
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-414",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-414",
         "path": [
           "resource",
           "aws_db_instance[db]",
@@ -30192,7 +30192,7 @@
           "resolve": "Set `encrypted` attribute to `true`."
         },
         "lineNumber": 80,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-108",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-108",
         "path": [
           "resource",
           "aws_redshift_cluster[redshift]",
@@ -30223,7 +30223,7 @@
           "resolve": "Set `storage_encrypted` attribute to true"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-201",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-201",
         "path": [
           "resource",
           "aws_db_instance[db]",
@@ -30254,7 +30254,7 @@
           "resolve": "Set `logging.enabled` attribute to `true`"
         },
         "lineNumber": 80,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-136",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-136",
         "path": [
           "resource",
           "aws_redshift_cluster[redshift]",
@@ -30285,7 +30285,7 @@
           "resolve": "Set `logs.general` attribute to `true`"
         },
         "lineNumber": 43,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-132",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-132",
         "path": [
           "resource",
           "aws_mq_broker[mq]",
@@ -30340,7 +30340,7 @@
           "resolve": "Set `associate_public_ip_address` attribute to `false`"
         },
         "lineNumber": 15,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-51",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-51",
         "path": [
           "resource",
           "aws_launch_configuration[public]",
@@ -30368,7 +30368,7 @@
           "resolve": "Set `associate_public_ip_address` attribute to `false`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-51",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-51",
         "path": [
           "resource",
           "aws_instance[public]",
@@ -30396,7 +30396,7 @@
           "resolve": "Set `associate_public_ip_address` attribute to `false`"
         },
         "lineNumber": 30,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-51",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-51",
         "path": [
           "resource",
           "aws_spot_fleet_request[public]",
@@ -30431,7 +30431,7 @@
           "resolve": "Set `root_block_device.encrypted` attribute to `true`"
         },
         "lineNumber": 11,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-53",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-53",
         "path": [
           "resource",
           "aws_launch_configuration[public]",
@@ -30466,7 +30466,7 @@
           "resolve": "Set `root_block_device.encrypted` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-53",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-53",
         "path": [
           "resource",
           "aws_instance[public]",
@@ -30501,7 +30501,7 @@
           "resolve": "Set `root_block_device.encrypted` attribute to `true`"
         },
         "lineNumber": 29,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-53",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-53",
         "path": [
           "resource",
           "aws_spot_fleet_request[public]",
@@ -30533,7 +30533,7 @@
           "resolve": "Set `metadata_options.http_tokens` attribute to `required`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-130",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-130",
         "path": [
           "resource",
           "aws_instance[public]",
@@ -30564,7 +30564,7 @@
           "resolve": "Set `disable_api_termination` attribute  with value `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-426",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-426",
         "path": [
           "resource",
           "aws_instance[public]",
@@ -30592,7 +30592,7 @@
           "resolve": "Set `associate_public_ip_address` attribute to `false`"
         },
         "lineNumber": 22,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-51",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-51",
         "path": [
           "resource",
           "aws_launch_template[public]",
@@ -30650,7 +30650,7 @@
           "resolve": "Set `metadata_options.http_tokens` attribute to `required`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-130",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-130",
         "path": [
           "resource",
           "aws_instance[encrypted]",
@@ -30681,7 +30681,7 @@
           "resolve": "Set `disable_api_termination` attribute  with value `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-426",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-426",
         "path": [
           "resource",
           "aws_instance[encrypted]",
@@ -30761,7 +30761,7 @@
           "resolve": "Set `description` attribute to meaningful statement"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-56",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-56",
         "path": [
           "resource",
           "aws_security_group[sg]",
@@ -30872,7 +30872,7 @@
           "resolve": "Set `kms_master_key_id` attribute to a customer managed key id"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-422",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-422",
         "path": [
           "resource",
           "aws_sns_topic[sns]",
@@ -30903,7 +30903,7 @@
           "resolve": "Set `kms_master_key_id` attribute to KMS key"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-55",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-55",
         "path": [
           "resource",
           "aws_sns_topic[sns]",
@@ -30990,7 +30990,7 @@
           "resolve": "Set `root_block_device.encrypted` attribute to `true`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-53",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-53",
         "path": [
           "resource",
           "aws_spot_fleet_request[unencrypted]",
@@ -31050,7 +31050,7 @@
           "resolve": "Set `kms_master_key_id` attribute to KMS key"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-54",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-54",
         "path": [
           "resource",
           "aws_sqs_queue[sqs]",
@@ -31160,7 +31160,7 @@
           "resolve": "Set `Action` in policy heredoc to specific actions e.g. `sqs:SendMessage`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-70",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-70",
         "path": [
           "resource",
           "aws_sqs_queue_policy[denied]",
@@ -31218,7 +31218,7 @@
           "resolve": "Set `access_log_settings` attribute"
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-138",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-138",
         "path": [
           "resource",
           "aws_api_gateway_stage[denied]",
@@ -31249,7 +31249,7 @@
           "resolve": "Set `access_log_settings` attribute"
         },
         "lineNumber": 16,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-138",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-138",
         "path": [
           "resource",
           "aws_apigatewayv2_stage[denied]",
@@ -31304,7 +31304,7 @@
           "resolve": "Migrate the resource to VPC mode"
         },
         "lineNumber": 9,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-46",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-46",
         "path": [
           "input",
           "resource",
@@ -31332,7 +31332,7 @@
           "resolve": "Migrate the resource to VPC mode"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-46",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-46",
         "path": [
           "input",
           "resource",
@@ -31360,7 +31360,7 @@
           "resolve": "Migrate the resource to VPC mode"
         },
         "lineNumber": 17,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-46",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-46",
         "path": [
           "input",
           "resource",
@@ -31418,7 +31418,7 @@
           "resolve": "Set `logging_config` attribute"
         },
         "lineNumber": 6,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-142",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-142",
         "path": [
           "resource",
           "aws_cloudfront_distribution[denied]",
@@ -31476,7 +31476,7 @@
           "resolve": "Set `is_multi_region_trail` attribute to `true`"
         },
         "lineNumber": 8,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-135",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-135",
         "path": [
           "resource",
           "aws_cloudtrail[denied]",
@@ -31507,7 +31507,7 @@
           "resolve": "Set `is_multi_region_trail` attribute to `true`"
         },
         "lineNumber": 16,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-135",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-135",
         "path": [
           "resource",
           "aws_cloudtrail[denied_2]",
@@ -31565,7 +31565,7 @@
           "resolve": "Set `cloud_watch_logs_group_arn` attribute to cloudwatch log group ARN"
         },
         "lineNumber": 8,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-256",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-256",
         "path": [
           "resource",
           "aws_cloudtrail[denied]",
@@ -31624,7 +31624,7 @@
           "resolve": "Set `kms_key_id` attribute with customer managed key id"
         },
         "lineNumber": 9,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-415",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-415",
         "path": [
           "resource",
           "aws_cloudwatch_log_group[denied]",
@@ -31655,7 +31655,7 @@
           "resolve": "Set `retention_in_days` attribute to required value, e.g. set `365`"
         },
         "lineNumber": 9,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-134",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-134",
         "path": [
           "resource",
           "aws_cloudwatch_log_group[denied]",
@@ -31687,7 +31687,7 @@
           "resolve": "Set `kms_key_id` attribute with customer managed key id"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-415",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-415",
         "path": [
           "resource",
           "aws_cloudwatch_log_group[allowed]",
@@ -31719,7 +31719,7 @@
           "resolve": "Set `kms_key_id` attribute with customer managed key id"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-415",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-415",
         "path": [
           "resource",
           "aws_cloudwatch_log_group[allowed_2]",
@@ -31777,7 +31777,7 @@
           "resolve": "Set `enabled_cloudwatch_logs_exports` attribute to `['profiler', 'audit']`"
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-141",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-141",
         "path": [
           "resource",
           "aws_docdb_cluster[denied]",
@@ -31809,7 +31809,7 @@
           "resolve": "Set `kms_key_id` attribute to customer managed key id"
         },
         "lineNumber": 20,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-416",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-416",
         "path": [
           "resource",
           "aws_docdb_cluster[denied_4]"
@@ -31840,7 +31840,7 @@
           "resolve": "Set `kms_key_id` attribute to customer managed key id"
         },
         "lineNumber": 16,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-416",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-416",
         "path": [
           "resource",
           "aws_docdb_cluster[denied_3]"
@@ -31871,7 +31871,7 @@
           "resolve": "Set `kms_key_id` attribute to customer managed key id"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-416",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-416",
         "path": [
           "resource",
           "aws_docdb_cluster[allowed]"
@@ -31901,7 +31901,7 @@
           "resolve": "Set `enabled_cloudwatch_logs_exports` attribute to `['profiler', 'audit']`"
         },
         "lineNumber": 12,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-141",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-141",
         "path": [
           "resource",
           "aws_docdb_cluster[denied_2]",
@@ -31933,7 +31933,7 @@
           "resolve": "Set `kms_key_id` attribute to customer managed key id"
         },
         "lineNumber": 6,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-416",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-416",
         "path": [
           "resource",
           "aws_docdb_cluster[denied]"
@@ -31963,7 +31963,7 @@
           "resolve": "Set `enabled_cloudwatch_logs_exports` attribute to `['profiler', 'audit']`"
         },
         "lineNumber": 16,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-141",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-141",
         "path": [
           "resource",
           "aws_docdb_cluster[denied_3]",
@@ -31995,7 +31995,7 @@
           "resolve": "Set `kms_key_id` attribute to customer managed key id"
         },
         "lineNumber": 11,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-416",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-416",
         "path": [
           "resource",
           "aws_docdb_cluster[denied_2]"
@@ -32025,7 +32025,7 @@
           "resolve": "Set `enabled_cloudwatch_logs_exports` attribute to `['profiler', 'audit']`"
         },
         "lineNumber": 22,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-141",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-141",
         "path": [
           "resource",
           "aws_docdb_cluster[denied_4]",
@@ -32083,7 +32083,7 @@
           "resolve": "Set `disable_api_termination` attribute  with value `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-426",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-426",
         "path": [
           "resource",
           "aws_instance[denied]",
@@ -32114,7 +32114,7 @@
           "resolve": "Remove secret value from `user_data` attribute"
         },
         "lineNumber": 13,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-123",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-123",
         "path": [
           "resource",
           "aws_instance[denied_2]",
@@ -32145,7 +32145,7 @@
           "resolve": "Set `disable_api_termination` attribute  with value `true`"
         },
         "lineNumber": 25,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-426",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-426",
         "path": [
           "resource",
           "aws_instance[denied_3]",
@@ -32176,7 +32176,7 @@
           "resolve": "Remove secret value from `user_data` attribute"
         },
         "lineNumber": 25,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-123",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-123",
         "path": [
           "resource",
           "aws_instance[denied_3]",
@@ -32207,7 +32207,7 @@
           "resolve": "Set `disable_api_termination` attribute  with value `true`"
         },
         "lineNumber": 61,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-426",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-426",
         "path": [
           "resource",
           "aws_instance[allowed_3]",
@@ -32238,7 +32238,7 @@
           "resolve": "Remove secret value from `user_data` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-123",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-123",
         "path": [
           "resource",
           "aws_instance[denied]",
@@ -32269,7 +32269,7 @@
           "resolve": "Remove secret value from `user_data` attribute"
         },
         "lineNumber": 13,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-123",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-123",
         "path": [
           "resource",
           "aws_instance[denied_2]",
@@ -32300,7 +32300,7 @@
           "resolve": "Set `disable_api_termination` attribute  with value `true`"
         },
         "lineNumber": 37,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-426",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-426",
         "path": [
           "resource",
           "aws_instance[allowed]",
@@ -32331,7 +32331,7 @@
           "resolve": "Set `disable_api_termination` attribute  with value `true`"
         },
         "lineNumber": 13,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-426",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-426",
         "path": [
           "resource",
           "aws_instance[denied_2]",
@@ -32362,7 +32362,7 @@
           "resolve": "Set `disable_api_termination` attribute  with value `true`"
         },
         "lineNumber": 49,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-426",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-426",
         "path": [
           "resource",
           "aws_instance[allowed_2]",
@@ -32421,7 +32421,7 @@
           "resolve": "Set `encryption_configuration.kms_key` attribute to customer managed KMS key"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-418",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-418",
         "path": [
           "resource",
           "aws_ecr_repository[allowed]",
@@ -32453,7 +32453,7 @@
           "resolve": "Set `encryption_configuration.kms_key` attribute to customer managed KMS key"
         },
         "lineNumber": 15,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-418",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-418",
         "path": [
           "resource",
           "aws_ecr_repository[denied_2]",
@@ -32485,7 +32485,7 @@
           "resolve": "Set `encryption_configuration.kms_key` attribute to customer managed KMS key"
         },
         "lineNumber": 8,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-418",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-418",
         "path": [
           "resource",
           "aws_ecr_repository[denied]",
@@ -32516,7 +32516,7 @@
           "resolve": "Set `image_tag_mutability` attribute to `IMMUTABLE`"
         },
         "lineNumber": 15,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-126",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-126",
         "path": [
           "resource",
           "aws_ecr_repository[denied_2]",
@@ -32547,7 +32547,7 @@
           "resolve": "Set `image_tag_mutability` attribute to `IMMUTABLE`"
         },
         "lineNumber": 12,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-126",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-126",
         "path": [
           "resource",
           "aws_ecr_repository[denied]",
@@ -32601,7 +32601,7 @@
           "resolve": "Set `enabled_cluster_log_types` attribute to `['api;, 'audit', 'authenticator', 'controllerManager', 'scheduler' ]`"
         },
         "lineNumber": 17,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-131",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-131",
         "path": [
           "resource",
           "aws_eks_cluster[denied]",
@@ -32628,7 +32628,7 @@
           "resolve": "Set `enabled_cluster_log_types` attribute to `['api;, 'audit', 'authenticator', 'controllerManager', 'scheduler' ]`"
         },
         "lineNumber": 38,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-131",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-131",
         "path": [
           "resource",
           "aws_eks_cluster[denied_3]",
@@ -32655,7 +32655,7 @@
           "resolve": "Set `enabled_cluster_log_types` attribute to `['api;, 'audit', 'authenticator', 'controllerManager', 'scheduler' ]`"
         },
         "lineNumber": 29,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-131",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-131",
         "path": [
           "resource",
           "aws_eks_cluster[denied_2]",
@@ -32713,7 +32713,7 @@
           "resolve": "Set `log_publishing_options` attribute"
         },
         "lineNumber": 86,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-140",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-140",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied]"
@@ -32743,7 +32743,7 @@
           "resolve": "Set `log_publishing_options` attribute"
         },
         "lineNumber": 105,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-140",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-140",
         "path": [
           "resource",
           "aws_elasticsearch_domain[denied_2]"
@@ -32796,7 +32796,7 @@
           "resolve": "Set `attributes.flow_logs_enabled` attribute to `true`"
         },
         "lineNumber": 13,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-137",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-137",
         "path": [
           "resource",
           "aws_globalaccelerator_accelerator[denied_2]",
@@ -32824,7 +32824,7 @@
           "resolve": "Set `attributes.flow_logs_enabled` attribute to `true`"
         },
         "lineNumber": 9,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-137",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-137",
         "path": [
           "resource",
           "aws_globalaccelerator_accelerator[denied]",
@@ -32884,7 +32884,7 @@
           "resolve": "Set `Principal` attribute to specific principal, e.g. `arn:aws:iam::1234:role/role-name`"
         },
         "lineNumber": 112,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-118",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-118",
         "path": [
           "resource",
           "aws_iam_role[denied_4]",
@@ -32916,7 +32916,7 @@
           "resolve": "Set `Principal` attribute to specific service or account, e.g. `Service: ec2.amazonaws.com`"
         },
         "lineNumber": 141,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-117",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-117",
         "path": [
           "data",
           "aws_iam_policy_document[allowed]",
@@ -32948,7 +32948,7 @@
           "resolve": "Set `Principal` attribute to specific principal, e.g. `arn:aws:iam::1234:role/role-name`"
         },
         "lineNumber": 214,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-118",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-118",
         "path": [
           "data",
           "aws_iam_policy_document[denied_4]",
@@ -32980,7 +32980,7 @@
           "resolve": "Set `Principal` attribute to specific principal, e.g. `arn:aws:iam::1234:role/role-name`"
         },
         "lineNumber": 69,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-118",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-118",
         "path": [
           "resource",
           "aws_iam_role[denied_3]",
@@ -33012,7 +33012,7 @@
           "resolve": "Set `Principal` attribute to specific service or account, e.g. `Service: ec2.amazonaws.com`"
         },
         "lineNumber": 153,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-117",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-117",
         "path": [
           "data",
           "aws_iam_policy_document[allowed_2]",
@@ -33044,7 +33044,7 @@
           "resolve": "Set `Principal` attribute to specific service or account, e.g. `Service: ec2.amazonaws.com`"
         },
         "lineNumber": 22,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-117",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-117",
         "path": [
           "resource",
           "aws_iam_role[allowed_2]",
@@ -33076,7 +33076,7 @@
           "resolve": "Set `Principal` attribute to specific principal, e.g. `arn:aws:iam::1234:role/role-name`"
         },
         "lineNumber": 194,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-118",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-118",
         "path": [
           "data",
           "aws_iam_policy_document[denied_2]",
@@ -33108,7 +33108,7 @@
           "resolve": "Set `Principal` attribute to specific principal, e.g. `arn:aws:iam::1234:role/role-name`"
         },
         "lineNumber": 92,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-118",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-118",
         "path": [
           "resource",
           "aws_iam_role[denied_2]",
@@ -33140,7 +33140,7 @@
           "resolve": "Set `Principal` attribute to specific service or account, e.g. `Service: ec2.amazonaws.com`"
         },
         "lineNumber": 173,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-117",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-117",
         "path": [
           "data",
           "aws_iam_policy_document[allowed_3]",
@@ -33172,7 +33172,7 @@
           "resolve": "Set `Principal` attribute to specific service or account, e.g. `Service: ec2.amazonaws.com`"
         },
         "lineNumber": 2,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-117",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-117",
         "path": [
           "resource",
           "aws_iam_role[allowed]",
@@ -33204,7 +33204,7 @@
           "resolve": "Set `Principal` attribute to specific principal, e.g. `arn:aws:iam::1234:role/role-name`"
         },
         "lineNumber": 49,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-118",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-118",
         "path": [
           "resource",
           "aws_iam_role[denied]",
@@ -33236,7 +33236,7 @@
           "resolve": "Set `Principal` attribute to specific principal, e.g. `arn:aws:iam::1234:role/role-name`"
         },
         "lineNumber": 204,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-118",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-118",
         "path": [
           "data",
           "aws_iam_policy_document[denied_3]",
@@ -33268,7 +33268,7 @@
           "resolve": "Set `Principal` attribute to specific principal, e.g. `arn:aws:iam::1234:role/role-name`"
         },
         "lineNumber": 184,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-118",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-118",
         "path": [
           "data",
           "aws_iam_policy_document[denied]",
@@ -33326,7 +33326,7 @@
           "resolve": "Set `tracing_config.mode` attribute to `Active` or `PassThrough`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-133",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-133",
         "path": [
           "resource",
           "aws_lambda_function[denied]",
@@ -33410,7 +33410,7 @@
           "resolve": "Set the `protocol` attribute to `HTTPS` or `TLS`"
         },
         "lineNumber": 14,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-47",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-47",
         "path": [
           "resource",
           "aws_alb_listener[http]",
@@ -33441,7 +33441,7 @@
           "resolve": "Set the `protocol` attribute to `HTTPS` or `TLS`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-47",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-47",
         "path": [
           "resource",
           "aws_lb_listener[http]",
@@ -33499,7 +33499,7 @@
           "resolve": "Set `ssl_policy` attribute to latest AWS predefined security policy"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-49",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-49",
         "path": [
           "resource",
           "aws_lb_listener[insecure]",
@@ -33530,7 +33530,7 @@
           "resolve": "Set `ssl_policy` attribute to latest AWS predefined security policy"
         },
         "lineNumber": 18,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-49",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-49",
         "path": [
           "resource",
           "aws_alb_listener[insecure]",
@@ -33588,7 +33588,7 @@
           "resolve": "Set `internal` attribute to `true`"
         },
         "lineNumber": 44,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-48",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-48",
         "path": [
           "resource",
           "aws_elb[internet]",
@@ -33619,7 +33619,7 @@
           "resolve": "Set `drop_invalid_header_fields` to `true`"
         },
         "lineNumber": 21,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-405",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-405",
         "path": [
           "resource",
           "aws_alb[internet]"
@@ -33649,7 +33649,7 @@
           "resolve": "Set `internal` attribute to `true`"
         },
         "lineNumber": 23,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-48",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-48",
         "path": [
           "resource",
           "aws_alb[internet]",
@@ -33680,7 +33680,7 @@
           "resolve": "Set `drop_invalid_header_fields` to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-405",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-405",
         "path": [
           "resource",
           "aws_lb[internet]"
@@ -33710,7 +33710,7 @@
           "resolve": "Set `internal` attribute to `true`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-48",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-48",
         "path": [
           "resource",
           "aws_lb[internet]",
@@ -33768,7 +33768,7 @@
           "resolve": "Set `drop_invalid_header_fields` to `true`"
         },
         "lineNumber": 21,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-405",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-405",
         "path": [
           "resource",
           "aws_alb[internet]"
@@ -33798,7 +33798,7 @@
           "resolve": "Set `internal` attribute to `true`"
         },
         "lineNumber": 21,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-48",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-48",
         "path": [
           "resource",
           "aws_alb[internet]",
@@ -33829,7 +33829,7 @@
           "resolve": "Set `drop_invalid_header_fields` to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-405",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-AWS-405",
         "path": [
           "resource",
           "aws_lb[internet]"
@@ -33912,7 +33912,7 @@
           "resolve": "Set `logs.general` attribute to `true`"
         },
         "lineNumber": 16,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-132",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-132",
         "path": [
           "resource",
           "aws_mq_broker[denied_3]",
@@ -33943,7 +33943,7 @@
           "resolve": "Set `logs.general` attribute to `true`"
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-132",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-132",
         "path": [
           "resource",
           "aws_mq_broker[denied]",
@@ -33974,7 +33974,7 @@
           "resolve": "Set `logs.general` attribute to `true`"
         },
         "lineNumber": 11,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-132",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-132",
         "path": [
           "resource",
           "aws_mq_broker[denied_2]",
@@ -34032,7 +34032,7 @@
           "resolve": "Set at least one of available `logging_info.broker_logs` attributes to `enabled`"
         },
         "lineNumber": 49,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-139",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-139",
         "path": [
           "resource",
           "aws_msk_cluster[denied_2]",
@@ -34063,7 +34063,7 @@
           "resolve": "Set at least one of available `logging_info.broker_logs` attributes to `enabled`"
         },
         "lineNumber": 44,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-139",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-139",
         "path": [
           "resource",
           "aws_msk_cluster[denied]",
@@ -34094,7 +34094,7 @@
           "resolve": "Set at least one of available `logging_info.broker_logs` attributes to `enabled`"
         },
         "lineNumber": 79,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-139",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-139",
         "path": [
           "resource",
           "aws_msk_cluster[denied_5]",
@@ -34125,7 +34125,7 @@
           "resolve": "Set at least one of available `logging_info.broker_logs` attributes to `enabled`"
         },
         "lineNumber": 69,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-139",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-139",
         "path": [
           "resource",
           "aws_msk_cluster[denied_4]",
@@ -34156,7 +34156,7 @@
           "resolve": "Set at least one of available `logging_info.broker_logs` attributes to `enabled`"
         },
         "lineNumber": 88,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-139",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-139",
         "path": [
           "resource",
           "aws_msk_cluster[denied_6]",
@@ -34187,7 +34187,7 @@
           "resolve": "Set at least one of available `logging_info.broker_logs` attributes to `enabled`"
         },
         "lineNumber": 59,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-139",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-139",
         "path": [
           "resource",
           "aws_msk_cluster[denied_3]",
@@ -34245,7 +34245,7 @@
           "resolve": "Set `logging.enabled` attribute to `true`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-136",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-136",
         "path": [
           "resource",
           "aws_redshift_cluster[allowed]",
@@ -34276,7 +34276,7 @@
           "resolve": "Set `logging.enabled` attribute to `true`"
         },
         "lineNumber": 15,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-136",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-136",
         "path": [
           "resource",
           "aws_redshift_cluster[denied_2]",
@@ -34307,7 +34307,7 @@
           "resolve": "Set `logging.enabled` attribute to `true`"
         },
         "lineNumber": 10,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-136",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-136",
         "path": [
           "resource",
           "aws_redshift_cluster[denied]",
@@ -34387,7 +34387,7 @@
           "resolve": "Set `encryption_state` attribute to `Enabled` or delete the attribute"
         },
         "lineNumber": 2,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-78",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-78",
         "path": [
           "resource",
           "azurerm_data_lake_store[denied]",
@@ -34441,7 +34441,7 @@
           "resolve": "Set `network_profile.network_policy` attribute to `azure` or `calico`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-176",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-176",
         "path": [
           "resource",
           "azurerm_kubernetes_cluster[denied]",
@@ -34469,7 +34469,7 @@
           "resolve": "Set `addon_profile.oms_agent.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-82",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-82",
         "path": [
           "resource",
           "azurerm_kubernetes_cluster[denied]",
@@ -34497,7 +34497,7 @@
           "resolve": "Set `addon_profile.oms_agent.enabled` attribute to `true`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-82",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-82",
         "path": [
           "resource",
           "azurerm_kubernetes_cluster[denied_2]",
@@ -34525,7 +34525,7 @@
           "resolve": "Set `api_server_authorized_ip_ranges` attribute to specific range e.g. 10.0.0.0/16"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-81",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-81",
         "path": [
           "resource",
           "azurerm_kubernetes_cluster[denied_2]",
@@ -34552,7 +34552,7 @@
           "resolve": "Set `api_server_authorized_ip_ranges` attribute to specific range e.g. 10.0.0.0/16"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-81",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-81",
         "path": [
           "resource",
           "azurerm_kubernetes_cluster[denied]",
@@ -34579,7 +34579,7 @@
           "resolve": "Set `network_profile.network_policy` attribute to `azure` or `calico`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-176",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-176",
         "path": [
           "resource",
           "azurerm_kubernetes_cluster[denied_2]",
@@ -34634,7 +34634,7 @@
           "resolve": "Set `network_profile.network_policy` attribute to `azure` or `calico`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-176",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-176",
         "path": [
           "resource",
           "azurerm_kubernetes_cluster[allowed]",
@@ -34662,7 +34662,7 @@
           "resolve": "Set `addon_profile.oms_agent.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-82",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-82",
         "path": [
           "resource",
           "azurerm_kubernetes_cluster[allowed]",
@@ -34717,7 +34717,7 @@
           "resolve": "Set `api_server_authorized_ip_ranges` attribute to specific range e.g. 10.0.0.0/16"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-81",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-81",
         "path": [
           "resource",
           "azurerm_kubernetes_cluster[allowed]",
@@ -34744,7 +34744,7 @@
           "resolve": "Set `network_profile.network_policy` attribute to `azure` or `calico`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-176",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-176",
         "path": [
           "resource",
           "azurerm_kubernetes_cluster[allowed]",
@@ -34799,7 +34799,7 @@
           "resolve": "Set `network_profile.network_policy` attribute to `azure` or `calico`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-176",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-176",
         "path": [
           "resource",
           "azurerm_kubernetes_cluster[denied]",
@@ -34827,7 +34827,7 @@
           "resolve": "Set `addon_profile.oms_agent.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-82",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-82",
         "path": [
           "resource",
           "azurerm_kubernetes_cluster[denied]",
@@ -34855,7 +34855,7 @@
           "resolve": "Set `addon_profile.oms_agent.enabled` attribute to `true`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-82",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-82",
         "path": [
           "resource",
           "azurerm_kubernetes_cluster[denied_2]",
@@ -34883,7 +34883,7 @@
           "resolve": "Set `api_server_authorized_ip_ranges` attribute to specific range e.g. 10.0.0.0/16"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-81",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-81",
         "path": [
           "resource",
           "azurerm_kubernetes_cluster[denied_2]",
@@ -34910,7 +34910,7 @@
           "resolve": "Set `api_server_authorized_ip_ranges` attribute to specific range e.g. 10.0.0.0/16"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-81",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-81",
         "path": [
           "resource",
           "azurerm_kubernetes_cluster[denied]",
@@ -34937,7 +34937,7 @@
           "resolve": "Set `network_profile.network_policy` attribute to `azure` or `calico`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-176",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-176",
         "path": [
           "resource",
           "azurerm_kubernetes_cluster[denied_2]",
@@ -34992,7 +34992,7 @@
           "resolve": "Set `network_profile.network_policy` attribute to `azure` or `calico`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-176",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-176",
         "path": [
           "resource",
           "azurerm_kubernetes_cluster[denied]",
@@ -35020,7 +35020,7 @@
           "resolve": "Set `addon_profile.oms_agent.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-82",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-82",
         "path": [
           "resource",
           "azurerm_kubernetes_cluster[denied]",
@@ -35048,7 +35048,7 @@
           "resolve": "Set `api_server_authorized_ip_ranges` attribute to specific range e.g. 10.0.0.0/16"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-81",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-81",
         "path": [
           "resource",
           "azurerm_kubernetes_cluster[denied]",
@@ -35075,7 +35075,7 @@
           "resolve": "Set `role_based_access_control.enabled` attribute to `true` or remove the attribute"
         },
         "lineNumber": 2,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-80",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-80",
         "path": [
           "resource",
           "azurerm_kubernetes_cluster[denied]",
@@ -35129,7 +35129,7 @@
           "resolve": "Set `api_server_authorized_ip_ranges` attribute to specific range e.g. 10.0.0.0/16"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-81",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-81",
         "path": [
           "resource",
           "azurerm_kubernetes_cluster[allowed]",
@@ -35156,7 +35156,7 @@
           "resolve": "Set `addon_profile.oms_agent.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-82",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-82",
         "path": [
           "resource",
           "azurerm_kubernetes_cluster[allowed_2]",
@@ -35184,7 +35184,7 @@
           "resolve": "Set `network_profile.network_policy` attribute to `azure` or `calico`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-176",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-176",
         "path": [
           "resource",
           "azurerm_kubernetes_cluster[allowed_2]",
@@ -35212,7 +35212,7 @@
           "resolve": "Set `network_profile.network_policy` attribute to `azure` or `calico`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-176",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-176",
         "path": [
           "resource",
           "azurerm_kubernetes_cluster[allowed]",
@@ -35240,7 +35240,7 @@
           "resolve": "Set `addon_profile.oms_agent.enabled` attribute to `true`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-82",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-82",
         "path": [
           "resource",
           "azurerm_kubernetes_cluster[allowed]",
@@ -35268,7 +35268,7 @@
           "resolve": "Set `api_server_authorized_ip_ranges` attribute to specific range e.g. 10.0.0.0/16"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-81",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-81",
         "path": [
           "resource",
           "azurerm_kubernetes_cluster[allowed_2]",
@@ -35349,7 +35349,7 @@
           "resolve": "Set `encryption_settings.enabled` attribute to `true`"
         },
         "lineNumber": 2,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-77",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-77",
         "path": [
           "resource",
           "azurerm_managed_disk[denied]",
@@ -35429,7 +35429,7 @@
           "resolve": "Set `admin_ssh_key` attribute instead of password authentication"
         },
         "lineNumber": 21,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-263",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-263",
         "path": [
           "resource",
           "azurerm_virtual_machine[denied_3]",
@@ -35457,7 +35457,7 @@
           "resolve": "Remove secret value from configuration"
         },
         "lineNumber": 46,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-182",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-182",
         "path": [
           "resource",
           "azurerm_linux_virtual_machine[denied_5]",
@@ -35484,7 +35484,7 @@
           "resolve": "Set `admin_ssh_key` attribute instead of password authentication"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-263",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-263",
         "path": [
           "resource",
           "azurerm_virtual_machine[denied]",
@@ -35512,7 +35512,7 @@
           "resolve": "Set `admin_ssh_key` attribute instead of password authentication"
         },
         "lineNumber": 34,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-263",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-263",
         "path": [
           "resource",
           "azurerm_virtual_machine[denied_4]",
@@ -35540,7 +35540,7 @@
           "resolve": "Set `admin_ssh_key` attribute instead of password authentication"
         },
         "lineNumber": 8,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-263",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-263",
         "path": [
           "resource",
           "azurerm_virtual_machine[denied_2]",
@@ -35621,7 +35621,7 @@
           "resolve": "Set `disable_password_authentication` attribute to `true` or remove the attribute"
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-79",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-79",
         "path": [
           "resource",
           "azurerm_virtual_machine[denied]",
@@ -35649,7 +35649,7 @@
           "resolve": "Set `disable_password_authentication` attribute to `true` or remove the attribute"
         },
         "lineNumber": 2,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-79",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-79",
         "path": [
           "resource",
           "azurerm_linux_virtual_machine[denied]",
@@ -35703,7 +35703,7 @@
           "resolve": "Set `categories` attribute to `['Action', 'Delete', 'Write']`"
         },
         "lineNumber": 23,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-157",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-157",
         "path": [
           "resource",
           "azurerm_monitor_log_profile[denied_3]",
@@ -35730,7 +35730,7 @@
           "resolve": "Set `categories` attribute to `['Action', 'Delete', 'Write']`"
         },
         "lineNumber": 10,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-157",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-157",
         "path": [
           "resource",
           "azurerm_monitor_log_profile[denied]",
@@ -35757,7 +35757,7 @@
           "resolve": "Set `categories` attribute to `['Action', 'Delete', 'Write']`"
         },
         "lineNumber": 29,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-157",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-157",
         "path": [
           "resource",
           "azurerm_monitor_log_profile[denied_4]",
@@ -35784,7 +35784,7 @@
           "resolve": "Set `categories` attribute to `['Action', 'Delete', 'Write']`"
         },
         "lineNumber": 16,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-157",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-157",
         "path": [
           "resource",
           "azurerm_monitor_log_profile[denied_2]",
@@ -35838,7 +35838,7 @@
           "resolve": "Set `retention_policy.days` attribute to `365` or greater"
         },
         "lineNumber": 23,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-156",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-156",
         "path": [
           "resource",
           "azurerm_monitor_log_profile[denied_2]",
@@ -35865,7 +35865,7 @@
           "resolve": "Set `retention_policy.days` attribute to `365` or greater"
         },
         "lineNumber": 30,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-156",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-156",
         "path": [
           "resource",
           "azurerm_monitor_log_profile[denied_3]",
@@ -35892,7 +35892,7 @@
           "resolve": "Set `retention_policy.days` attribute to `365` or greater"
         },
         "lineNumber": 16,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-156",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-156",
         "path": [
           "resource",
           "azurerm_monitor_log_profile[denied]",
@@ -35946,7 +35946,7 @@
           "resolve": "Set `retention_policy` attribute to `90` or greater"
         },
         "lineNumber": 30,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-152",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-152",
         "path": [
           "resource",
           "azurerm_network_watcher_flow_log[denied_3]",
@@ -35973,7 +35973,7 @@
           "resolve": "Set `retention_policy` attribute to `90` or greater"
         },
         "lineNumber": 16,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-152",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-152",
         "path": [
           "resource",
           "azurerm_network_watcher_flow_log[denied]",
@@ -36000,7 +36000,7 @@
           "resolve": "Set `retention_policy` attribute to `90` or greater"
         },
         "lineNumber": 23,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-152",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-152",
         "path": [
           "resource",
           "azurerm_network_watcher_flow_log[denied_2]",
@@ -36054,7 +36054,7 @@
           "resolve": "Set `name` attribute to `log_checkpoints`, and `value` attribute to `on`"
         },
         "lineNumber": 11,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-154",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-154",
         "path": [
           "resource",
           "azurerm_postgresql_configuration[denied]"
@@ -36107,7 +36107,7 @@
           "resolve": "Set `retention_in_days` attribute to `90` or greater. Alternatively set the value to `0` to retain records indefinitely"
         },
         "lineNumber": 32,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-153",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-153",
         "path": [
           "resource",
           "azurerm_mssql_server[denied_2]",
@@ -36135,7 +36135,7 @@
           "resolve": "Set `retention_in_days` attribute to `90` or greater. Alternatively set the value to `0` to retain records indefinitely"
         },
         "lineNumber": 38,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-153",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-153",
         "path": [
           "resource",
           "azurerm_mssql_server[denied_3]",
@@ -36163,7 +36163,7 @@
           "resolve": "Set `retention_in_days` attribute to `90` or greater. Alternatively set the value to `0` to retain records indefinitely"
         },
         "lineNumber": 50,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-153",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-153",
         "path": [
           "resource",
           "azurerm_sql_server[denied]",
@@ -36191,7 +36191,7 @@
           "resolve": "Set `extended_auditing_policy` attribute"
         },
         "lineNumber": 24,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-167",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-167",
         "path": [
           "resource",
           "azurerm_mssql_server[allowed_5]"
@@ -36217,7 +36217,7 @@
           "resolve": "Set `extended_auditing_policy` attribute"
         },
         "lineNumber": 27,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-167",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-167",
         "path": [
           "resource",
           "azurerm_sql_server[allowed]"
@@ -36270,7 +36270,7 @@
           "resolve": "Set `extended_auditing_policy` attribute"
         },
         "lineNumber": 6,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-167",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-167",
         "path": [
           "resource",
           "azurerm_mssql_server[denied]"
@@ -36296,7 +36296,7 @@
           "resolve": "Set `extended_auditing_policy` attribute"
         },
         "lineNumber": 15,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-167",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-167",
         "path": [
           "resource",
           "azurerm_sql_server[denied]"
@@ -36322,7 +36322,7 @@
           "resolve": "Set `retention_in_days` attribute to `90` or greater. Alternatively set the value to `0` to retain records indefinitely"
         },
         "lineNumber": 11,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-153",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-153",
         "path": [
           "resource",
           "azurerm_sql_server[allowed]",
@@ -36377,7 +36377,7 @@
           "resolve": "Set `logging.read` attribute to `true`"
         },
         "lineNumber": 22,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-155",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-155",
         "path": [
           "resource",
           "azurerm_storage_account[denied]",
@@ -36404,7 +36404,7 @@
           "resolve": "Set `network_rules.bypass` attribute to `['Azure Services']`"
         },
         "lineNumber": 21,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-172",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-172",
         "path": [
           "resource",
           "azurerm_storage_account[denied]",
@@ -36431,7 +36431,7 @@
           "resolve": "Set `min_tls_version` attribute to `TLS1_2`"
         },
         "lineNumber": 9,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-149",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-149",
         "path": [
           "resource",
           "azurerm_storage_account[allowed_3]",
@@ -36458,7 +36458,7 @@
           "resolve": "Set `min_tls_version` attribute to `TLS1_2`"
         },
         "lineNumber": 26,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-149",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-149",
         "path": [
           "resource",
           "azurerm_storage_account[denied_2]",
@@ -36485,7 +36485,7 @@
           "resolve": "Set `min_tls_version` attribute to `TLS1_2`"
         },
         "lineNumber": 13,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-149",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-149",
         "path": [
           "resource",
           "azurerm_storage_account[allowed_4]",
@@ -36512,7 +36512,7 @@
           "resolve": "Set `min_tls_version` attribute to `TLS1_2`"
         },
         "lineNumber": 21,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-149",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-149",
         "path": [
           "resource",
           "azurerm_storage_account[denied]",
@@ -36539,7 +36539,7 @@
           "resolve": "Set `logging.read` attribute to `true`"
         },
         "lineNumber": 27,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-155",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-155",
         "path": [
           "resource",
           "azurerm_storage_account[denied_2]",
@@ -36566,7 +36566,7 @@
           "resolve": "Set `network_rules.bypass` attribute to `['Azure Services']`"
         },
         "lineNumber": 9,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-172",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-172",
         "path": [
           "resource",
           "azurerm_storage_account[allowed_3]",
@@ -36593,7 +36593,7 @@
           "resolve": "Set `network_rules.bypass` attribute to `['Azure Services']`"
         },
         "lineNumber": 26,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-172",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-172",
         "path": [
           "resource",
           "azurerm_storage_account[denied_2]",
@@ -36620,7 +36620,7 @@
           "resolve": "Set `network_rules.bypass` attribute to `['Azure Services']`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-172",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-172",
         "path": [
           "resource",
           "azurerm_storage_account[allowed_2]",
@@ -36647,7 +36647,7 @@
           "resolve": "Set `min_tls_version` attribute to `TLS1_2`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-149",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-149",
         "path": [
           "resource",
           "azurerm_storage_account[allowed]",
@@ -36674,7 +36674,7 @@
           "resolve": "Set `network_rules.bypass` attribute to `['Azure Services']`"
         },
         "lineNumber": 13,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-172",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-172",
         "path": [
           "resource",
           "azurerm_storage_account[allowed_4]",
@@ -36701,7 +36701,7 @@
           "resolve": "Set `network_rules.bypass` attribute to `['Azure Services']`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-172",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-172",
         "path": [
           "resource",
           "azurerm_storage_account[allowed]",
@@ -36728,7 +36728,7 @@
           "resolve": "Set `min_tls_version` attribute to `TLS1_2`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-149",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-149",
         "path": [
           "resource",
           "azurerm_storage_account[allowed_2]",
@@ -36786,7 +36786,7 @@
           "resolve": "Set `is_multi_region_trail` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-135",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-135",
         "path": [
           "resource",
           "aws_cloudtrail[insecure]",
@@ -36815,7 +36815,7 @@
           "resolve": "Set the `enable_log_file_validation` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-16",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-16",
         "path": [
           "input",
           "resource",
@@ -36847,7 +36847,7 @@
           "resolve": "Set `kms_key_id` attribute to valid KMS key id"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-17",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-17",
         "path": [
           "input",
           "resource",
@@ -36879,7 +36879,7 @@
           "resolve": "Set `cloud_watch_logs_group_arn` attribute to cloudwatch log group ARN"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-256",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-256",
         "path": [
           "resource",
           "aws_cloudtrail[insecure]",
@@ -36908,7 +36908,7 @@
           "resolve": "Set the `enable_logging` attribute to `true`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-15",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-15",
         "path": [
           "input",
           "resource",
@@ -36961,7 +36961,7 @@
           "resolve": "Adding or updating the attribute `encrypted` and setting it to `true` to ensure the snapshots are now encrypted. "
         },
         "lineNumber": 14,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-2",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-2",
         "path": [
           "input",
           "resource",
@@ -37018,7 +37018,7 @@
           "resolve": "Set `encrypted` attribute to `true`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-3",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-3",
         "path": [
           "input",
           "resource",
@@ -37100,7 +37100,7 @@
           "resolve": "Do not include users in `members` attribute"
         },
         "lineNumber": 80,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-90",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-90",
         "path": [
           "resource",
           "google_data_catalog_entry_group_iam_binding[denied]",
@@ -37128,7 +37128,7 @@
           "resolve": "Do not include users in `members` attribute"
         },
         "lineNumber": 224,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-90",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-90",
         "path": [
           "resource",
           "google_sourcerepo_repository_iam_binding[denied]",
@@ -37156,7 +37156,7 @@
           "resolve": "Do not include users in `members` attribute"
         },
         "lineNumber": 242,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-90",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-90",
         "path": [
           "resource",
           "google_storage_bucket_iam_binding[denied]",
@@ -37184,7 +37184,7 @@
           "resolve": "Do not include users in `members` attribute"
         },
         "lineNumber": 38,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-90",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-90",
         "path": [
           "resource",
           "google_cloud_run_service_iam_binding[denied]",
@@ -37212,7 +37212,7 @@
           "resolve": "Do not include users in `members` attribute"
         },
         "lineNumber": 218,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-90",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-90",
         "path": [
           "resource",
           "google_service_account_iam_binding[denied]",
@@ -37240,7 +37240,7 @@
           "resolve": "Do not include users in `members` attribute"
         },
         "lineNumber": 2,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-90",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-90",
         "path": [
           "resource",
           "google_project_iam_binding[denied]",
@@ -37268,7 +37268,7 @@
           "resolve": "Do not include users in `members` attribute"
         },
         "lineNumber": 98,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-90",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-90",
         "path": [
           "resource",
           "google_endpoints_service_iam_binding[denied]",
@@ -37296,7 +37296,7 @@
           "resolve": "Do not include users in `members` attribute"
         },
         "lineNumber": 212,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-90",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-90",
         "path": [
           "resource",
           "google_secret_manager_secret_iam_binding[denied]",
@@ -37324,7 +37324,7 @@
           "resolve": "Do not include users in `members` attribute"
         },
         "lineNumber": 26,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-90",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-90",
         "path": [
           "resource",
           "google_billing_account_iam_binding[denied]",
@@ -37352,7 +37352,7 @@
           "resolve": "Do not include users in `members` attribute"
         },
         "lineNumber": 68,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-90",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-90",
         "path": [
           "resource",
           "google_compute_region_disk_iam_binding[denied]",
@@ -37380,7 +37380,7 @@
           "resolve": "Do not include users in `members` attribute"
         },
         "lineNumber": 128,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-90",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-90",
         "path": [
           "resource",
           "google_healthcare_hl7_v2_store_iam_binding[denied]",
@@ -37408,7 +37408,7 @@
           "resolve": "Do not include users in `members` attribute"
         },
         "lineNumber": 140,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-90",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-90",
         "path": [
           "resource",
           "google_iap_app_engine_version_iam_binding[denied]",
@@ -37436,7 +37436,7 @@
           "resolve": "Do not include users in `members` attribute"
         },
         "lineNumber": 152,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-90",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-90",
         "path": [
           "resource",
           "google_iap_web_backend_service_iam_binding[denied]",
@@ -37464,7 +37464,7 @@
           "resolve": "Do not include users in `members` attribute"
         },
         "lineNumber": 110,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-90",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-90",
         "path": [
           "resource",
           "google_healthcare_dataset_iam_binding[denied]",
@@ -37492,7 +37492,7 @@
           "resolve": "Do not include users in `members` attribute"
         },
         "lineNumber": 194,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-90",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-90",
         "path": [
           "resource",
           "google_pubsub_subscription_iam_binding[denied]",
@@ -37520,7 +37520,7 @@
           "resolve": "Do not include users in `members` attribute"
         },
         "lineNumber": 104,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-90",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-90",
         "path": [
           "resource",
           "google_folder_iam_binding[denied]",
@@ -37548,7 +37548,7 @@
           "resolve": "Do not include users in `members` attribute"
         },
         "lineNumber": 62,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-90",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-90",
         "path": [
           "resource",
           "google_compute_instance_iam_binding[denied]",
@@ -37576,7 +37576,7 @@
           "resolve": "Do not include users in `members` attribute"
         },
         "lineNumber": 164,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-90",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-90",
         "path": [
           "resource",
           "google_iap_web_type_app_engine_iam_binding[denied]",
@@ -37604,7 +37604,7 @@
           "resolve": "Do not include users in `members` attribute"
         },
         "lineNumber": 170,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-90",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-90",
         "path": [
           "resource",
           "google_iap_web_type_compute_iam_binding[denied]",
@@ -37632,7 +37632,7 @@
           "resolve": "Do not include users in `members` attribute"
         },
         "lineNumber": 122,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-90",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-90",
         "path": [
           "resource",
           "google_healthcare_fhir_store_iam_binding[denied]",
@@ -37660,7 +37660,7 @@
           "resolve": "Do not include users in `members` attribute"
         },
         "lineNumber": 20,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-90",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-90",
         "path": [
           "resource",
           "google_bigtable_instance_iam_binding[denied]",
@@ -37688,7 +37688,7 @@
           "resolve": "Do not include users in `members` attribute"
         },
         "lineNumber": 230,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-90",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-90",
         "path": [
           "resource",
           "google_spanner_database_iam_binding[denied]",
@@ -37716,7 +37716,7 @@
           "resolve": "Do not include users in `members` attribute"
         },
         "lineNumber": 116,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-90",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-90",
         "path": [
           "resource",
           "google_healthcare_dicom_store_iam_binding[denied]",
@@ -37744,7 +37744,7 @@
           "resolve": "Do not include users in `members` attribute"
         },
         "lineNumber": 176,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-90",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-90",
         "path": [
           "resource",
           "google_kms_crypto_key_iam_binding[denied]",
@@ -37772,7 +37772,7 @@
           "resolve": "Do not include users in `members` attribute"
         },
         "lineNumber": 134,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-90",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-90",
         "path": [
           "resource",
           "google_iap_app_engine_service_iam_binding[denied]",
@@ -37800,7 +37800,7 @@
           "resolve": "Do not include users in `members` attribute"
         },
         "lineNumber": 44,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-90",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-90",
         "path": [
           "resource",
           "google_cloudfunctions_function_iam_binding[denied]",
@@ -37828,7 +37828,7 @@
           "resolve": "Do not include users in `members` attribute"
         },
         "lineNumber": 86,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-90",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-90",
         "path": [
           "resource",
           "google_dataproc_cluster_iam_binding[denied]",
@@ -37856,7 +37856,7 @@
           "resolve": "Do not include users in `members` attribute"
         },
         "lineNumber": 146,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-90",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-90",
         "path": [
           "resource",
           "google_iap_tunnel_instance_iam_binding[denied]",
@@ -37884,7 +37884,7 @@
           "resolve": "Do not include users in `members` attribute"
         },
         "lineNumber": 200,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-90",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-90",
         "path": [
           "resource",
           "google_pubsub_topic_iam_binding[denied]",
@@ -37912,7 +37912,7 @@
           "resolve": "Do not include users in `members` attribute"
         },
         "lineNumber": 14,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-90",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-90",
         "path": [
           "resource",
           "google_bigquery_table_iam_binding[denied]",
@@ -37940,7 +37940,7 @@
           "resolve": "Do not include users in `members` attribute"
         },
         "lineNumber": 158,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-90",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-90",
         "path": [
           "resource",
           "google_iap_web_iam_binding[denied]",
@@ -37968,7 +37968,7 @@
           "resolve": "Do not include users in `members` attribute"
         },
         "lineNumber": 236,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-90",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-90",
         "path": [
           "resource",
           "google_spanner_instance_iam_binding[denied]",
@@ -37996,7 +37996,7 @@
           "resolve": "Do not include users in `members` attribute"
         },
         "lineNumber": 32,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-90",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-90",
         "path": [
           "resource",
           "google_binary_authorization_attestor_iam_binding[denied]",
@@ -38024,7 +38024,7 @@
           "resolve": "Do not include users in `members` attribute"
         },
         "lineNumber": 50,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-90",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-90",
         "path": [
           "resource",
           "google_compute_disk_iam_binding[denied]",
@@ -38052,7 +38052,7 @@
           "resolve": "Do not include users in `members` attribute"
         },
         "lineNumber": 92,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-90",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-90",
         "path": [
           "resource",
           "google_dataproc_job_iam_binding[denied]",
@@ -38080,7 +38080,7 @@
           "resolve": "Do not include users in `members` attribute"
         },
         "lineNumber": 206,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-90",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-90",
         "path": [
           "resource",
           "google_runtimeconfig_config_iam_binding[denied]",
@@ -38108,7 +38108,7 @@
           "resolve": "Do not include users in `members` attribute"
         },
         "lineNumber": 188,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-90",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-90",
         "path": [
           "resource",
           "google_organization_iam_binding[denied]",
@@ -38136,7 +38136,7 @@
           "resolve": "Do not include users in `members` attribute"
         },
         "lineNumber": 8,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-90",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-90",
         "path": [
           "resource",
           "google_bigquery_dataset_iam_binding[denied]",
@@ -38164,7 +38164,7 @@
           "resolve": "Do not include users in `members` attribute"
         },
         "lineNumber": 182,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-90",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-90",
         "path": [
           "resource",
           "google_kms_key_ring_iam_binding[denied]",
@@ -38192,7 +38192,7 @@
           "resolve": "Do not include users in `members` attribute"
         },
         "lineNumber": 56,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-90",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-90",
         "path": [
           "resource",
           "google_compute_image_iam_binding[denied]",
@@ -38220,7 +38220,7 @@
           "resolve": "Do not include users in `members` attribute"
         },
         "lineNumber": 74,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-90",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-90",
         "path": [
           "resource",
           "google_compute_subnetwork_iam_binding[denied]",
@@ -38275,7 +38275,7 @@
           "resolve": "Set `pod_security_policy_config.enabled` attribute to `true`"
         },
         "lineNumber": 9,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-88",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-88",
         "path": [
           "resource",
           "google_container_cluster[denied_3]",
@@ -38303,7 +38303,7 @@
           "resolve": "Set `master_auth.username` and `master_auth.password` attributes to `\"\"`"
         },
         "lineNumber": 20,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-86",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-86",
         "path": [
           "resource",
           "google_container_cluster[denied_5]",
@@ -38331,7 +38331,7 @@
           "resolve": "Set `network_policy.enabled` attribute to `true`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-196",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-196",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -38360,7 +38360,7 @@
           "resolve": "Set `network_policy.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-196",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-196",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -38389,7 +38389,7 @@
           "resolve": "Set `workload_metadata_config.node_metadata` attribute to `GKE_METADATA_SERVER`"
         },
         "lineNumber": 19,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-84",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-84",
         "path": [
           "resource",
           "google_container_cluster[denied_5]",
@@ -38418,7 +38418,7 @@
           "resolve": "Set `master_auth.username` and `master_auth.password` attributes to `\"\"`"
         },
         "lineNumber": 9,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-86",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-86",
         "path": [
           "resource",
           "google_container_cluster[denied_3]",
@@ -38445,7 +38445,7 @@
           "resolve": "Set `resource_labels` attribute"
         },
         "lineNumber": 9,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-202",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-202",
         "path": [
           "resource",
           "google_container_cluster[denied_3]",
@@ -38473,7 +38473,7 @@
           "resolve": "Set `pod_security_policy_config.enabled` attribute to `true`"
         },
         "lineNumber": 19,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-88",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-88",
         "path": [
           "resource",
           "google_container_cluster[denied_5]",
@@ -38501,7 +38501,7 @@
           "resolve": "Set `network_policy.enabled` attribute to `true`"
         },
         "lineNumber": 9,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-196",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-196",
         "path": [
           "resource",
           "google_container_cluster[denied_3]",
@@ -38530,7 +38530,7 @@
           "resolve": "Set `private_cluster_config` attribute"
         },
         "lineNumber": 9,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-238",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-238",
         "path": [
           "resource",
           "google_container_cluster[denied_3]",
@@ -38558,7 +38558,7 @@
           "resolve": "Set `pod_security_policy_config.enabled` attribute to `true`"
         },
         "lineNumber": 13,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-88",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-88",
         "path": [
           "resource",
           "google_container_cluster[denied_4]",
@@ -38586,7 +38586,7 @@
           "resolve": "Set `master_auth.username` and `master_auth.password` attributes to `\"\"`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-86",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-86",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -38613,7 +38613,7 @@
           "resolve": "Set `ip_allocation_policy` attribute with dedicated IP ranges"
         },
         "lineNumber": 19,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-269",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-269",
         "path": [
           "resource",
           "google_container_cluster[denied_5]",
@@ -38640,7 +38640,7 @@
           "resolve": "Set `ip_allocation_policy` attribute with dedicated IP ranges"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-269",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-269",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -38667,7 +38667,7 @@
           "resolve": "Set `ip_allocation_policy` attribute with dedicated IP ranges"
         },
         "lineNumber": 13,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-269",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-269",
         "path": [
           "resource",
           "google_container_cluster[denied_4]",
@@ -38694,7 +38694,7 @@
           "resolve": "Set `ip_allocation_policy` attribute with dedicated IP ranges"
         },
         "lineNumber": 9,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-269",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-269",
         "path": [
           "resource",
           "google_container_cluster[denied_3]",
@@ -38722,7 +38722,7 @@
           "resolve": "Set `pod_security_policy_config.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-88",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-88",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -38749,7 +38749,7 @@
           "resolve": "Set `resource_labels` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-202",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-202",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -38776,7 +38776,7 @@
           "resolve": "Set `resource_labels` attribute"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-202",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-202",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -38804,7 +38804,7 @@
           "resolve": "Set `private_cluster_config` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-238",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-238",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -38832,7 +38832,7 @@
           "resolve": "Set `master_auth.issue_client_certificate` attribute to `false`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-87",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-87",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -38859,7 +38859,7 @@
           "resolve": "Set `resource_labels` attribute"
         },
         "lineNumber": 19,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-202",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-202",
         "path": [
           "resource",
           "google_container_cluster[denied_5]",
@@ -38887,7 +38887,7 @@
           "resolve": "Set `private_cluster_config` attribute"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-238",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-238",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -38915,7 +38915,7 @@
           "resolve": "Set `private_cluster_config` attribute"
         },
         "lineNumber": 13,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-238",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-238",
         "path": [
           "resource",
           "google_container_cluster[denied_4]",
@@ -38942,7 +38942,7 @@
           "resolve": "Set `enable_shielded_nodes` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-89",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-89",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -38970,7 +38970,7 @@
           "resolve": "Set `workload_metadata_config.node_metadata` attribute to `GKE_METADATA_SERVER`"
         },
         "lineNumber": 9,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-84",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-84",
         "path": [
           "resource",
           "google_container_cluster[denied_3]",
@@ -38998,7 +38998,7 @@
           "resolve": "Set `enable_shielded_nodes` attribute to `true`"
         },
         "lineNumber": 13,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-89",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-89",
         "path": [
           "resource",
           "google_container_cluster[denied_4]",
@@ -39025,7 +39025,7 @@
           "resolve": "Set `resource_labels` attribute"
         },
         "lineNumber": 13,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-202",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-202",
         "path": [
           "resource",
           "google_container_cluster[denied_4]",
@@ -39053,7 +39053,7 @@
           "resolve": "Set `network_policy.enabled` attribute to `true`"
         },
         "lineNumber": 13,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-196",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-196",
         "path": [
           "resource",
           "google_container_cluster[denied_4]",
@@ -39082,7 +39082,7 @@
           "resolve": "Set `master_auth.issue_client_certificate` attribute to `false`"
         },
         "lineNumber": 14,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-87",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-87",
         "path": [
           "resource",
           "google_container_cluster[denied_4]",
@@ -39110,7 +39110,7 @@
           "resolve": "Set `network_policy.enabled` attribute to `true`"
         },
         "lineNumber": 19,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-196",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-196",
         "path": [
           "resource",
           "google_container_cluster[denied_5]",
@@ -39139,7 +39139,7 @@
           "resolve": "Set `private_cluster_config` attribute"
         },
         "lineNumber": 19,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-238",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-238",
         "path": [
           "resource",
           "google_container_cluster[denied_5]",
@@ -39167,7 +39167,7 @@
           "resolve": "Set `master_auth.username` and `master_auth.password` attributes to `\"\"`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-86",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-86",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -39195,7 +39195,7 @@
           "resolve": "Set `workload_metadata_config.node_metadata` attribute to `GKE_METADATA_SERVER`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-84",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-84",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -39223,7 +39223,7 @@
           "resolve": "Set `enable_shielded_nodes` attribute to `true`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-89",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-89",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -39250,7 +39250,7 @@
           "resolve": "Set `ip_allocation_policy` attribute with dedicated IP ranges"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-269",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-269",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -39278,7 +39278,7 @@
           "resolve": "Set `master_auth.issue_client_certificate` attribute to `false`"
         },
         "lineNumber": 20,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-87",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-87",
         "path": [
           "resource",
           "google_container_cluster[denied_5]",
@@ -39306,7 +39306,7 @@
           "resolve": "Set `workload_metadata_config.node_metadata` attribute to `GKE_METADATA_SERVER`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-84",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-84",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -39335,7 +39335,7 @@
           "resolve": "Set `master_auth.issue_client_certificate` attribute to `false`"
         },
         "lineNumber": 9,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-87",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-87",
         "path": [
           "resource",
           "google_container_cluster[denied_3]",
@@ -39363,7 +39363,7 @@
           "resolve": "Set `master_auth.username` and `master_auth.password` attributes to `\"\"`"
         },
         "lineNumber": 14,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-86",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-86",
         "path": [
           "resource",
           "google_container_cluster[denied_4]",
@@ -39391,7 +39391,7 @@
           "resolve": "Set `pod_security_policy_config.enabled` attribute to `true`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-88",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-88",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -39418,7 +39418,7 @@
           "resolve": "Set `enable_shielded_nodes` attribute to `true`"
         },
         "lineNumber": 9,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-89",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-89",
         "path": [
           "resource",
           "google_container_cluster[denied_3]",
@@ -39446,7 +39446,7 @@
           "resolve": "Set `workload_metadata_config.node_metadata` attribute to `GKE_METADATA_SERVER`"
         },
         "lineNumber": 13,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-84",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-84",
         "path": [
           "resource",
           "google_container_cluster[denied_4]",
@@ -39475,7 +39475,7 @@
           "resolve": "Set `master_auth.issue_client_certificate` attribute to `false`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-87",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-87",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -39502,7 +39502,7 @@
           "resolve": "Set `enable_shielded_nodes` attribute to `true`"
         },
         "lineNumber": 19,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-89",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-89",
         "path": [
           "resource",
           "google_container_cluster[denied_5]",
@@ -39557,7 +39557,7 @@
           "resolve": "Set `pod_security_policy_config.enabled` attribute to `true`"
         },
         "lineNumber": 11,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-88",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-88",
         "path": [
           "resource",
           "google_container_cluster[denied_3]",
@@ -39585,7 +39585,7 @@
           "resolve": "Set `master_auth.issue_client_certificate` attribute to `false`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-87",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-87",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -39613,7 +39613,7 @@
           "resolve": "Set `network_policy.enabled` attribute to `true`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-196",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-196",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -39642,7 +39642,7 @@
           "resolve": "Set `network_policy.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-196",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-196",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -39671,7 +39671,7 @@
           "resolve": "Set `master_auth.username` and `master_auth.password` attributes to `\"\"`"
         },
         "lineNumber": 11,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-86",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-86",
         "path": [
           "resource",
           "google_container_cluster[denied_3]",
@@ -39699,7 +39699,7 @@
           "resolve": "Set `private_cluster_config` attribute"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-238",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-238",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -39726,7 +39726,7 @@
           "resolve": "Set `resource_labels` attribute"
         },
         "lineNumber": 11,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-202",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-202",
         "path": [
           "resource",
           "google_container_cluster[denied_3]",
@@ -39753,7 +39753,7 @@
           "resolve": "Set `enable_shielded_nodes` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-89",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-89",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -39781,7 +39781,7 @@
           "resolve": "Set `workload_metadata_config.node_metadata` attribute to `GKE_METADATA_SERVER`"
         },
         "lineNumber": 11,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-84",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-84",
         "path": [
           "resource",
           "google_container_cluster[denied_3]",
@@ -39810,7 +39810,7 @@
           "resolve": "Set `network_policy.enabled` attribute to `true`"
         },
         "lineNumber": 11,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-196",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-196",
         "path": [
           "resource",
           "google_container_cluster[denied_3]",
@@ -39839,7 +39839,7 @@
           "resolve": "Set `private_cluster_config` attribute"
         },
         "lineNumber": 11,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-238",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-238",
         "path": [
           "resource",
           "google_container_cluster[denied_3]",
@@ -39867,7 +39867,7 @@
           "resolve": "Set `master_auth.username` and `master_auth.password` attributes to `\"\"`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-86",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-86",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -39895,7 +39895,7 @@
           "resolve": "Set `master_auth.username` and `master_auth.password` attributes to `\"\"`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-86",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-86",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -39923,7 +39923,7 @@
           "resolve": "Set `workload_metadata_config.node_metadata` attribute to `GKE_METADATA_SERVER`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-84",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-84",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -39951,7 +39951,7 @@
           "resolve": "Set `enable_shielded_nodes` attribute to `true`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-89",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-89",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -39978,7 +39978,7 @@
           "resolve": "Set `ip_allocation_policy` attribute with dedicated IP ranges"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-269",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-269",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -40005,7 +40005,7 @@
           "resolve": "Set `ip_allocation_policy` attribute with dedicated IP ranges"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-269",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-269",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -40032,7 +40032,7 @@
           "resolve": "Set `ip_allocation_policy` attribute with dedicated IP ranges"
         },
         "lineNumber": 11,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-269",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-269",
         "path": [
           "resource",
           "google_container_cluster[denied_3]",
@@ -40060,7 +40060,7 @@
           "resolve": "Set `pod_security_policy_config.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-88",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-88",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -40088,7 +40088,7 @@
           "resolve": "Set `workload_metadata_config.node_metadata` attribute to `GKE_METADATA_SERVER`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-84",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-84",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -40116,7 +40116,7 @@
           "resolve": "Set `resource_labels` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-202",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-202",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -40144,7 +40144,7 @@
           "resolve": "Set `master_auth.issue_client_certificate` attribute to `false`"
         },
         "lineNumber": 11,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-87",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-87",
         "path": [
           "resource",
           "google_container_cluster[denied_3]",
@@ -40172,7 +40172,7 @@
           "resolve": "Set `pod_security_policy_config.enabled` attribute to `true`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-88",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-88",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -40199,7 +40199,7 @@
           "resolve": "Set `enable_shielded_nodes` attribute to `true`"
         },
         "lineNumber": 11,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-89",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-89",
         "path": [
           "resource",
           "google_container_cluster[denied_3]",
@@ -40226,7 +40226,7 @@
           "resolve": "Set `resource_labels` attribute"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-202",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-202",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -40254,7 +40254,7 @@
           "resolve": "Set `master_auth.issue_client_certificate` attribute to `false`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-87",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-87",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -40282,7 +40282,7 @@
           "resolve": "Set `private_cluster_config` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-238",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-238",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -40337,7 +40337,7 @@
           "resolve": "Set `network_policy.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-196",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-196",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -40365,7 +40365,7 @@
           "resolve": "Set `ip_allocation_policy` attribute with dedicated IP ranges"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-269",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-269",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -40393,7 +40393,7 @@
           "resolve": "Set `master_auth.username` and `master_auth.password` attributes to `\"\"`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-86",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-86",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -40421,7 +40421,7 @@
           "resolve": "Set `pod_security_policy_config.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-88",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-88",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -40449,7 +40449,7 @@
           "resolve": "Set `enable_legacy_abac` attribute to `false`, or remove the attribute"
         },
         "lineNumber": 2,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-83",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-83",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -40477,7 +40477,7 @@
           "resolve": "Set `master_auth.issue_client_certificate` attribute to `false`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-87",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-87",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -40505,7 +40505,7 @@
           "resolve": "Set `workload_metadata_config.node_metadata` attribute to `GKE_METADATA_SERVER`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-84",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-84",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -40533,7 +40533,7 @@
           "resolve": "Set `enable_shielded_nodes` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-89",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-89",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -40560,7 +40560,7 @@
           "resolve": "Set `resource_labels` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-202",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-202",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -40588,7 +40588,7 @@
           "resolve": "Set `private_cluster_config` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-238",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-238",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -40642,7 +40642,7 @@
           "resolve": "Set `enable_shielded_nodes` attribute to `true`"
         },
         "lineNumber": 6,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-89",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-89",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -40669,7 +40669,7 @@
           "resolve": "Set `ip_allocation_policy` attribute with dedicated IP ranges"
         },
         "lineNumber": 6,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-269",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-269",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -40697,7 +40697,7 @@
           "resolve": "Set `master_auth.issue_client_certificate` attribute to `false`"
         },
         "lineNumber": 6,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-87",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-87",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -40725,7 +40725,7 @@
           "resolve": "Set `network_policy.enabled` attribute to `true`"
         },
         "lineNumber": 6,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-196",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-196",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -40754,7 +40754,7 @@
           "resolve": "Set `metadata.disable-legacy-endpoints` attribute to `true`"
         },
         "lineNumber": 2,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-85",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-85",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -40782,7 +40782,7 @@
           "resolve": "Set `network_policy.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-196",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-196",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -40810,7 +40810,7 @@
           "resolve": "Set `ip_allocation_policy` attribute with dedicated IP ranges"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-269",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-269",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -40838,7 +40838,7 @@
           "resolve": "Set `pod_security_policy_config.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-88",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-88",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -40866,7 +40866,7 @@
           "resolve": "Set `private_cluster_config` attribute"
         },
         "lineNumber": 6,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-238",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-238",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -40894,7 +40894,7 @@
           "resolve": "Set `workload_metadata_config.node_metadata` attribute to `GKE_METADATA_SERVER`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-84",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-84",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -40922,7 +40922,7 @@
           "resolve": "Set `enable_shielded_nodes` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-89",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-89",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -40949,7 +40949,7 @@
           "resolve": "Set `resource_labels` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-202",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-202",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -40977,7 +40977,7 @@
           "resolve": "Set `pod_security_policy_config.enabled` attribute to `true`"
         },
         "lineNumber": 6,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-88",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-88",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -41005,7 +41005,7 @@
           "resolve": "Set `metadata.disable-legacy-endpoints` attribute to `true`"
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-85",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-85",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -41033,7 +41033,7 @@
           "resolve": "Set `master_auth.username` and `master_auth.password` attributes to `\"\"`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-86",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-86",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -41060,7 +41060,7 @@
           "resolve": "Set `resource_labels` attribute"
         },
         "lineNumber": 6,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-202",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-202",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -41088,7 +41088,7 @@
           "resolve": "Set `master_auth.issue_client_certificate` attribute to `false`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-87",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-87",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -41116,7 +41116,7 @@
           "resolve": "Set `master_auth.username` and `master_auth.password` attributes to `\"\"`"
         },
         "lineNumber": 6,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-86",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-86",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -41144,7 +41144,7 @@
           "resolve": "Set `workload_metadata_config.node_metadata` attribute to `GKE_METADATA_SERVER`"
         },
         "lineNumber": 6,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-84",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-84",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -41173,7 +41173,7 @@
           "resolve": "Set `private_cluster_config` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-238",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-238",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -41228,7 +41228,7 @@
           "resolve": "Set `network_policy.enabled` attribute to `true`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-196",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-196",
         "path": [
           "resource",
           "google_container_cluster[allowed_2]",
@@ -41256,7 +41256,7 @@
           "resolve": "Set `enable_shielded_nodes` attribute to `true`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-89",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-89",
         "path": [
           "resource",
           "google_container_cluster[allowed_2]",
@@ -41284,7 +41284,7 @@
           "resolve": "Set `private_cluster_config` attribute"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-238",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-238",
         "path": [
           "resource",
           "google_container_cluster[allowed_2]",
@@ -41312,7 +41312,7 @@
           "resolve": "Set `pod_security_policy_config.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-88",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-88",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -41339,7 +41339,7 @@
           "resolve": "Set `resource_labels` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-202",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-202",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -41367,7 +41367,7 @@
           "resolve": "Set `pod_security_policy_config.enabled` attribute to `true`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-88",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-88",
         "path": [
           "resource",
           "google_container_cluster[allowed_2]",
@@ -41394,7 +41394,7 @@
           "resolve": "Set `enable_shielded_nodes` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-89",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-89",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -41422,7 +41422,7 @@
           "resolve": "Set `network_policy.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-196",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-196",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -41451,7 +41451,7 @@
           "resolve": "Set `workload_metadata_config.node_metadata` attribute to `GKE_METADATA_SERVER`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-84",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-84",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -41479,7 +41479,7 @@
           "resolve": "Set `ip_allocation_policy` attribute with dedicated IP ranges"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-269",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-269",
         "path": [
           "resource",
           "google_container_cluster[allowed_2]",
@@ -41507,7 +41507,7 @@
           "resolve": "Set `private_cluster_config` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-238",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-238",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -41534,7 +41534,7 @@
           "resolve": "Set `ip_allocation_policy` attribute with dedicated IP ranges"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-269",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-269",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -41562,7 +41562,7 @@
           "resolve": "Set `master_auth.username` and `master_auth.password` attributes to `\"\"`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-86",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-86",
         "path": [
           "resource",
           "google_container_cluster[allowed_2]",
@@ -41589,7 +41589,7 @@
           "resolve": "Set `resource_labels` attribute"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-202",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-202",
         "path": [
           "resource",
           "google_container_cluster[allowed_2]",
@@ -41617,7 +41617,7 @@
           "resolve": "Set `master_auth.username` and `master_auth.password` attributes to `\"\"`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-86",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-86",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -41645,7 +41645,7 @@
           "resolve": "Set `master_auth.issue_client_certificate` attribute to `false`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-87",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-87",
         "path": [
           "resource",
           "google_container_cluster[allowed_2]",
@@ -41673,7 +41673,7 @@
           "resolve": "Set `workload_metadata_config.node_metadata` attribute to `GKE_METADATA_SERVER`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-84",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-84",
         "path": [
           "resource",
           "google_container_cluster[allowed_2]",
@@ -41702,7 +41702,7 @@
           "resolve": "Set `master_auth.issue_client_certificate` attribute to `false`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-87",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-87",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -41756,7 +41756,7 @@
           "resolve": "Set `enable_shielded_nodes` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-89",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-89",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -41784,7 +41784,7 @@
           "resolve": "Set `network_policy.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-196",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-196",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -41813,7 +41813,7 @@
           "resolve": "Set `workload_metadata_config.node_metadata` attribute to `GKE_METADATA_SERVER`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-84",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-84",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -41842,7 +41842,7 @@
           "resolve": "Set `private_cluster_config` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-238",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-238",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -41869,7 +41869,7 @@
           "resolve": "Set `ip_allocation_policy` attribute with dedicated IP ranges"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-269",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-269",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -41897,7 +41897,7 @@
           "resolve": "Set `pod_security_policy_config.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-88",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-88",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -41924,7 +41924,7 @@
           "resolve": "Set `resource_labels` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-202",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-202",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -41952,7 +41952,7 @@
           "resolve": "Set `master_auth.issue_client_certificate` attribute to `false`"
         },
         "lineNumber": 2,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-87",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-87",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -42006,7 +42006,7 @@
           "resolve": "Set `enable_shielded_nodes` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-89",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-89",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -42034,7 +42034,7 @@
           "resolve": "Set `network_policy.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-196",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-196",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -42063,7 +42063,7 @@
           "resolve": "Set `workload_metadata_config.node_metadata` attribute to `GKE_METADATA_SERVER`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-84",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-84",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -42092,7 +42092,7 @@
           "resolve": "Set `private_cluster_config` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-238",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-238",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -42119,7 +42119,7 @@
           "resolve": "Set `ip_allocation_policy` attribute with dedicated IP ranges"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-269",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-269",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -42147,7 +42147,7 @@
           "resolve": "Set `pod_security_policy_config.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-88",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-88",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -42175,7 +42175,7 @@
           "resolve": "Set `master_auth.username` and `master_auth.password` attributes to `\"\"`"
         },
         "lineNumber": 2,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-86",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-86",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -42202,7 +42202,7 @@
           "resolve": "Set `resource_labels` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-202",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-202",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -42257,7 +42257,7 @@
           "resolve": "Set `network_policy.enabled` attribute to `true`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-196",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-196",
         "path": [
           "resource",
           "google_container_cluster[allowed_2]",
@@ -42285,7 +42285,7 @@
           "resolve": "Set `enable_shielded_nodes` attribute to `true`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-89",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-89",
         "path": [
           "resource",
           "google_container_cluster[allowed_2]",
@@ -42313,7 +42313,7 @@
           "resolve": "Set `private_cluster_config` attribute"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-238",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-238",
         "path": [
           "resource",
           "google_container_cluster[allowed_2]",
@@ -42341,7 +42341,7 @@
           "resolve": "Set `pod_security_policy_config.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-88",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-88",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -42368,7 +42368,7 @@
           "resolve": "Set `resource_labels` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-202",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-202",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -42396,7 +42396,7 @@
           "resolve": "Set `pod_security_policy_config.enabled` attribute to `true`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-88",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-88",
         "path": [
           "resource",
           "google_container_cluster[allowed_2]",
@@ -42423,7 +42423,7 @@
           "resolve": "Set `enable_shielded_nodes` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-89",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-89",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -42451,7 +42451,7 @@
           "resolve": "Set `network_policy.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-196",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-196",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -42480,7 +42480,7 @@
           "resolve": "Set `workload_metadata_config.node_metadata` attribute to `GKE_METADATA_SERVER`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-84",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-84",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -42508,7 +42508,7 @@
           "resolve": "Set `ip_allocation_policy` attribute with dedicated IP ranges"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-269",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-269",
         "path": [
           "resource",
           "google_container_cluster[allowed_2]",
@@ -42536,7 +42536,7 @@
           "resolve": "Set `private_cluster_config` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-238",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-238",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -42563,7 +42563,7 @@
           "resolve": "Set `ip_allocation_policy` attribute with dedicated IP ranges"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-269",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-269",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -42591,7 +42591,7 @@
           "resolve": "Set `master_auth.username` and `master_auth.password` attributes to `\"\"`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-86",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-86",
         "path": [
           "resource",
           "google_container_cluster[allowed_2]",
@@ -42618,7 +42618,7 @@
           "resolve": "Set `resource_labels` attribute"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-202",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-202",
         "path": [
           "resource",
           "google_container_cluster[allowed_2]",
@@ -42646,7 +42646,7 @@
           "resolve": "Set `master_auth.username` and `master_auth.password` attributes to `\"\"`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-86",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-86",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -42674,7 +42674,7 @@
           "resolve": "Set `master_auth.issue_client_certificate` attribute to `false`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-87",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-87",
         "path": [
           "resource",
           "google_container_cluster[allowed_2]",
@@ -42702,7 +42702,7 @@
           "resolve": "Set `workload_metadata_config.node_metadata` attribute to `GKE_METADATA_SERVER`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-84",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-84",
         "path": [
           "resource",
           "google_container_cluster[allowed_2]",
@@ -42731,7 +42731,7 @@
           "resolve": "Set `master_auth.issue_client_certificate` attribute to `false`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-87",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-87",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -42785,7 +42785,7 @@
           "resolve": "Set `enable_shielded_nodes` attribute to `true`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-89",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-89",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -42812,7 +42812,7 @@
           "resolve": "Set `ip_allocation_policy` attribute with dedicated IP ranges"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-269",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-269",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -42840,7 +42840,7 @@
           "resolve": "Set `master_auth.issue_client_certificate` attribute to `false`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-87",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-87",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -42868,7 +42868,7 @@
           "resolve": "Set `network_policy.enabled` attribute to `true`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-196",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-196",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -42897,7 +42897,7 @@
           "resolve": "Set `network_policy.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-196",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-196",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -42925,7 +42925,7 @@
           "resolve": "Set `ip_allocation_policy` attribute with dedicated IP ranges"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-269",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-269",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -42953,7 +42953,7 @@
           "resolve": "Set `pod_security_policy_config.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-88",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-88",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -42981,7 +42981,7 @@
           "resolve": "Set `private_cluster_config` attribute"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-238",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-238",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -43009,7 +43009,7 @@
           "resolve": "Set `workload_metadata_config.node_metadata` attribute to `GKE_METADATA_SERVER`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-84",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-84",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -43037,7 +43037,7 @@
           "resolve": "Set `enable_shielded_nodes` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-89",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-89",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -43064,7 +43064,7 @@
           "resolve": "Set `resource_labels` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-202",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-202",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -43092,7 +43092,7 @@
           "resolve": "Set `pod_security_policy_config.enabled` attribute to `true`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-88",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-88",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -43120,7 +43120,7 @@
           "resolve": "Set `master_auth.username` and `master_auth.password` attributes to `\"\"`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-86",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-86",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -43147,7 +43147,7 @@
           "resolve": "Set `resource_labels` attribute"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-202",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-202",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -43175,7 +43175,7 @@
           "resolve": "Set `master_auth.issue_client_certificate` attribute to `false`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-87",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-87",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -43203,7 +43203,7 @@
           "resolve": "Set `master_auth.username` and `master_auth.password` attributes to `\"\"`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-86",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-86",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -43231,7 +43231,7 @@
           "resolve": "Set `workload_metadata_config.node_metadata` attribute to `GKE_METADATA_SERVER`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-84",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-84",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -43260,7 +43260,7 @@
           "resolve": "Set `private_cluster_config` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-238",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-238",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -43314,7 +43314,7 @@
           "resolve": "Set `enable_shielded_nodes` attribute to `true`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-89",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-89",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -43341,7 +43341,7 @@
           "resolve": "Set `ip_allocation_policy` attribute with dedicated IP ranges"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-269",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-269",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -43369,7 +43369,7 @@
           "resolve": "Set `master_auth.issue_client_certificate` attribute to `false`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-87",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-87",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -43397,7 +43397,7 @@
           "resolve": "Set `network_policy.enabled` attribute to `true`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-196",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-196",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -43426,7 +43426,7 @@
           "resolve": "Set `network_policy.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-196",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-196",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -43454,7 +43454,7 @@
           "resolve": "Set `ip_allocation_policy` attribute with dedicated IP ranges"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-269",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-269",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -43482,7 +43482,7 @@
           "resolve": "Set `pod_security_policy_config.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-88",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-88",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -43510,7 +43510,7 @@
           "resolve": "Set `private_cluster_config` attribute"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-238",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-238",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -43538,7 +43538,7 @@
           "resolve": "Set `workload_metadata_config.node_metadata` attribute to `GKE_METADATA_SERVER`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-84",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-84",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -43566,7 +43566,7 @@
           "resolve": "Set `enable_shielded_nodes` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-89",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-89",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -43593,7 +43593,7 @@
           "resolve": "Set `resource_labels` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-202",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-202",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -43621,7 +43621,7 @@
           "resolve": "Set `pod_security_policy_config.enabled` attribute to `true`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-88",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-88",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -43649,7 +43649,7 @@
           "resolve": "Set `master_auth.username` and `master_auth.password` attributes to `\"\"`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-86",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-86",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -43676,7 +43676,7 @@
           "resolve": "Set `resource_labels` attribute"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-202",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-202",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -43704,7 +43704,7 @@
           "resolve": "Set `master_auth.issue_client_certificate` attribute to `false`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-87",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-87",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -43732,7 +43732,7 @@
           "resolve": "Set `master_auth.username` and `master_auth.password` attributes to `\"\"`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-86",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-86",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -43760,7 +43760,7 @@
           "resolve": "Set `workload_metadata_config.node_metadata` attribute to `GKE_METADATA_SERVER`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-84",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-84",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -43789,7 +43789,7 @@
           "resolve": "Set `private_cluster_config` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-238",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-238",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -43844,7 +43844,7 @@
           "resolve": "Set `pod_security_policy_config.enabled` attribute to `true`"
         },
         "lineNumber": 14,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-88",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-88",
         "path": [
           "resource",
           "google_container_cluster[denied_3]",
@@ -43872,7 +43872,7 @@
           "resolve": "Set `master_auth.issue_client_certificate` attribute to `false`"
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-87",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-87",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -43900,7 +43900,7 @@
           "resolve": "Set `network_policy.enabled` attribute to `true`"
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-196",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-196",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -43929,7 +43929,7 @@
           "resolve": "Set `network_policy.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-196",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-196",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -43958,7 +43958,7 @@
           "resolve": "Set `master_auth.username` and `master_auth.password` attributes to `\"\"`"
         },
         "lineNumber": 14,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-86",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-86",
         "path": [
           "resource",
           "google_container_cluster[denied_3]",
@@ -43986,7 +43986,7 @@
           "resolve": "Set `private_cluster_config` attribute"
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-238",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-238",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -44013,7 +44013,7 @@
           "resolve": "Set `resource_labels` attribute"
         },
         "lineNumber": 14,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-202",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-202",
         "path": [
           "resource",
           "google_container_cluster[denied_3]",
@@ -44040,7 +44040,7 @@
           "resolve": "Set `enable_shielded_nodes` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-89",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-89",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -44068,7 +44068,7 @@
           "resolve": "Set `workload_metadata_config.node_metadata` attribute to `GKE_METADATA_SERVER`"
         },
         "lineNumber": 14,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-84",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-84",
         "path": [
           "resource",
           "google_container_cluster[denied_3]",
@@ -44097,7 +44097,7 @@
           "resolve": "Set `network_policy.enabled` attribute to `true`"
         },
         "lineNumber": 14,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-196",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-196",
         "path": [
           "resource",
           "google_container_cluster[denied_3]",
@@ -44126,7 +44126,7 @@
           "resolve": "Set `private_cluster_config` attribute"
         },
         "lineNumber": 14,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-238",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-238",
         "path": [
           "resource",
           "google_container_cluster[denied_3]",
@@ -44154,7 +44154,7 @@
           "resolve": "Set `master_auth.username` and `master_auth.password` attributes to `\"\"`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-86",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-86",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -44182,7 +44182,7 @@
           "resolve": "Set `master_auth.username` and `master_auth.password` attributes to `\"\"`"
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-86",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-86",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -44210,7 +44210,7 @@
           "resolve": "Set `workload_metadata_config.node_metadata` attribute to `GKE_METADATA_SERVER`"
         },
         "lineNumber": 9,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-84",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-84",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -44238,7 +44238,7 @@
           "resolve": "Set `enable_shielded_nodes` attribute to `true`"
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-89",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-89",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -44265,7 +44265,7 @@
           "resolve": "Set `ip_allocation_policy` attribute with dedicated IP ranges"
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-269",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-269",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -44292,7 +44292,7 @@
           "resolve": "Set `ip_allocation_policy` attribute with dedicated IP ranges"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-269",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-269",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -44319,7 +44319,7 @@
           "resolve": "Set `ip_allocation_policy` attribute with dedicated IP ranges"
         },
         "lineNumber": 14,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-269",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-269",
         "path": [
           "resource",
           "google_container_cluster[denied_3]",
@@ -44347,7 +44347,7 @@
           "resolve": "Set `pod_security_policy_config.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-88",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-88",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -44375,7 +44375,7 @@
           "resolve": "Set `workload_metadata_config.node_metadata` attribute to `GKE_METADATA_SERVER`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-84",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-84",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -44403,7 +44403,7 @@
           "resolve": "Set `resource_labels` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-202",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-202",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -44431,7 +44431,7 @@
           "resolve": "Set `master_auth.issue_client_certificate` attribute to `false`"
         },
         "lineNumber": 14,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-87",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-87",
         "path": [
           "resource",
           "google_container_cluster[denied_3]",
@@ -44459,7 +44459,7 @@
           "resolve": "Set `pod_security_policy_config.enabled` attribute to `true`"
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-88",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-88",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -44486,7 +44486,7 @@
           "resolve": "Set `enable_shielded_nodes` attribute to `true`"
         },
         "lineNumber": 14,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-89",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-89",
         "path": [
           "resource",
           "google_container_cluster[denied_3]",
@@ -44513,7 +44513,7 @@
           "resolve": "Set `resource_labels` attribute"
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-202",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-202",
         "path": [
           "resource",
           "google_container_cluster[denied_2]",
@@ -44541,7 +44541,7 @@
           "resolve": "Set `master_auth.issue_client_certificate` attribute to `false`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-87",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-87",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -44569,7 +44569,7 @@
           "resolve": "Set `private_cluster_config` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-238",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-238",
         "path": [
           "resource",
           "google_container_cluster[denied]",
@@ -44623,7 +44623,7 @@
           "resolve": "Set `enable_shielded_nodes` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-89",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-89",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -44651,7 +44651,7 @@
           "resolve": "Set `network_policy.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-196",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-196",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -44680,7 +44680,7 @@
           "resolve": "Set `workload_metadata_config.node_metadata` attribute to `GKE_METADATA_SERVER`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-84",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-84",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -44709,7 +44709,7 @@
           "resolve": "Set `private_cluster_config` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-238",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-238",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -44736,7 +44736,7 @@
           "resolve": "Set `ip_allocation_policy` attribute with dedicated IP ranges"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-269",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-269",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -44764,7 +44764,7 @@
           "resolve": "Set `master_auth.username` and `master_auth.password` attributes to `\"\"`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-86",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-86",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -44791,7 +44791,7 @@
           "resolve": "Set `resource_labels` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-202",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-202",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -44819,7 +44819,7 @@
           "resolve": "Set `master_auth.issue_client_certificate` attribute to `false`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-87",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-87",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -44874,7 +44874,7 @@
           "resolve": "Set `network_policy.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-196",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-196",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -44903,7 +44903,7 @@
           "resolve": "Set `workload_metadata_config.node_metadata` attribute to `GKE_METADATA_SERVER`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-84",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-84",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -44932,7 +44932,7 @@
           "resolve": "Set `private_cluster_config` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-238",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-238",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -44959,7 +44959,7 @@
           "resolve": "Set `ip_allocation_policy` attribute with dedicated IP ranges"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-269",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-269",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -44987,7 +44987,7 @@
           "resolve": "Set `pod_security_policy_config.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-88",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-88",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -45015,7 +45015,7 @@
           "resolve": "Set `master_auth.username` and `master_auth.password` attributes to `\"\"`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-86",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-86",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -45042,7 +45042,7 @@
           "resolve": "Set `resource_labels` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-202",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-202",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -45070,7 +45070,7 @@
           "resolve": "Set `master_auth.issue_client_certificate` attribute to `false`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-87",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-87",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -45124,7 +45124,7 @@
           "resolve": "Set `enable_shielded_nodes` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-89",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-89",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -45152,7 +45152,7 @@
           "resolve": "Set `network_policy.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-196",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-196",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -45181,7 +45181,7 @@
           "resolve": "Set `private_cluster_config` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-238",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-238",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -45208,7 +45208,7 @@
           "resolve": "Set `ip_allocation_policy` attribute with dedicated IP ranges"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-269",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-269",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -45236,7 +45236,7 @@
           "resolve": "Set `pod_security_policy_config.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-88",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-88",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -45264,7 +45264,7 @@
           "resolve": "Set `master_auth.username` and `master_auth.password` attributes to `\"\"`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-86",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-86",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -45291,7 +45291,7 @@
           "resolve": "Set `resource_labels` attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-202",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-202",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -45319,7 +45319,7 @@
           "resolve": "Set `master_auth.issue_client_certificate` attribute to `false`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-87",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-87",
         "path": [
           "resource",
           "google_container_cluster[allowed]",
@@ -45371,7 +45371,7 @@
           "resolve": "Set the `minimum_password_length` attribute to be at least `14` to increase the strength of your password"
         },
         "lineNumber": 41,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-11",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-11",
         "path": [
           "input",
           "resource",
@@ -45397,7 +45397,7 @@
           "resolve": "Set the `max_password_age` attribute to be less than `90` therefore reducing your exposure window"
         },
         "lineNumber": 89,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-13",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-13",
         "path": [
           "input",
           "resource",
@@ -45423,7 +45423,7 @@
           "resolve": "Set the `max_password_age` attribute to be less than `90` therefore reducing your exposure window"
         },
         "lineNumber": 71,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-13",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-13",
         "path": [
           "input",
           "resource",
@@ -45449,7 +45449,7 @@
           "resolve": "Set the `require_symbols` attribute to be `true` to increase the strength of your password"
         },
         "lineNumber": 26,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-9",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-9",
         "path": [
           "input",
           "resource",
@@ -45475,7 +45475,7 @@
           "resolve": "Set the `minimum_password_length` attribute to be at least `14` to increase the strength of your password"
         },
         "lineNumber": 51,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-11",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-11",
         "path": [
           "input",
           "resource",
@@ -45501,7 +45501,7 @@
           "resolve": "Set the `password_reuse_prevention` attribute to be `24` to ensure the previous 24 passwords cannot be reused"
         },
         "lineNumber": 67,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-12",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-12",
         "path": [
           "input",
           "resource",
@@ -45527,7 +45527,7 @@
           "resolve": "Set the `require_lowercase` attribute to be `true` to increase the strength of your password"
         },
         "lineNumber": 13,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-8",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-8",
         "path": [
           "input",
           "resource",
@@ -45553,7 +45553,7 @@
           "resolve": "Set the `require_uppercase` attribute to be `true` to increase the strength of your password"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-7",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-7",
         "path": [
           "input",
           "resource",
@@ -45579,7 +45579,7 @@
           "resolve": "Set the `require_numbers` attribute to be `true` to increase the strength of your password"
         },
         "lineNumber": 34,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-10",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-10",
         "path": [
           "input",
           "resource",
@@ -45636,7 +45636,7 @@
           "resolve": "Set `enable_key_rotation` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-14",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-14",
         "path": [
           "input",
           "resource",
@@ -45692,7 +45692,7 @@
           "resolve": "Migrate the resource to VPC mode"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-46",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-46",
         "path": [
           "input",
           "resource",
@@ -45747,7 +45747,7 @@
           "resolve": "Migrate the resource to VPC mode"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-46",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-46",
         "path": [
           "input",
           "resource",
@@ -45778,7 +45778,7 @@
           "resolve": "Set `cidr` attribute to specific IP range only, for example `192.168.1.0/24`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-39",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-39",
         "path": [
           "resource",
           "aws_db_security_group[denied]",
@@ -45857,7 +45857,7 @@
           "resolve": "Set cidr_block to specific IP range only, e.g. `192.168.1.0/24`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-40",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-40",
         "path": [
           "resource",
           "aws_default_network_acl[denied]",
@@ -45910,7 +45910,7 @@
           "resolve": "Updating the `cidr_block` attribute with a more restrictive IP range or a specific IP address to ensure traffic can only reach known destinations. "
         },
         "lineNumber": 9,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-6",
         "path": [
           "input",
           "resource",
@@ -45963,7 +45963,7 @@
           "resolve": "Updating the `cidr_block` attribute with a more restrictive IP range or a specific IP address to ensure traffic can only reach known destinations. "
         },
         "lineNumber": 15,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-6",
         "path": [
           "input",
           "resource",
@@ -45989,7 +45989,7 @@
           "resolve": "Updating the `cidr_block` attribute with a more restrictive IP range or a specific IP address to ensure traffic can only come from known sources. "
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-5",
         "path": [
           "input",
           "resource",
@@ -46074,7 +46074,7 @@
           "resolve": "Set `cidr_block` attribute to specific IP range only, for example `192.168.1.0/24`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-41",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-41",
         "path": [
           "resource",
           "aws_network_acl[denied]",
@@ -46157,7 +46157,7 @@
           "resolve": "Set cidr_block to specific IP range only, e.g. `192.168.1.0/24`"
         },
         "lineNumber": 6,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-42",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-42",
         "path": [
           "resource",
           "aws_network_acl_rule[denied]",
@@ -46212,7 +46212,7 @@
           "resolve": "Migrate the resource to VPC mode"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-46",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-46",
         "path": [
           "input",
           "resource",
@@ -46267,7 +46267,7 @@
           "resolve": "Migrate the resource to VPC mode"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-46",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-46",
         "path": [
           "input",
           "resource",
@@ -46298,7 +46298,7 @@
           "resolve": "Set `cidr` attribute to specific IP range only, for example `192.168.1.0/24`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-38",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-38",
         "path": [
           "resource",
           "aws_redshift_security_group[denied]",
@@ -46356,7 +46356,7 @@
           "impact": "Open egress can be used to exfiltrate data to unauthorized destinations, and enable access to potentially malicious resources"
         },
         "lineNumber": 12,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-73",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-73",
         "path": [
           "resource",
           "aws_security_group[allowed]",
@@ -46414,7 +46414,7 @@
           "resolve": "Set `cidr_block` attribute with a more restrictive IP, for example `192.16.0.0/24`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-1",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-1",
         "path": [
           "input",
           "resource",
@@ -46445,7 +46445,7 @@
           "impact": "Open egress can be used to exfiltrate data to unauthorized destinations, and enable access to potentially malicious resources"
         },
         "lineNumber": 19,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-73",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-73",
         "path": [
           "resource",
           "aws_security_group[denied]",
@@ -46527,7 +46527,7 @@
           "resolve": "Set `cidr_blocks` attribute to specific IP range only, e.g. `192.168.1.0/24`"
         },
         "lineNumber": 6,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-37",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-37",
         "path": [
           "resource",
           "aws_security_group_rule[denied]",
@@ -46581,7 +46581,7 @@
           "resolve": "Set `description` attribute to meaningful statement"
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-56",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-56",
         "path": [
           "resource",
           "aws_security_group[allowed_2]",
@@ -46608,7 +46608,7 @@
           "resolve": "Set `description` attribute to meaningful statement"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-56",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-56",
         "path": [
           "resource",
           "aws_security_group[allowed]",
@@ -46662,7 +46662,7 @@
           "resolve": "Set `description` attribute to meaningful statement"
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-56",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-56",
         "path": [
           "resource",
           "aws_security_group[denied_2]",
@@ -46692,7 +46692,7 @@
           "impact": "Open egress can be used to exfiltrate data to unauthorized destinations, and enable access to potentially malicious resources"
         },
         "lineNumber": 7,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-73",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-73",
         "path": [
           "resource",
           "aws_security_group[denied_2]",
@@ -46719,7 +46719,7 @@
           "resolve": "Set `description` attribute to meaningful statement"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-56",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-56",
         "path": [
           "resource",
           "aws_security_group[denied]",
@@ -46749,7 +46749,7 @@
           "impact": "Open egress can be used to exfiltrate data to unauthorized destinations, and enable access to potentially malicious resources"
         },
         "lineNumber": 2,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-73",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-73",
         "path": [
           "resource",
           "aws_security_group[denied]",
@@ -46879,7 +46879,7 @@
           "resolve": "Set start_ip_address to specific IP range only, e.g. `192.168.1.0/24`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-23",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-23",
         "path": [
           "resource",
           "azurerm_data_lake_analytics_firewall_rule[denied]",
@@ -46957,7 +46957,7 @@
           "resolve": "Set start_ip_address to specific IP range only, e.g. `192.168.1.0/24`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-24",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-24",
         "path": [
           "resource",
           "azurerm_data_lake_store_firewall_rule[denied]",
@@ -47035,7 +47035,7 @@
           "resolve": "Set source_addresses to specific IP range only, e.g. `192.168.1.0/24`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-21",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-21",
         "path": [
           "resource",
           "azurerm_firewall_application_rule_collection[denied]",
@@ -47114,7 +47114,7 @@
           "resolve": "Set source_addresses to specific IP range only, e.g. `192.168.1.0/24`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-20",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-20",
         "path": [
           "resource",
           "azurerm_firewall_network_rule_collection[denied]",
@@ -47193,7 +47193,7 @@
           "resolve": "Set start_ip_address to specific IP range only, e.g. `192.168.1.0/24`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-25",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-25",
         "path": [
           "resource",
           "azurerm_mariadb_firewall_rule[denied]",
@@ -47271,7 +47271,7 @@
           "resolve": "Set start_ip_address to specific IP range only, e.g. `192.168.1.0/24`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-26",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-26",
         "path": [
           "resource",
           "azurerm_mysql_firewall_rule[denied]",
@@ -47349,7 +47349,7 @@
           "resolve": "Set source_address_prefix to specific IP range only, e.g. `192.168.1.0/24`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-33",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-33",
         "path": [
           "resource",
           "azurerm_network_security_group[denied]",
@@ -47375,7 +47375,7 @@
           "resolve": "Set source_address_prefix to specific IP range only, e.g. `192.168.1.0/24`"
         },
         "lineNumber": 32,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-33",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-33",
         "path": [
           "resource",
           "azurerm_network_security_group[denied_2]",
@@ -47454,7 +47454,7 @@
           "resolve": "Set source_address_prefix to specific IP range only, e.g. `192.168.1.0/24`"
         },
         "lineNumber": 9,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-35",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-35",
         "path": [
           "resource",
           "azurerm_network_security_rule[denied]",
@@ -47479,7 +47479,7 @@
           "resolve": "Set source_address_prefix to specific IP range only, e.g. `192.168.1.0/24`"
         },
         "lineNumber": 23,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-35",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-35",
         "path": [
           "resource",
           "azurerm_network_security_rule[denied_2]",
@@ -47560,7 +47560,7 @@
           "resolve": "Set `destination_address_prefix` attribute to specific ranges e.g. `192.168.1.0/24`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-76",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-76",
         "path": [
           "resource",
           "azurerm_network_security_rule[denied]",
@@ -47588,7 +47588,7 @@
           "resolve": "Set `destination_address_prefix` attribute to specific ranges e.g. `192.168.1.0/24`"
         },
         "lineNumber": 10,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-76",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-76",
         "path": [
           "resource",
           "azurerm_network_security_rule[denied_2]",
@@ -47616,7 +47616,7 @@
           "resolve": "Set `destination_address_prefix` attribute to specific ranges e.g. `192.168.1.0/24`"
         },
         "lineNumber": 16,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-76",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-76",
         "path": [
           "resource",
           "azurerm_network_security_rule[denied_3]",
@@ -47694,7 +47694,7 @@
           "resolve": "Set start_ip_address to specific IP range only, e.g. `192.168.1.0/24`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-27",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-27",
         "path": [
           "resource",
           "azurerm_postgresql_firewall_rule[denied]",
@@ -47772,7 +47772,7 @@
           "resolve": "Set start_ip to specific IP range only, e.g. `192.168.1.0/24`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-28",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-28",
         "path": [
           "resource",
           "azurerm_redis_firewall_rule[denied]",
@@ -47850,7 +47850,7 @@
           "resolve": "Set start_ip_address to specific IP range only, e.g. `192.168.1.0/24`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-29",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-29",
         "path": [
           "resource",
           "azurerm_sql_firewall_rule[denied]",
@@ -47928,7 +47928,7 @@
           "resolve": "Set start_ip_address to specific IP range only, e.g. `192.168.1.0/24`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-30",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-30",
         "path": [
           "resource",
           "azurerm_synapse_firewall_rule[denied]",
@@ -48006,7 +48006,7 @@
           "resolve": "Set source_range to specific IP range only, e.g. `192.168.1.0/24`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-31",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-31",
         "path": [
           "resource",
           "google_app_engine_firewall_rule[denied]",
@@ -48084,7 +48084,7 @@
           "resolve": "Set source_ranges to specific IP range only, e.g. `192.168.1.0/24`"
         },
         "lineNumber": 11,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-32",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-32",
         "path": [
           "resource",
           "google_compute_firewall[denied]",
@@ -48162,7 +48162,7 @@
           "resolve": "Set `destination_ranges` attribute to specific net addresses e.g. `192.168.0.0/16`"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-91",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-91",
         "path": [
           "resource",
           "google_compute_firewall[denied]",
@@ -48223,7 +48223,7 @@
           "resolve": "Set `block_public_policy` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-96",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-96",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[allowed]",
@@ -48257,7 +48257,7 @@
           "resolve": "Set `restrict_public_buckets` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-98",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-98",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[allowed]",
@@ -48291,7 +48291,7 @@
           "resolve": "Set `ignore_public_acls` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-97",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-97",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[allowed]",
@@ -48352,7 +48352,7 @@
           "resolve": "Set `ignore_public_acls` attribute to `true`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-97",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-97",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[denied_2]",
@@ -48386,7 +48386,7 @@
           "resolve": "Set `restrict_public_buckets` attribute to `true`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-98",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-98",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[denied_2]",
@@ -48420,7 +48420,7 @@
           "resolve": "Set `block_public_policy` attribute to `true`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-96",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-96",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[denied_2]",
@@ -48454,7 +48454,7 @@
           "resolve": "Set `block_public_acls` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-95",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-95",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[denied]",
@@ -48488,7 +48488,7 @@
           "resolve": "Set `restrict_public_buckets` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-98",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-98",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[denied]",
@@ -48522,7 +48522,7 @@
           "resolve": "Set `block_public_acls` attribute to `true`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-95",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-95",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[denied_2]",
@@ -48556,7 +48556,7 @@
           "resolve": "Set `ignore_public_acls` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-97",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-97",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[denied]",
@@ -48590,7 +48590,7 @@
           "resolve": "Set `block_public_policy` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-96",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-96",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[denied]",
@@ -48651,7 +48651,7 @@
           "resolve": "Set `block_public_acls` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-95",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-95",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[allowed]",
@@ -48685,7 +48685,7 @@
           "resolve": "Set `restrict_public_buckets` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-98",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-98",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[allowed]",
@@ -48719,7 +48719,7 @@
           "resolve": "Set `ignore_public_acls` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-97",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-97",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[allowed]",
@@ -48780,7 +48780,7 @@
           "resolve": "Set `ignore_public_acls` attribute to `true`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-97",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-97",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[denied_2]",
@@ -48814,7 +48814,7 @@
           "resolve": "Set `restrict_public_buckets` attribute to `true`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-98",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-98",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[denied_2]",
@@ -48848,7 +48848,7 @@
           "resolve": "Set `block_public_policy` attribute to `true`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-96",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-96",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[denied_2]",
@@ -48882,7 +48882,7 @@
           "resolve": "Set `block_public_acls` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-95",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-95",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[denied]",
@@ -48916,7 +48916,7 @@
           "resolve": "Set `restrict_public_buckets` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-98",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-98",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[denied]",
@@ -48950,7 +48950,7 @@
           "resolve": "Set `block_public_acls` attribute to `true`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-95",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-95",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[denied_2]",
@@ -48984,7 +48984,7 @@
           "resolve": "Set `ignore_public_acls` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-97",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-97",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[denied]",
@@ -49018,7 +49018,7 @@
           "resolve": "Set `block_public_policy` attribute to `true`"
         },
         "lineNumber": 2,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-96",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-96",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[denied]",
@@ -49074,7 +49074,7 @@
           "resolve": "Set `server_side_encryption_configuration` block attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-4",
         "path": [
           "input",
           "resource",
@@ -49105,7 +49105,7 @@
           "resolve": "Add `logging` block attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-45",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-45",
         "path": [
           "input",
           "resource",
@@ -49134,7 +49134,7 @@
           "resolve": "Set `versioning.mfa_delete` attribute to `true`"
         },
         "lineNumber": 2,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-127",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-127",
         "path": [
           "resource",
           "aws_s3_bucket[allowed]",
@@ -49190,7 +49190,7 @@
           "resolve": "Set `versioning.mfa_delete` attribute to `true`"
         },
         "lineNumber": 9,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-127",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-127",
         "path": [
           "resource",
           "aws_s3_bucket[denied_3]",
@@ -49222,7 +49222,7 @@
           "resolve": "Add `logging` block attribute"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-45",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-45",
         "path": [
           "input",
           "resource",
@@ -49251,7 +49251,7 @@
           "resolve": "Set `versioning.mfa_delete` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-127",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-127",
         "path": [
           "resource",
           "aws_s3_bucket[denied]",
@@ -49283,7 +49283,7 @@
           "resolve": "Set `versioning.enabled` attribute to `true`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-124",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-124",
         "path": [
           "resource",
           "aws_s3_bucket[denied_2]",
@@ -49313,7 +49313,7 @@
           "resolve": "Set `server_side_encryption_configuration` block attribute"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-4",
         "path": [
           "input",
           "resource",
@@ -49344,7 +49344,7 @@
           "resolve": "Set `versioning.enabled` attribute to `true`"
         },
         "lineNumber": 10,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-124",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-124",
         "path": [
           "resource",
           "aws_s3_bucket[denied_3]",
@@ -49376,7 +49376,7 @@
           "resolve": "Add `logging` block attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-45",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-45",
         "path": [
           "input",
           "resource",
@@ -49406,7 +49406,7 @@
           "resolve": "Set `server_side_encryption_configuration` block attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-4",
         "path": [
           "input",
           "resource",
@@ -49437,7 +49437,7 @@
           "resolve": "Add `logging` block attribute"
         },
         "lineNumber": 8,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-45",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-45",
         "path": [
           "input",
           "resource",
@@ -49467,7 +49467,7 @@
           "resolve": "Set `server_side_encryption_configuration` block attribute"
         },
         "lineNumber": 8,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-4",
         "path": [
           "input",
           "resource",
@@ -49498,7 +49498,7 @@
           "resolve": "Set `versioning.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-124",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-124",
         "path": [
           "resource",
           "aws_s3_bucket[denied]",
@@ -49527,7 +49527,7 @@
           "resolve": "Set `versioning.mfa_delete` attribute to `true`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-127",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-127",
         "path": [
           "resource",
           "aws_s3_bucket[denied_2]",
@@ -49584,7 +49584,7 @@
           "resolve": "Set `server_side_encryption_configuration` block attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-4",
         "path": [
           "input",
           "resource",
@@ -49615,7 +49615,7 @@
           "resolve": "Add `logging` block attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-45",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-45",
         "path": [
           "input",
           "resource",
@@ -49647,7 +49647,7 @@
           "resolve": "Set `versioning.enabled` attribute to `true`"
         },
         "lineNumber": 2,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-124",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-124",
         "path": [
           "resource",
           "aws_s3_bucket[allowed]",
@@ -49703,7 +49703,7 @@
           "resolve": "Set `versioning.mfa_delete` attribute to `true`"
         },
         "lineNumber": 11,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-127",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-127",
         "path": [
           "resource",
           "aws_s3_bucket[denied_3]",
@@ -49735,7 +49735,7 @@
           "resolve": "Add `logging` block attribute"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-45",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-45",
         "path": [
           "input",
           "resource",
@@ -49764,7 +49764,7 @@
           "resolve": "Set `versioning.mfa_delete` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-127",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-127",
         "path": [
           "resource",
           "aws_s3_bucket[denied]",
@@ -49796,7 +49796,7 @@
           "resolve": "Set `versioning.enabled` attribute to `true`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-124",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-124",
         "path": [
           "resource",
           "aws_s3_bucket[denied_2]",
@@ -49826,7 +49826,7 @@
           "resolve": "Set `server_side_encryption_configuration` block attribute"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-4",
         "path": [
           "input",
           "resource",
@@ -49857,7 +49857,7 @@
           "resolve": "Set `versioning.enabled` attribute to `true`"
         },
         "lineNumber": 10,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-124",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-124",
         "path": [
           "resource",
           "aws_s3_bucket[denied_3]",
@@ -49889,7 +49889,7 @@
           "resolve": "Add `logging` block attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-45",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-45",
         "path": [
           "input",
           "resource",
@@ -49919,7 +49919,7 @@
           "resolve": "Set `server_side_encryption_configuration` block attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-4",
         "path": [
           "input",
           "resource",
@@ -49950,7 +49950,7 @@
           "resolve": "Add `logging` block attribute"
         },
         "lineNumber": 9,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-45",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-45",
         "path": [
           "input",
           "resource",
@@ -49980,7 +49980,7 @@
           "resolve": "Set `server_side_encryption_configuration` block attribute"
         },
         "lineNumber": 9,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-4",
         "path": [
           "input",
           "resource",
@@ -50011,7 +50011,7 @@
           "resolve": "Set `versioning.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-124",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-124",
         "path": [
           "resource",
           "aws_s3_bucket[denied]",
@@ -50040,7 +50040,7 @@
           "resolve": "Set `versioning.mfa_delete` attribute to `true`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-127",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-127",
         "path": [
           "resource",
           "aws_s3_bucket[denied_2]",
@@ -50102,7 +50102,7 @@
           "resolve": "Set `block_public_acls` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-95",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-95",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[allowed]",
@@ -50136,7 +50136,7 @@
           "resolve": "Set `block_public_policy` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-96",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-96",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[allowed]",
@@ -50170,7 +50170,7 @@
           "resolve": "Set `restrict_public_buckets` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-98",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-98",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[allowed]",
@@ -50231,7 +50231,7 @@
           "resolve": "Set `ignore_public_acls` attribute to `true`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-97",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-97",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[denied_2]",
@@ -50265,7 +50265,7 @@
           "resolve": "Set `restrict_public_buckets` attribute to `true`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-98",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-98",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[denied_2]",
@@ -50299,7 +50299,7 @@
           "resolve": "Set `block_public_policy` attribute to `true`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-96",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-96",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[denied_2]",
@@ -50333,7 +50333,7 @@
           "resolve": "Set `block_public_acls` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-95",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-95",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[denied]",
@@ -50367,7 +50367,7 @@
           "resolve": "Set `restrict_public_buckets` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-98",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-98",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[denied]",
@@ -50401,7 +50401,7 @@
           "resolve": "Set `block_public_acls` attribute to `true`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-95",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-95",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[denied_2]",
@@ -50435,7 +50435,7 @@
           "resolve": "Set `ignore_public_acls` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-97",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-97",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[denied]",
@@ -50469,7 +50469,7 @@
           "resolve": "Set `block_public_policy` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-96",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-96",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[denied]",
@@ -50530,7 +50530,7 @@
           "resolve": "Set `block_public_acls` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-95",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-95",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[allowed]",
@@ -50564,7 +50564,7 @@
           "resolve": "Set `block_public_policy` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-96",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-96",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[allowed]",
@@ -50598,7 +50598,7 @@
           "resolve": "Set `ignore_public_acls` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-97",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-97",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[allowed]",
@@ -50659,7 +50659,7 @@
           "resolve": "Set `ignore_public_acls` attribute to `true`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-97",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-97",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[denied_2]",
@@ -50693,7 +50693,7 @@
           "resolve": "Set `restrict_public_buckets` attribute to `true`"
         },
         "lineNumber": 5,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-98",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-98",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[denied_2]",
@@ -50727,7 +50727,7 @@
           "resolve": "Set `block_public_policy` attribute to `true`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-96",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-96",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[denied_2]",
@@ -50761,7 +50761,7 @@
           "resolve": "Set `block_public_acls` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-95",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-95",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[denied]",
@@ -50795,7 +50795,7 @@
           "resolve": "Set `restrict_public_buckets` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-98",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-98",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[denied]",
@@ -50829,7 +50829,7 @@
           "resolve": "Set `block_public_acls` attribute to `true`"
         },
         "lineNumber": 4,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-95",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-95",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[denied_2]",
@@ -50863,7 +50863,7 @@
           "resolve": "Set `ignore_public_acls` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-97",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-97",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[denied]",
@@ -50897,7 +50897,7 @@
           "resolve": "Set `block_public_policy` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-96",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-96",
         "path": [
           "resource",
           "aws_s3_bucket_public_access_block[denied]",
@@ -50955,7 +50955,7 @@
           "resolve": "Set `versioning.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-124",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-124",
         "path": [
           "resource",
           "aws_s3_bucket[logging]",
@@ -50985,7 +50985,7 @@
           "resolve": "Set `server_side_encryption_configuration` block attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-4",
         "path": [
           "input",
           "resource",
@@ -51013,7 +51013,7 @@
           "resolve": "Set `versioning.mfa_delete` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-127",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-127",
         "path": [
           "resource",
           "aws_s3_bucket[logging]",
@@ -51072,7 +51072,7 @@
           "resolve": "Set `versioning.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-124",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-124",
         "path": [
           "resource",
           "aws_s3_bucket[no_logging]",
@@ -51102,7 +51102,7 @@
           "resolve": "Set `server_side_encryption_configuration` block attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-4",
         "path": [
           "input",
           "resource",
@@ -51130,7 +51130,7 @@
           "resolve": "Set `versioning.mfa_delete` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-127",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-127",
         "path": [
           "resource",
           "aws_s3_bucket[no_logging]",
@@ -51162,7 +51162,7 @@
           "resolve": "Add `logging` block attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-45",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-45",
         "path": [
           "input",
           "resource",
@@ -51219,7 +51219,7 @@
           "resolve": "Set `server_side_encryption_configuration` block attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-4",
         "path": [
           "input",
           "resource",
@@ -51250,7 +51250,7 @@
           "resolve": "Set `acl` attribute to `private`, or remove the attribute"
         },
         "lineNumber": 8,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-18",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-18",
         "path": [
           "input",
           "resource",
@@ -51282,7 +51282,7 @@
           "resolve": "Add `logging` block attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-45",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-45",
         "path": [
           "input",
           "resource",
@@ -51314,7 +51314,7 @@
           "resolve": "Set the `acl` attribute to `private`, or remove the attribute"
         },
         "lineNumber": 3,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-19",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-19",
         "path": [
           "input",
           "resource",
@@ -51346,7 +51346,7 @@
           "resolve": "Set `versioning.enabled` attribute to `true`"
         },
         "lineNumber": 6,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-124",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-124",
         "path": [
           "resource",
           "aws_s3_bucket[readable]",
@@ -51378,7 +51378,7 @@
           "resolve": "Set `versioning.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-124",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-124",
         "path": [
           "resource",
           "aws_s3_bucket[writable]",
@@ -51408,7 +51408,7 @@
           "resolve": "Set `server_side_encryption_configuration` block attribute"
         },
         "lineNumber": 6,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-4",
         "path": [
           "input",
           "resource",
@@ -51439,7 +51439,7 @@
           "resolve": "Add `logging` block attribute"
         },
         "lineNumber": 6,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-45",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-45",
         "path": [
           "input",
           "resource",
@@ -51468,7 +51468,7 @@
           "resolve": "Set `versioning.mfa_delete` attribute to `true`"
         },
         "lineNumber": 6,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-127",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-127",
         "path": [
           "resource",
           "aws_s3_bucket[readable]",
@@ -51497,7 +51497,7 @@
           "resolve": "Set `versioning.mfa_delete` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-127",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-127",
         "path": [
           "resource",
           "aws_s3_bucket[writable]",
@@ -51553,7 +51553,7 @@
           "resolve": "Set `versioning.mfa_delete` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-127",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-127",
         "path": [
           "resource",
           "aws_s3_bucket[without_server_side_encryption_configuration]",
@@ -51585,7 +51585,7 @@
           "resolve": "Add `logging` block attribute"
         },
         "lineNumber": 33,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-45",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-45",
         "path": [
           "input",
           "resource",
@@ -51614,7 +51614,7 @@
           "resolve": "Set `versioning.mfa_delete` attribute to `true`"
         },
         "lineNumber": 17,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-127",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-127",
         "path": [
           "resource",
           "aws_s3_bucket[without_rule]",
@@ -51646,7 +51646,7 @@
           "resolve": "Add `logging` block attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-45",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-45",
         "path": [
           "input",
           "resource",
@@ -51678,7 +51678,7 @@
           "resolve": "Set `versioning.enabled` attribute to `true`"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-124",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-124",
         "path": [
           "resource",
           "aws_s3_bucket[without_server_side_encryption_configuration]",
@@ -51708,7 +51708,7 @@
           "resolve": "Set `server_side_encryption_configuration` block attribute"
         },
         "lineNumber": 1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-4",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-4",
         "path": [
           "input",
           "resource",
@@ -51739,7 +51739,7 @@
           "resolve": "Set `versioning.enabled` attribute to `true`"
         },
         "lineNumber": 24,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-124",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-124",
         "path": [
           "resource",
           "aws_s3_bucket[without_apply_server_side_encryption_by_default]",
@@ -51771,7 +51771,7 @@
           "resolve": "Add `logging` block attribute"
         },
         "lineNumber": 17,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-45",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-45",
         "path": [
           "input",
           "resource",
@@ -51803,7 +51803,7 @@
           "resolve": "Set `versioning.enabled` attribute to `true`"
         },
         "lineNumber": 33,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-124",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-124",
         "path": [
           "resource",
           "aws_s3_bucket[without_sse_algorithm]",
@@ -51835,7 +51835,7 @@
           "resolve": "Add `logging` block attribute"
         },
         "lineNumber": 24,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-45",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-45",
         "path": [
           "input",
           "resource",
@@ -51867,7 +51867,7 @@
           "resolve": "Set `versioning.enabled` attribute to `true`"
         },
         "lineNumber": 17,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-124",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-124",
         "path": [
           "resource",
           "aws_s3_bucket[without_rule]",
@@ -51897,7 +51897,7 @@
           "resolve": "Set `enable_key_rotation` attribute to `true`"
         },
         "lineNumber": 12,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-14",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-14",
         "path": [
           "input",
           "resource",
@@ -51926,7 +51926,7 @@
           "resolve": "Set `versioning.mfa_delete` attribute to `true`"
         },
         "lineNumber": 33,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-127",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-127",
         "path": [
           "resource",
           "aws_s3_bucket[without_sse_algorithm]",
@@ -51955,7 +51955,7 @@
           "resolve": "Set `versioning.mfa_delete` attribute to `true`"
         },
         "lineNumber": 24,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-127",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-127",
         "path": [
           "resource",
           "aws_s3_bucket[without_apply_server_side_encryption_by_default]",
@@ -52008,7 +52008,7 @@
           "resolve": "Updating the `cidr_block` attribute with a more restrictive IP range or a specific IP address to ensure traffic can only reach known destinations. "
         },
         "lineNumber": 15,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-6",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-6",
         "path": [
           "input",
           "resource",
@@ -52034,7 +52034,7 @@
           "resolve": "Updating the `cidr_block` attribute with a more restrictive IP range or a specific IP address to ensure traffic can only come from known sources. "
         },
         "lineNumber": 8,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-5",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-5",
         "path": [
           "input",
           "resource",
@@ -52093,7 +52093,7 @@
           "resolve": "Set `cidr_block` attribute with a more restrictive IP, for example `192.16.0.0/24`"
         },
         "lineNumber": 6,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-1",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-1",
         "path": [
           "input",
           "resource",
@@ -52152,7 +52152,7 @@
           "resolve": "Set `cidr_block` attribute with a more restrictive IP, for example `192.16.0.0/24`"
         },
         "lineNumber": 6,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-1",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-1",
         "path": [
           "input",
           "resource",
@@ -52211,7 +52211,7 @@
           "resolve": "Set `cidr_block` attribute with a more restrictive IP, for example `192.16.0.0/24`"
         },
         "lineNumber": 6,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-1",
+        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-1",
         "path": [
           "input",
           "resource",


### PR DESCRIPTION
### Description

Updating all URLs for IaC rules from https://snyk.io/security-rules to https://security.snyk.io/rules/cloud/, as all the rules are now hosted there. The old site is deprecated, and everything is redirected already to the new one.