### PR TITLE
fix: update dependencies to address exception when itly loads slf4j [HEAD-883]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Snyk Changelog
 
+## [2.5.5]
+
+### Fixed
+- Exception occurring due to a dependency conflict
+- Add a requestID to all Snyk Code requests for better error analysis
+
 ## [2.5.4]
 
 ### Added

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,14 +40,16 @@ dependencies {
     implementation("com.squareup.okhttp3:logging-interceptor")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.12.7.1")
     implementation("org.json:json:20230227")
+    implementation("org.slf4j:slf4j-api:2.0.5")
     implementation("ly.iterative.itly:plugin-iteratively:1.2.11") {
         exclude(group = "com.fasterxml.jackson.core")
     }
-    implementation("ly.iterative.itly:plugin-schema-validator:1.2.11")
+    implementation("ly.iterative.itly:plugin-schema-validator:1.2.11") {
+        exclude(group = "org.slf4j")
+    }
     implementation("ly.iterative.itly:sdk-jvm:1.2.11") {
         exclude(group = "org.json")
     }
-    implementation("com.segment.analytics.java:analytics:3.4.0")
 
     testImplementation("com.google.jimfs:jimfs:1.3.0")
     testImplementation("com.squareup.okhttp3:mockwebserver")


### PR DESCRIPTION
### Description

Originally, I wanted to update the itly sdk to use amplitude sdk. Unfortunately, there does not seem to be an amplitude JVM sdk, the only one applicable would be the Android one, which is not compatible with non Android clients, it seems.

So I:

- excluded org.slf4j from the plugin verifier dependency of Itly
- defined a non-conflicting version 2.0.5 of org.slf4j.slf4j-api as implementation dependency, which should add it to the right classloaders.

This should fix the following exception:
```
java.lang.LinkageError: loader constraint violation: when resolving method 'org.slf4j.ILoggerFactory org.slf4j.impl.StaticLoggerBinder.getLoggerFactory()' the class loader com.intellij.ide.plugins.cl.PluginClassLoader @3a1e0dd7 of the current class, org/slf4j/LoggerFactory, and the class loader com.intellij.ide.plugins.cl.PluginClassLoader @5ac37318 for the method's defining class, org/slf4j/impl/StaticLoggerBinder, have different Class objects for the type org/slf4j/ILoggerFactory used in the signature (org.slf4j.LoggerFactory is in unnamed module of loader com.intellij.ide.plugins.cl.PluginClassLoader @3a1e0dd7, parent loader 'bootstrap'; org.slf4j.impl.StaticLoggerBinder is in unnamed module of loader com.intellij.ide.plugins.cl.PluginClassLoader @5ac37318, parent loader 'bootstrap')
	at org.slf4j.LoggerFactory.getILoggerFactory(LoggerFactory.java:423)
	at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:362)
	at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:388)
	at com.networknt.schema.JsonSchemaFactory.<clinit>(JsonSchemaFactory.java:39)
	at ly.iterative.itly.SchemaValidatorPlugin.load(SchemaValidatorPlugin.kt:24)
	at ly.iterative.itly.core.Itly$load$2.invoke(Itly.kt:62)
	at ly.iterative.itly.core.Itly$load$2.invoke(Itly.kt:6)
	at ly.iterative.itly.core.Itly.runOnAllPlugins(Itly.kt:160)
	at ly.iterative.itly.core.Itly.runOnAllPlugins$default(Itly.kt:157)
	at ly.iterative.itly.core.Itly.load(Itly.kt:62)
	at ly.iterative.itly.core.Itly.load(Itly.kt:34)
	at snyk.analytics.Itly.load(Itly.java:71)
	at io.snyk.plugin.analytics.Iteratively.<clinit>(Iteratively.kt:43)
	at io.snyk.plugin.services.SnykAnalyticsService.<init>(SnykAnalyticsService.kt:32)
	at com.intellij.serviceContainer.ComponentManagerImpl.doInstantiateClass(ComponentManagerImpl.kt:962)
	... 20 more
```

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
