### PR TITLE
feat: download arm64 CLI on M1/M2 macs, allow baseURL configuration [HEAD-867]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Snyk Changelog
 
+## [2.5.4]
+
+### Added
+
+- support for arm64 CLI on macOS
+- support to configure base URL for CLI downloads
+
 ## [2.5.3]
 
 ### Fixed

--- a/src/main/kotlin/io/snyk/plugin/cli/Platform.kt
+++ b/src/main/kotlin/io/snyk/plugin/cli/Platform.kt
@@ -9,23 +9,24 @@ class Platform(val snykWrapperFileName: String) {
         val LINUX = Platform("snyk-linux")
         val LINUX_ALPINE = Platform("snyk-alpine")
         val MAC_OS = Platform("snyk-macos")
+        val MAC_OS_ARM64 = Platform("snyk-macos-arm64")
         val WINDOWS = Platform("snyk-win.exe")
 
         @Throws(PlatformDetectionException::class)
         fun current(): Platform = detect(System.getProperties())
 
-        @Suppress("MoveVariableDeclarationIntoWhen")
         @Throws(PlatformDetectionException::class)
         fun detect(systemProperties: Properties): Platform {
-            val architectureName = (systemProperties["os.name"] as String).lowercase()
-            return when (architectureName) {
+            val osName = (systemProperties["os.name"] as String).lowercase()
+            val archName = (systemProperties["os.arch"] as String).lowercase()
+            return when (osName) {
                 "linux" -> if (Paths.get("/etc/alpine-release").toFile().exists()) LINUX_ALPINE else LINUX
-                "mac os x", "darwin", "osx" -> MAC_OS
+                "mac os x", "darwin", "osx" -> if (archName != "aarch64") MAC_OS else MAC_OS_ARM64
                 else -> {
-                    if (architectureName.contains("windows")) {
+                    if (osName.contains("windows")) {
                         WINDOWS
                     } else {
-                        throw PlatformDetectionException("$architectureName is not supported CPU type")
+                        throw PlatformDetectionException("$osName is not supported CPU type")
                     }
                 }
             }

--- a/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
@@ -27,6 +27,7 @@ import java.util.UUID
 )
 class SnykApplicationSettingsStateService : PersistentStateComponent<SnykApplicationSettingsStateService> {
 
+    var cliBaseDownloadURL: String = "https://static.snyk.io"
     var cliPath: String = getPluginPath() + separator + Platform.current().snykWrapperFileName
     var manageBinariesAutomatically: Boolean = true
     var fileListenerEnabled: Boolean = true

--- a/src/main/kotlin/io/snyk/plugin/services/download/CliDownloader.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/download/CliDownloader.kt
@@ -2,6 +2,7 @@ package io.snyk.plugin.services.download
 
 import com.intellij.openapi.progress.ProgressIndicator
 import io.snyk.plugin.cli.Platform
+import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.services.download.HttpRequestHelper.createRequest
 import java.io.File
 import java.nio.file.AtomicMoveNotSupportedException
@@ -13,10 +14,14 @@ import javax.xml.bind.DatatypeConverter
 
 class CliDownloader {
     companion object {
-        const val BASE_URL = "https://static.snyk.io"
-        const val LATEST_RELEASES_URL = "$BASE_URL/cli/latest/version"
-        val LATEST_RELEASE_DOWNLOAD_URL = "$BASE_URL/cli/latest/${Platform.current().snykWrapperFileName}"
-        val SHA256_DOWNLOAD_URL = "$BASE_URL/cli/latest/${Platform.current().snykWrapperFileName}.sha256"
+        val BASE_URL: String
+            get() = pluginSettings().cliBaseDownloadURL
+        val LATEST_RELEASES_URL: String
+            get() = "$BASE_URL/cli/latest/version"
+        val LATEST_RELEASE_DOWNLOAD_URL: String
+            get() = "$BASE_URL/cli/latest/${Platform.current().snykWrapperFileName}"
+        val SHA256_DOWNLOAD_URL: String
+            get() = "$BASE_URL/cli/latest/${Platform.current().snykWrapperFileName}.sha256"
     }
 
     fun calculateSha256(bytes: ByteArray): String {

--- a/src/main/kotlin/io/snyk/plugin/settings/SnykProjectSettingsConfigurable.kt
+++ b/src/main/kotlin/io/snyk/plugin/settings/SnykProjectSettingsConfigurable.kt
@@ -45,7 +45,8 @@ class SnykProjectSettingsConfigurable(val project: Project) : SearchableConfigur
         snykSettingsDialog.isScanTypeChanged() ||
         snykSettingsDialog.isSeverityEnablementChanged() ||
         snykSettingsDialog.manageBinariesAutomatically() != settingsStateService.manageBinariesAutomatically ||
-        snykSettingsDialog.getCliPath() != settingsStateService.cliPath
+        snykSettingsDialog.getCliPath() != settingsStateService.cliPath ||
+        snykSettingsDialog.getCliBaseDownloadURL() != settingsStateService.cliBaseDownloadURL
 
     private fun isCoreParamsModified() = isTokenModified() ||
         isCustomEndpointModified() ||
@@ -83,6 +84,7 @@ class SnykProjectSettingsConfigurable(val project: Project) : SearchableConfigur
 
         settingsStateService.manageBinariesAutomatically = snykSettingsDialog.manageBinariesAutomatically()
         settingsStateService.cliPath = snykSettingsDialog.getCliPath().trim()
+        settingsStateService.cliBaseDownloadURL = snykSettingsDialog.getCliBaseDownloadURL().trim()
 
         snykSettingsDialog.saveScanTypeChanges()
         snykSettingsDialog.saveSeveritiesEnablementChanges()

--- a/src/main/kotlin/io/snyk/plugin/ui/SnykSettingsDialog.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/SnykSettingsDialog.kt
@@ -78,6 +78,7 @@ class SnykSettingsDialog(
 
     private val manageBinariesAutomatically: JCheckBox = JCheckBox()
     private val cliPathTextBoxWithFileBrowser = TextFieldWithBrowseButton()
+    private val cliBaseDownloadUrlTextField = JTextField()
 
     private val logger = Logger.getInstance(this::class.java)
 
@@ -126,6 +127,7 @@ class SnykSettingsDialog(
             manageBinariesAutomatically.isSelected = applicationSettings.manageBinariesAutomatically
 
             cliPathTextBoxWithFileBrowser.text = applicationSettings.cliPath
+            cliBaseDownloadUrlTextField.text = applicationSettings.cliBaseDownloadURL
             additionalParametersTextField.text = applicationSettings.getAdditionalParameters(project)
         }
     }
@@ -463,6 +465,15 @@ class SnykSettingsDialog(
             )
         )
 
+        cliBaseDownloadUrlTextField.toolTipText = "The default URL is https://static.snyk.io. " +
+            "for FIPS-enabled CLIs (only available for Windows and Linux), please use https://static.snyk.io/fips"
+        executableSettingsPanel.add(
+            UI.PanelFactory
+                .panel(cliBaseDownloadUrlTextField)
+                .withLabel("Base URL to download the CLI: ").createPanel(),
+            gb.nextLine()
+        )
+
         cliPathTextBoxWithFileBrowser.toolTipText = "The default path is ${getCliFile().canonicalPath}."
         val descriptor = FileChooserDescriptor(true, false, false, false, false, false)
         cliPathTextBoxWithFileBrowser.addBrowseFolderListener(
@@ -564,4 +575,5 @@ class SnykSettingsDialog(
 
     fun getCliPath(): String = cliPathTextBoxWithFileBrowser.text
     fun manageBinariesAutomatically() = manageBinariesAutomatically.isSelected
+    fun getCliBaseDownloadURL(): String = cliBaseDownloadUrlTextField.text
 }

--- a/src/test/kotlin/io/snyk/plugin/cli/PlatformTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/cli/PlatformTest.kt
@@ -2,7 +2,7 @@ package io.snyk.plugin.cli
 
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import java.util.*
+import java.util.Properties
 
 class PlatformTest {
 
@@ -20,6 +20,10 @@ class PlatformTest {
 
         properties["os.name"] = "darwin"
         assertTrue(Platform.MAC_OS == Platform.detect(properties))
+
+        properties["os.name"] = "darwin"
+        properties["os.arch"] = "aarch64"
+        assertTrue(Platform.MAC_OS_ARM64 == Platform.detect(properties))
 
         properties["os.name"] = "osx"
         assertTrue(Platform.MAC_OS == Platform.detect(properties))


### PR DESCRIPTION
### Description

This PR adds the new arm64 binary for the CLI download. Also, it allows to add the baseURL to download the CLI from, to faciliate usage of FIPS enabled binaries, or locally provided CLIs.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
