### PR TITLE
feat: adjust to changed analytics interface [HEAD-921]

### DIFF
--- a/src/main/kotlin/io/snyk/plugin/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/Utils.kt
@@ -384,7 +384,7 @@ fun getOS(): String {
         "lin" to "linux"
     )
     val osName = SystemUtils.OS_NAME.toString().lowercase().substring(0, END_INDEX_FOR_OS_MATCHING)
-    return osMap[osName] ?: "unknown"
+    return osMap[osName] ?: osName
 }
 
 fun getArch(): String {
@@ -397,5 +397,5 @@ fun getArch(): String {
         "x8632" to "386",
         "386" to "386",
     )
-    return archMap[value] ?: "unknown"
+    return archMap[value] ?: value
 }

--- a/src/main/kotlin/io/snyk/plugin/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/Utils.kt
@@ -39,6 +39,7 @@ import io.snyk.plugin.snykcode.core.RunUtils
 import io.snyk.plugin.ui.SnykBalloonNotificationHelper
 import io.snyk.plugin.ui.toolwindow.SnykToolWindowFactory
 import io.snyk.plugin.ui.toolwindow.SnykToolWindowPanel
+import org.apache.commons.lang.SystemUtils
 import snyk.advisor.AdvisorService
 import snyk.advisor.AdvisorServiceImpl
 import snyk.advisor.SnykAdvisorModel
@@ -373,3 +374,28 @@ fun VirtualFile.contentRoot(project: Project): VirtualFile? {
 fun PsiFile.contentRoot(project: Project) = this.virtualFile.contentRoot(project)
 fun PsiFile.relativePathToContentRoot(project: Project): Path? =
     this.contentRoot(project)?.toNioPath()?.relativize(this.virtualFile.toNioPath())
+
+private const val END_INDEX_FOR_OS_MATCHING = 3
+
+fun getOS(): String {
+    val osMap = mapOf(
+        "mac" to "macOS",
+        "win" to "windows",
+        "lin" to "linux"
+    )
+    val osName = SystemUtils.OS_NAME.toString().lowercase().substring(0, END_INDEX_FOR_OS_MATCHING)
+    return osMap[osName] ?: "unknown"
+}
+
+fun getArch(): String {
+    val value: String = SystemUtils.OS_ARCH.toString().lowercase()
+    val archMap = mapOf(
+        "x8664" to "x86_64",
+        "amd64" to "x86_64",
+        "arm64" to "arm64",
+        "aarch64" to "arm64",
+        "x8632" to "386",
+        "386" to "386",
+    )
+    return archMap[value] ?: "unknown"
+}

--- a/src/main/kotlin/snyk/common/lsp/commands/ScanDoneEvent.kt
+++ b/src/main/kotlin/snyk/common/lsp/commands/ScanDoneEvent.kt
@@ -1,8 +1,9 @@
 package snyk.common.lsp.commands
 
 import com.google.gson.annotations.SerializedName
+import io.snyk.plugin.getArch
+import io.snyk.plugin.getOS
 import io.snyk.plugin.pluginSettings
-import org.apache.commons.lang.SystemUtils
 import snyk.pluginInfo
 import java.time.ZonedDateTime
 
@@ -15,23 +16,40 @@ data class ScanDoneEvent(
     )
 
     data class Attributes(
-        @SerializedName("deviceId") val deviceId: String = pluginSettings().userAnonymousId,
+        @SerializedName("device_id") val deviceId: String = pluginSettings().userAnonymousId,
         @SerializedName("application") val application: String = pluginInfo.integrationEnvironment,
         @SerializedName("application_version")
         val applicationVersion: String = pluginInfo.integrationEnvironmentVersion,
-        @SerializedName("os") val os: String = SystemUtils.OS_NAME,
-        @SerializedName("arch") val arch: String = SystemUtils.OS_ARCH,
-        @SerializedName("integration_name") val integrationName: String = pluginInfo.integrationName,
-        @SerializedName("integration_version") val integrationVersion: String = pluginInfo.integrationVersion,
+        @SerializedName("os") val os: String = getOS(),
+        @SerializedName("arch") val arch: String = getArch(),
+
+        @SerializedName("integration_name")
+        val integrationName: String = pluginInfo.integrationName,
+
+        @SerializedName("integration_version")
+        val integrationVersion: String = pluginInfo.integrationVersion,
+
         @SerializedName("integration_environment")
         val integrationEnvironment: String = pluginInfo.integrationEnvironment,
+
         @SerializedName("integration_environment_version")
         val integrationEnvironmentVersion: String = pluginInfo.integrationEnvironmentVersion,
-        @SerializedName("event_type") val eventType: String = "Scan done",
-        @SerializedName("status") val status: String = "Succeeded",
-        @SerializedName("scan_type") val scanType: String,
-        @SerializedName("unique_issue_count") val uniqueIssueCount: UniqueIssueCount,
-        @SerializedName("duration_ms") val durationMs: String,
+
+        @SerializedName("event_type")
+        val eventType: String = "Scan done",
+
+        @SerializedName("status")
+        val status: String = "Succeeded",
+
+        @SerializedName("scan_type")
+        val scanType: String,
+
+        @SerializedName("unique_issue_count")
+        val uniqueIssueCount: UniqueIssueCount,
+
+        @SerializedName("duration_ms")
+        val durationMs: String,
+
         @SerializedName("timestamp_finished")
         val timestampFinished: String = ZonedDateTime.now().withZoneSameInstant(java.time.ZoneOffset.UTC).toString()
     )

--- a/src/test/kotlin/io/snyk/plugin/analytics/AnalyticsScanListenerTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/analytics/AnalyticsScanListenerTest.kt
@@ -6,12 +6,13 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.verify
+import io.snyk.plugin.getArch
+import io.snyk.plugin.getOS
 import io.snyk.plugin.getSnykTaskQueueService
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.services.SnykApplicationSettingsStateService
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertNotNull
-import org.apache.commons.lang.SystemUtils
 import org.eclipse.lsp4j.ExecuteCommandParams
 import org.eclipse.lsp4j.services.LanguageServer
 import org.junit.After
@@ -67,8 +68,8 @@ class AnalyticsScanListenerTest {
         assertEquals("2020.3.2", scanDoneEvent.data.attributes.applicationVersion)
         assertEquals("IntelliJ IDEA", scanDoneEvent.data.attributes.integrationEnvironment)
         assertEquals("2020.3.2", scanDoneEvent.data.attributes.integrationEnvironmentVersion)
-        assertEquals(SystemUtils.OS_NAME, scanDoneEvent.data.attributes.os)
-        assertEquals(SystemUtils.OS_ARCH, scanDoneEvent.data.attributes.arch)
+        assertEquals(getOS(), scanDoneEvent.data.attributes.os)
+        assertEquals(getArch(), scanDoneEvent.data.attributes.arch)
 
         assertEquals("analytics", scanDoneEvent.data.type)
         assertEquals("Scan done", scanDoneEvent.data.attributes.eventType)


### PR DESCRIPTION
### Description

This PR changes the client side of the analytics to:
- change `deviceId` to `device_id`
- sync os and arch values to the ones used in LS and in VS

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
