### PR TITLE
fix: don't use extension function from kotlin intellij lib

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,4 +11,4 @@ workflows:
           name: Scan repository for secrets
           context:
             - snyk-bot-slack
-          channel: hammerhead-alerts
+          channel: dx-local-alerts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 # Snyk Changelog
+
+## [2.6.1]
+### Fixed
+- don't use kotlin library on non-kotlin IDEs
+
+## [2.6.0]
+### Fixed
+- fix threading and UI incompatibilities with 2023.3
+
 ## [2.5.8]
 ### Added
 - support for IntelliJ 2023.3 platform

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -4,8 +4,8 @@ metadata:
   name: snyk-intellij-plugin
   annotations:
     github.com/project-slug: snyk/snyk-intellij-plugin
-    github.com/team-slug: snyk/hammerhead
+    github.com/team-slug: snyk/ide
 spec:
   type: ide-plugin
   lifecycle: "-"
-  owner: hammerhead
+  owner: ide

--- a/src/main/kotlin/io/snyk/plugin/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/Utils.kt
@@ -399,3 +399,7 @@ fun getArch(): String {
     )
     return archMap[value] ?: value
 }
+
+fun VirtualFile.toPsiFile(project: Project): PsiFile? {
+    return PsiManager.getInstance(project).findFile(this)
+}

--- a/src/main/kotlin/io/snyk/plugin/snykcode/core/SnykCodeFile.kt
+++ b/src/main/kotlin/io/snyk/plugin/snykcode/core/SnykCodeFile.kt
@@ -4,7 +4,7 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Iconable
 import com.intellij.openapi.vfs.VirtualFile
-import org.jetbrains.kotlin.idea.core.util.toPsiFile
+import io.snyk.plugin.toPsiFile
 import snyk.common.RelativePathHelper
 import javax.swing.Icon
 


### PR DESCRIPTION
### Description

The Kotlin library is not available on all Jetbrains IDEs, e.g. in PyCharm or Goland. This results in ClassNotFoundExceptions when using (extension) functions that are provided there.

Previously, we by accident referenced an extension function provided by the Kotlin library. This commit fixes this by defining a similar extension function `virtualFile.toPsiFile(project)` in the plugin code using `PsiManager.getInstance(project).findFile(virtualFile)`.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
