### PR TITLE
chore: adds SCA monitoring to CICD

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,10 +59,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Snyk
-        run: |
-          curl --compressed https://static.snyk.io/cli/latest/snyk-linux -o snyk
-          sudo chmod +x ./snyk
-          sudo mv ./snyk /usr/bin/
+        uses: snyk/actions/setup@0.4.0
 
       - name: Snyk Monitor SCA
         run: snyk monitor --all-projects --exclude=integTest --org=${{ vars.PLATFORM_HAMMERHEAD_ORG_ID }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,25 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
           SNYK_ORG_NAME: ${{ secrets.SNYK_ORG_NAME }}
 
+  snyk:
+    name: Snyk Tests
+    needs: gradleValidation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Sources
+        uses: actions/checkout@v2
+
+      - name: Install Snyk
+        run: |
+          curl --compressed https://static.snyk.io/cli/latest/snyk-linux -o snyk
+          sudo chmod +x ./snyk
+          sudo mv ./snyk /usr/bin/
+
+      - name: Snyk Monitor SCA
+        run: snyk monitor --all-projects --exclude=integTest --org=${{ vars.PLATFORM_HAMMERHEAD_ORG_ID }}
+        env:
+          SNYK_TOKEN: ${{ secrets.HAMMERHEAD_SNYK_INTELLIJ_PLUGIN_TOKEN }}
+
   pluginVerifier:
     name: Plugin Verifier
     needs: gradleValidation


### PR DESCRIPTION
### Description

_As part of the Snyk on Snyk initiative, we should add SCA monitoring to our CICD._

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

Output
```
Run snyk monitor --all-projects --exclude=integTest --org=7d7ab703-3630-4b46-afed-bad53a655ca3
  snyk monitor --all-projects --exclude=integTest --org=7d7ab703-3630-4b46-afed-bad53a655ca3
  shell: /usr/bin/bash -e {0}
  env:
    SNYK_TOKEN: ***

Monitoring /home/runner/work/snyk-intellij-plugin/snyk-intellij-plugin (snyk-intellij-plugin)...

Explore this snapshot at https://app.snyk.io/org/platform_hammerhead/project/4615ba08-519d-477a-9117-94d34d3fecd3/history/9e0e503e-5ab9-4918-9d13-b48505[2](https://github.com/snyk/snyk-intellij-plugin/actions/runs/5831859368/job/15816127239#step:4:2)20[7](https://github.com/snyk/snyk-intellij-plugin/actions/runs/5831859368/job/15816127239#step:4:8)70

Notifications about newly disclosed issues related to these dependencies will be emailed to you.
```
