### PR TITLE
fix: stalled org display name

### DIFF
--- a/src/main/kotlin/io/snyk/plugin/snykcode/core/SnykCodeParams.kt
+++ b/src/main/kotlin/io/snyk/plugin/snykcode/core/SnykCodeParams.kt
@@ -25,6 +25,12 @@ class SnykCodeParams private constructor() : DeepCodeParamsBase(
 
     override fun setConsentGiven(project: Any) = Unit
 
+    // This is needed because when an org changes via plugin settings,
+    // `DeepCodeParamsBase.getOrgDisplayName` is referring to a stalled value
+    override fun getOrgDisplayName(): String? {
+        return pluginSettings().organization
+    }
+
     companion object {
         val instance = SnykCodeParams()
     }


### PR DESCRIPTION
Fixes stalled org display name for Snyk Code. Related to [this](https://snyk.slack.com/archives/C04ERK5JXL6/p1694617480680969) Slack thread

**The problem**:

I did a SAST scan with org `pulsar`, and then I did another scan with org `shirtesting`.  Logs in DataDog ([src](https://app.datadoghq.com/logs?query=service:sast-analysis-api%20AND%20@analysisContext.flow:%22Snyk%20Code-Jetbrains%22%20@analysisContext.org.name:%22scle-prod-cluster%22%20OR%20@analysisContext.org.name:%22pulsar%22%20OR%20@analysisContext.org.name:%22shirtesting%22%20&cols=host,service,@analysisContext.flow,@analysisContext.org.name&index=*&messageDisplay=inline&stream_sort=desc&viz=stream&from_ts=1694660337859&to_ts=1694674737859&live=true)) was showing org `pulsar` for both analysis, despite making sure the last test I did was with `shirtesting` org.

With the change in this PR, on each SAST scan, the org name reflects the one in plugin settings.