### PR TITLE
fix: CLI update & download [IDE-123][IDE-124]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Snyk Changelog
 
+## [2.7.1]
+### Fixed
+- only start up language server after CLI update (fixes lock error on Windows)
+- only start up one instance of language server, manage projects via workspace folders
+
 ## [2.7.0]
 ### Added
 - Snyk controller extension point

--- a/src/main/kotlin/io/snyk/plugin/SnykPostStartupActivity.kt
+++ b/src/main/kotlin/io/snyk/plugin/SnykPostStartupActivity.kt
@@ -46,6 +46,7 @@ class SnykPostStartupActivity : ProjectActivity {
     private var listenersActivated = false
     val settings = pluginSettings()
 
+    @Suppress("TooGenericExceptionCaught")
     override suspend fun execute(project: Project) {
         PluginInstaller.addStateListener(UninstallListener())
 

--- a/src/main/kotlin/io/snyk/plugin/SnykPostStartupActivity.kt
+++ b/src/main/kotlin/io/snyk/plugin/SnykPostStartupActivity.kt
@@ -4,6 +4,7 @@ import com.intellij.ide.plugins.IdeaPluginDescriptor
 import com.intellij.ide.plugins.PluginInstaller
 import com.intellij.ide.plugins.PluginStateListener
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.extensions.ExtensionPointName
 import com.intellij.openapi.progress.EmptyProgressIndicator
@@ -83,9 +84,8 @@ class SnykPostStartupActivity : ProjectActivity {
             try {
                 getSnykTaskQueueService(project)?.connectProjectToLanguageServer(project)
                 getAnalyticsScanListener(project)?.initScanListener()
-            } catch (ignored: Exception) {
-                // do nothing to not break UX for analytics
-                ignored.printStackTrace()
+            } catch (e: Exception) {
+                Logger.getInstance(SnykPostStartupActivity::class.java).error(e)
             }
         }
 

--- a/src/main/kotlin/io/snyk/plugin/SnykProjectManagerListener.kt
+++ b/src/main/kotlin/io/snyk/plugin/SnykProjectManagerListener.kt
@@ -2,19 +2,18 @@ package io.snyk.plugin
 
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManagerListener
-import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.serviceContainer.AlreadyDisposedException
 import io.snyk.plugin.services.SnykTaskQueueService
 import io.snyk.plugin.snykcode.core.AnalysisData
 import io.snyk.plugin.snykcode.core.RunUtils
 import io.snyk.plugin.snykcode.core.SnykCodeIgnoreInfoHolder
-import org.eclipse.lsp4j.WorkspaceFolder
 
 class SnykProjectManagerListener : ProjectManagerListener {
 
     override fun projectClosing(project: Project) {
         RunUtils.instance.runInBackground(
-            project, "Project closing: " + project.name
+            project,
+            "Project closing: " + project.name
         ) {
             // lets all running ProgressIndicators release MUTEX first
             RunUtils.instance.cancelRunningIndicators(project)
@@ -24,11 +23,12 @@ class SnykProjectManagerListener : ProjectManagerListener {
 
         // doesn't need to run in the background, as the called update is already running in a background thread
         if (SnykTaskQueueService.ls.isInitialized) {
-            val removedWorkspaceFolders = ProjectRootManager.getInstance(project).contentRoots
-                .mapNotNull { WorkspaceFolder(it.url, it.name) }
-                .toCollection(mutableListOf())
             try {
-                SnykTaskQueueService.ls.updateWorkspaceFolders(project, emptyList(), removedWorkspaceFolders)
+                SnykTaskQueueService.ls.updateWorkspaceFolders(
+                    project,
+                    emptySet(),
+                    SnykTaskQueueService.ls.getWorkspaceFolders(project)
+                )
             } catch (ignore: AlreadyDisposedException) {
                 // ignore
             }

--- a/src/main/kotlin/io/snyk/plugin/SnykProjectManagerListener.kt
+++ b/src/main/kotlin/io/snyk/plugin/SnykProjectManagerListener.kt
@@ -2,21 +2,36 @@ package io.snyk.plugin
 
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManagerListener
+import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.serviceContainer.AlreadyDisposedException
+import io.snyk.plugin.services.SnykTaskQueueService
 import io.snyk.plugin.snykcode.core.AnalysisData
 import io.snyk.plugin.snykcode.core.RunUtils
 import io.snyk.plugin.snykcode.core.SnykCodeIgnoreInfoHolder
+import org.eclipse.lsp4j.WorkspaceFolder
 
 class SnykProjectManagerListener : ProjectManagerListener {
 
     override fun projectClosing(project: Project) {
         RunUtils.instance.runInBackground(
-            project,
-            "Project closing: " + project.name
+            project, "Project closing: " + project.name
         ) {
             // lets all running ProgressIndicators release MUTEX first
             RunUtils.instance.cancelRunningIndicators(project)
             AnalysisData.instance.removeProjectFromCaches(project)
             SnykCodeIgnoreInfoHolder.instance.removeProject(project)
+        }
+
+        // doesn't need to run in the background, as the called update is already running in a background thread
+        if (SnykTaskQueueService.ls.isInitialized) {
+            val removedWorkspaceFolders = ProjectRootManager.getInstance(project).contentRoots
+                .mapNotNull { WorkspaceFolder(it.url, it.name) }
+                .toCollection(mutableListOf())
+            try {
+                SnykTaskQueueService.ls.updateWorkspaceFolders(project, emptyList(), removedWorkspaceFolders)
+            } catch (ignore: AlreadyDisposedException) {
+                // ignore
+            }
         }
     }
 }

--- a/src/main/kotlin/io/snyk/plugin/analytics/AnalyticsScanListener.kt
+++ b/src/main/kotlin/io/snyk/plugin/analytics/AnalyticsScanListener.kt
@@ -3,7 +3,7 @@ package io.snyk.plugin.analytics
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.project.Project
 import io.snyk.plugin.events.SnykScanListener
-import io.snyk.plugin.getSnykTaskQueueService
+import io.snyk.plugin.services.SnykTaskQueueService
 import io.snyk.plugin.snykcode.SnykCodeResults
 import snyk.common.SnykError
 import snyk.common.lsp.commands.ScanDoneEvent
@@ -48,7 +48,7 @@ class AnalyticsScanListener(val project: Project) {
                 ossResult.mediumSeveritiesCount(),
                 ossResult.lowSeveritiesCount()
             )
-            getSnykTaskQueueService(project)?.ls?.sendReportAnalyticsCommand(scanDoneEvent)
+            SnykTaskQueueService.ls.sendReportAnalyticsCommand(scanDoneEvent)
         }
 
         override fun scanningSnykCodeFinished(snykCodeResults: SnykCodeResults?) {
@@ -66,7 +66,7 @@ class AnalyticsScanListener(val project: Project) {
             } else {
                 getScanDoneEvent(duration, product, 0, 0, 0, 0)
             }
-            getSnykTaskQueueService(project)?.ls?.sendReportAnalyticsCommand(scanDoneEvent)
+            SnykTaskQueueService.ls.sendReportAnalyticsCommand(scanDoneEvent)
         }
 
         override fun scanningIacFinished(iacResult: IacResult) {
@@ -78,7 +78,7 @@ class AnalyticsScanListener(val project: Project) {
                 iacResult.mediumSeveritiesCount(),
                 iacResult.lowSeveritiesCount()
             )
-            getSnykTaskQueueService(project)?.ls?.sendReportAnalyticsCommand(scanDoneEvent)
+            SnykTaskQueueService.ls.sendReportAnalyticsCommand(scanDoneEvent)
         }
 
         override fun scanningContainerFinished(containerResult: ContainerResult) {
@@ -90,7 +90,7 @@ class AnalyticsScanListener(val project: Project) {
                 containerResult.mediumSeveritiesCount(),
                 containerResult.lowSeveritiesCount()
             )
-            getSnykTaskQueueService(project)?.ls?.sendReportAnalyticsCommand(scanDoneEvent)
+            SnykTaskQueueService.ls.sendReportAnalyticsCommand(scanDoneEvent)
         }
 
         override fun scanningOssError(snykError: SnykError) {

--- a/src/main/kotlin/io/snyk/plugin/services/SnykCliAuthenticationService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykCliAuthenticationService.kt
@@ -16,7 +16,7 @@ import com.intellij.util.PlatformIcons
 import io.snyk.plugin.cli.ConsoleCommandRunner
 import io.snyk.plugin.getCliFile
 import io.snyk.plugin.getPluginPath
-import io.snyk.plugin.getSnykCliDownloaderService
+import io.snyk.plugin.getSnykTaskQueueService
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.ui.SnykBalloonNotificationHelper
 import io.snyk.plugin.ui.getReadOnlyClickableHtmlJEditorPane
@@ -55,7 +55,7 @@ class SnykCliAuthenticationService(val project: Project) {
         val downloadCliTask: () -> Unit = {
             if (!getCliFile().exists()) {
                 val currentIndicator = ProgressManager.getInstance().progressIndicator
-                getSnykCliDownloaderService().downloadLatestRelease(currentIndicator, project)
+                getSnykTaskQueueService(project)?.downloadLatestRelease(currentIndicator)
             } else {
                 logger.debug("Skip CLI download, since it was already downloaded")
             }

--- a/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
@@ -30,9 +30,6 @@ import io.snyk.plugin.net.ClientException
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.snykcode.core.RunUtils
 import io.snyk.plugin.ui.SnykBalloonNotifications
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
 import org.eclipse.lsp4j.WorkspaceFolder
 import org.jetbrains.annotations.TestOnly
 import snyk.common.SnykError

--- a/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
@@ -9,7 +9,6 @@ import com.intellij.openapi.progress.BackgroundTaskQueue
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.roots.ProjectRootManager
 import io.snyk.plugin.events.SnykCliDownloadListener
 import io.snyk.plugin.events.SnykScanListener
 import io.snyk.plugin.events.SnykTaskQueueListener
@@ -30,7 +29,6 @@ import io.snyk.plugin.net.ClientException
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.snykcode.core.RunUtils
 import io.snyk.plugin.ui.SnykBalloonNotifications
-import org.eclipse.lsp4j.WorkspaceFolder
 import org.jetbrains.annotations.TestOnly
 import snyk.common.SnykError
 import snyk.common.lsp.LanguageServerWrapper
@@ -82,10 +80,7 @@ class SnykTaskQueueService(val project: Project) {
                 ls.initialize()
             }
         }
-        val addedWorkspaceFolders = ProjectRootManager.getInstance(project).contentRoots
-            .mapNotNull { WorkspaceFolder(it.url, it.name) }
-            .toCollection(mutableListOf())
-        ls.updateWorkspaceFolders(project, addedWorkspaceFolders, emptyList())
+        ls.updateWorkspaceFolders(project, ls.getWorkspaceFolders(project), emptySet())
     }
 
     fun scan() {

--- a/src/main/kotlin/io/snyk/plugin/services/download/CliDownloaderService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/download/CliDownloaderService.kt
@@ -9,11 +9,9 @@ import com.intellij.util.io.HttpRequests
 import io.snyk.plugin.cli.Platform
 import io.snyk.plugin.events.SnykCliDownloadListener
 import io.snyk.plugin.getCliFile
-import io.snyk.plugin.isCliInstalled
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.services.download.HttpRequestHelper.createRequest
 import io.snyk.plugin.tail
-import io.snyk.plugin.ui.SnykBalloonNotificationHelper
 import java.io.IOException
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
@@ -60,18 +58,9 @@ class SnykCliDownloaderService {
     }
 
     fun downloadLatestRelease(indicator: ProgressIndicator, project: Project) {
-        if (!pluginSettings().manageBinariesAutomatically) {
-            if (!isCliInstalled()) {
-                val msg =
-                    "The plugin cannot scan without Snyk CLI, but automatic download is disabled. " +
-                        "Please put a Snyk CLI executable in ${pluginSettings().cliPath} and retry."
-                SnykBalloonNotificationHelper.showError(msg, project)
-            }
-            return
-        }
+        currentProgressIndicator = indicator
         cliDownloadPublisher.cliDownloadStarted()
         indicator.isIndeterminate = true
-        currentProgressIndicator = indicator
         var succeeded = false
         val cliFile = getCliFile()
         try {

--- a/src/main/kotlin/io/snyk/plugin/services/download/CliDownloaderService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/download/CliDownloaderService.kt
@@ -118,7 +118,6 @@ class SnykCliDownloaderService {
                 latestReleaseInfo.tagName.isNotEmpty() &&
                 isNewVersionAvailable(settings.cliVersion, cliVersionNumbers(latestReleaseInfo.tagName))
             ) {
-
                 downloadLatestRelease(indicator, project)
 
                 settings.lastCheckDate = Date()
@@ -133,13 +132,11 @@ class SnykCliDownloaderService {
     }
 
     fun isNewVersionAvailable(currentCliVersion: String?, newCliVersion: String?): Boolean {
-        if (currentCliVersion == null ||
-            newCliVersion == null ||
-            currentCliVersion.isEmpty() ||
-            currentCliVersion.isEmpty()
-        ) {
-            return true
-        }
+        val cliVersionsNullOrEmpty =
+            currentCliVersion == null || newCliVersion == null ||
+                currentCliVersion.isEmpty() || newCliVersion.isEmpty()
+
+        if (cliVersionsNullOrEmpty) return true
 
         tailrec fun checkIsNewVersionAvailable(
             currentCliVersionNumbers: List<String>,
@@ -158,7 +155,7 @@ class SnykCliDownloaderService {
             }
         }
 
-        return checkIsNewVersionAvailable(currentCliVersion.split('.'), newCliVersion.split('.'))
+        return checkIsNewVersionAvailable(currentCliVersion!!.split('.'), newCliVersion!!.split('.'))
     }
 
     fun getLatestReleaseInfo(): LatestReleaseInfo? = this.latestReleaseInfo

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
@@ -143,7 +143,6 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
 
     init {
         vulnerabilitiesTree.cellRenderer = SnykTreeCellRenderer()
-
         layout = BorderLayout()
         TreeSpeedSearch(vulnerabilitiesTree, TreeSpeedSearch.NODE_DESCRIPTOR_TOSTRING, true)
 

--- a/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
@@ -26,6 +26,10 @@ import snyk.common.lsp.commands.ScanDoneEvent
 import snyk.pluginInfo
 import java.util.concurrent.TimeUnit
 
+private const val DEFAULT_SLEEP_TIME = 100L
+private const val INITIALIZATION_TIMEOUT = 20L
+
+@Suppress("TooGenericExceptionCaught")
 class LanguageServerWrapper(private val lsPath: String = getCliFile().absolutePath) {
     private val gson = com.google.gson.Gson()
     val logger = Logger.getInstance("Snyk Language Server")
@@ -55,7 +59,6 @@ class LanguageServerWrapper(private val lsPath: String = getCliFile().absolutePa
     val isInitialized: Boolean
         get() = ::languageClient.isInitialized && ::languageServer.isInitialized &&
             ::process.isInitialized && process.info().startInstant().isPresent
-
 
     @OptIn(DelicateCoroutinesApi::class)
     internal fun initialize() {
@@ -106,7 +109,7 @@ class LanguageServerWrapper(private val lsPath: String = getCliFile().absolutePa
         params.initializationOptions = getInitializationOptions()
         params.workspaceFolders = workspaceFolders
 
-        languageServer.initialize(params).get(20, TimeUnit.SECONDS)
+        languageServer.initialize(params).get(INITIALIZATION_TIMEOUT, TimeUnit.SECONDS)
     }
 
     fun updateWorkspaceFolders(project: Project, added: List<WorkspaceFolder>, removed: List<WorkspaceFolder>) {
@@ -127,7 +130,7 @@ class LanguageServerWrapper(private val lsPath: String = getCliFile().absolutePa
 
     private fun ensureLanguageServerInitialized() {
         while (isInitializing) {
-            Thread.sleep(100)
+            Thread.sleep(DEFAULT_SLEEP_TIME)
         }
         if (!isInitialized) {
             initialize()

--- a/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
@@ -1,13 +1,21 @@
 package snyk.common.lsp
 
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.roots.ProjectRootManager
 import io.snyk.plugin.getCliFile
 import io.snyk.plugin.pluginSettings
+import io.snyk.plugin.snykcode.core.RunUtils
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import org.eclipse.lsp4j.ClientInfo
+import org.eclipse.lsp4j.DidChangeWorkspaceFoldersParams
 import org.eclipse.lsp4j.ExecuteCommandParams
 import org.eclipse.lsp4j.InitializeParams
 import org.eclipse.lsp4j.WorkspaceFolder
+import org.eclipse.lsp4j.WorkspaceFoldersChangeEvent
 import org.eclipse.lsp4j.jsonrpc.Launcher
 import org.eclipse.lsp4j.launch.LSPLauncher
 import org.eclipse.lsp4j.services.LanguageClient
@@ -16,13 +24,16 @@ import snyk.common.EnvironmentHelper
 import snyk.common.getEndpointUrl
 import snyk.common.lsp.commands.ScanDoneEvent
 import snyk.pluginInfo
+import java.util.concurrent.TimeUnit
 
 class LanguageServerWrapper(private val lsPath: String = getCliFile().absolutePath) {
     private val gson = com.google.gson.Gson()
+    val logger = Logger.getInstance("Snyk Language Server")
 
     /**
      * The language client is used to receive messages from LS
      */
+    @Suppress("MemberVisibilityCanBePrivate")
     lateinit var languageClient: LanguageClient
 
     /**
@@ -40,30 +51,54 @@ class LanguageServerWrapper(private val lsPath: String = getCliFile().absolutePa
      */
     lateinit var process: Process
 
-    fun initialize() {
-        val snykLanguageClient = SnykLanguageClient()
-        languageClient = snykLanguageClient
-        val logLevel = if (snykLanguageClient.logger.isDebugEnabled) "debug" else "info"
-        val cmd = listOf(lsPath, "language-server", "-l", logLevel)
+    var isInitializing: Boolean = false
+    val isInitialized: Boolean
+        get() = ::languageClient.isInitialized && ::languageServer.isInitialized &&
+            ::process.isInitialized && process.info().startInstant().isPresent
 
-        val processBuilder = ProcessBuilder(cmd)
-        pluginSettings().token?.let { EnvironmentHelper.updateEnvironment(processBuilder.environment(), it) }
 
-        process = processBuilder.start()
-        launcher = LSPLauncher.createClientLauncher(languageClient, process.inputStream, process.outputStream)
-        languageServer = launcher.remoteProxy
+    @OptIn(DelicateCoroutinesApi::class)
+    internal fun initialize() {
+        try {
+            isInitializing = true
+            val snykLanguageClient = SnykLanguageClient()
+            languageClient = snykLanguageClient
+            val logLevel = if (snykLanguageClient.logger.isDebugEnabled) "debug" else "info"
+            val cmd = listOf(lsPath, "language-server", "-l", logLevel)
+
+            val processBuilder = ProcessBuilder(cmd)
+            pluginSettings().token?.let { EnvironmentHelper.updateEnvironment(processBuilder.environment(), it) }
+
+            process = processBuilder.start()
+            launcher = LSPLauncher.createClientLauncher(languageClient, process.inputStream, process.outputStream)
+            languageServer = launcher.remoteProxy
+
+            GlobalScope.launch {
+                process.errorStream.bufferedReader().forEachLine { println(it) }
+            }
+
+            launcher.startListening()
+
+            sendInitializeMessage()
+        } catch (e: Exception) {
+            logger.error(e)
+        } finally {
+            isInitializing = false
+        }
     }
 
-    fun startListening() {
-        // Start the server
-        launcher.startListening()
-    }
-
-    fun sendInitializeMessage(project: Project) {
+    private fun determineWorkspaceFolders(): List<WorkspaceFolder> {
         val workspaceFolders = mutableListOf<WorkspaceFolder>()
-        ProjectRootManager.getInstance(project)
-            .contentRoots
-            .mapNotNull { WorkspaceFolder(it.url, it.name) }.toCollection(workspaceFolders)
+        ProjectManager.getInstance().openProjects.forEach { project ->
+            ProjectRootManager.getInstance(project)
+                .contentRoots
+                .mapNotNull { WorkspaceFolder(it.url, it.name) }.toCollection(workspaceFolders)
+        }
+        return workspaceFolders.toList()
+    }
+
+    fun sendInitializeMessage() {
+        val workspaceFolders = determineWorkspaceFolders()
 
         val params = InitializeParams()
         params.processId = ProcessHandle.current().pid().toInt()
@@ -71,18 +106,44 @@ class LanguageServerWrapper(private val lsPath: String = getCliFile().absolutePa
         params.initializationOptions = getInitializationOptions()
         params.workspaceFolders = workspaceFolders
 
-        languageServer.initialize(params).get()
+        languageServer.initialize(params).get(20, TimeUnit.SECONDS)
+    }
+
+    fun updateWorkspaceFolders(project: Project, added: List<WorkspaceFolder>, removed: List<WorkspaceFolder>) {
+        RunUtils.instance.runInBackground(
+            project,
+            "Updating workspace folders for project: ${project.name}"
+        ) {
+            try {
+                ensureLanguageServerInitialized()
+                val params = DidChangeWorkspaceFoldersParams()
+                params.event = WorkspaceFoldersChangeEvent(added, removed)
+                languageServer.workspaceService.didChangeWorkspaceFolders(params)
+            } catch (e: Exception) {
+                logger.error(e)
+            }
+        }
+    }
+
+    private fun ensureLanguageServerInitialized() {
+        while (isInitializing) {
+            Thread.sleep(100)
+        }
+        if (!isInitialized) {
+            initialize()
+        }
     }
 
     fun sendReportAnalyticsCommand(scanDoneEvent: ScanDoneEvent) {
+        ensureLanguageServerInitialized()
         try {
             val eventString = gson.toJson(scanDoneEvent)
             val param = ExecuteCommandParams()
             param.command = "snyk.reportAnalytics"
             param.arguments = listOf(eventString)
             languageServer.workspaceService.executeCommand(param)
-        } catch (ignored: Exception) {
-            // do nothing to not break UX for analytics
+        } catch (e: Exception) {
+            logger.error(e)
         }
     }
 
@@ -96,6 +157,7 @@ class LanguageServerWrapper(private val lsPath: String = getCliFile().absolutePa
             endpoint = getEndpointUrl(),
             cliPath = getCliFile().absolutePath,
             token = ps.token,
+            enableTrustedFoldersFeature = "false",
             filterSeverity = SeverityFilter(
                 critical = ps.criticalSeverityEnabled,
                 high = ps.highSeverityEnabled,

--- a/src/main/kotlin/snyk/common/lsp/commands/ScanDoneEvent.kt
+++ b/src/main/kotlin/snyk/common/lsp/commands/ScanDoneEvent.kt
@@ -39,7 +39,7 @@ data class ScanDoneEvent(
         val eventType: String = "Scan done",
 
         @SerializedName("status")
-        val status: String = "Succeeded",
+        val status: String = "Success",
 
         @SerializedName("scan_type")
         val scanType: String,

--- a/src/test/java/snyk/common/lsp/LanguageServerWrapperTest.kt
+++ b/src/test/java/snyk/common/lsp/LanguageServerWrapperTest.kt
@@ -55,7 +55,7 @@ class LanguageServerWrapperTest {
         every { rootManagerMock.contentRoots } returns emptyArray()
         every { lsMock.initialize(any<InitializeParams>()) } returns CompletableFuture.completedFuture(null)
 
-        cut.sendInitializeMessage(projectMock)
+        cut.sendInitializeMessage()
 
         verify { lsMock.initialize(any<InitializeParams>()) }
     }

--- a/src/test/java/snyk/common/lsp/LanguageServerWrapperTest.kt
+++ b/src/test/java/snyk/common/lsp/LanguageServerWrapperTest.kt
@@ -62,6 +62,10 @@ class LanguageServerWrapperTest {
 
     @Test
     fun `sendReportAnalyticsCommand should send a reportAnalytics command to the language server`() {
+        cut.languageClient = mockk(relaxed = true)
+        val processMock = mockk<Process>(relaxed = true)
+        cut.process = processMock
+        every { processMock.info().startInstant().isPresent } returns true
         every {
             lsMock.workspaceService.executeCommand(any<ExecuteCommandParams>())
         } returns CompletableFuture.completedFuture(null)

--- a/src/test/kotlin/io/snyk/plugin/analytics/AnalyticsScanListenerTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/analytics/AnalyticsScanListenerTest.kt
@@ -30,7 +30,7 @@ class AnalyticsScanListenerTest {
     @Before
     fun setUp() {
         unmockkAll()
-        
+
         mockkStatic("io.snyk.plugin.UtilsKt")
         every { pluginSettings() } returns settings
 
@@ -79,7 +79,7 @@ class AnalyticsScanListenerTest {
 
         assertEquals("analytics", scanDoneEvent.data.type)
         assertEquals("Scan done", scanDoneEvent.data.attributes.eventType)
-        assertEquals("Succeeded", scanDoneEvent.data.attributes.status)
+        assertEquals("Success", scanDoneEvent.data.attributes.status)
         assertEquals(settings.userAnonymousId, scanDoneEvent.data.attributes.deviceId)
 
         assertNotNull(scanDoneEvent.data.attributes.timestampFinished)

--- a/src/test/kotlin/io/snyk/plugin/analytics/AnalyticsScanListenerTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/analytics/AnalyticsScanListenerTest.kt
@@ -8,9 +8,9 @@ import io.mockk.unmockkAll
 import io.mockk.verify
 import io.snyk.plugin.getArch
 import io.snyk.plugin.getOS
-import io.snyk.plugin.getSnykTaskQueueService
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.services.SnykApplicationSettingsStateService
+import io.snyk.plugin.services.SnykTaskQueueService
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertNotNull
 import org.eclipse.lsp4j.ExecuteCommandParams
@@ -83,7 +83,7 @@ class AnalyticsScanListenerTest {
     fun `testScanListener scanningIacFinished should call language server to report analytics`() {
         val languageServerWrapper = LanguageServerWrapper("dummy")
         languageServerWrapper.languageServer = lsMock
-        every { getSnykTaskQueueService(projectMock)?.ls } returns languageServerWrapper
+        every { SnykTaskQueueService?.ls } returns languageServerWrapper
         every {
             lsMock.workspaceService.executeCommand(any<ExecuteCommandParams>())
         } returns CompletableFuture.completedFuture(null)
@@ -97,7 +97,7 @@ class AnalyticsScanListenerTest {
     fun `testScanListener scanningOssFinished should call language server to report analytics`() {
         val languageServerWrapper = LanguageServerWrapper("dummy")
         languageServerWrapper.languageServer = lsMock
-        every { getSnykTaskQueueService(projectMock)?.ls } returns languageServerWrapper
+        every { SnykTaskQueueService?.ls } returns languageServerWrapper
         every {
             lsMock.workspaceService.executeCommand(any<ExecuteCommandParams>())
         } returns CompletableFuture.completedFuture(null)
@@ -111,7 +111,7 @@ class AnalyticsScanListenerTest {
     fun `testScanListener scanningCodeFinished should call language server to report analytics`() {
         val languageServerWrapper = LanguageServerWrapper("dummy")
         languageServerWrapper.languageServer = lsMock
-        every { getSnykTaskQueueService(projectMock)?.ls } returns languageServerWrapper
+        every { SnykTaskQueueService?.ls } returns languageServerWrapper
         every {
             lsMock.workspaceService.executeCommand(any<ExecuteCommandParams>())
         } returns CompletableFuture.completedFuture(null)
@@ -125,7 +125,7 @@ class AnalyticsScanListenerTest {
     fun `testScanListener scanningContainerFinished should call language server to report analytics`() {
         val languageServerWrapper = LanguageServerWrapper("dummy")
         languageServerWrapper.languageServer = lsMock
-        every { getSnykTaskQueueService(projectMock)?.ls } returns languageServerWrapper
+        every { SnykTaskQueueService?.ls } returns languageServerWrapper
         every {
             lsMock.workspaceService.executeCommand(any<ExecuteCommandParams>())
         } returns CompletableFuture.completedFuture(null)

--- a/src/test/kotlin/io/snyk/plugin/services/SnykTaskQueueServiceTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/services/SnykTaskQueueServiceTest.kt
@@ -37,7 +37,6 @@ import snyk.oss.OssService
 import snyk.trust.confirmScanningAndSetWorkspaceTrustedStateIfNeeded
 import java.util.concurrent.TimeUnit
 
-@Suppress("FunctionName")
 class SnykTaskQueueServiceTest : LightPlatformTestCase() {
 
     private lateinit var ossServiceMock: OssService

--- a/src/test/kotlin/io/snyk/plugin/services/download/SnykCliDownloaderServiceTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/services/download/SnykCliDownloaderServiceTest.kt
@@ -2,17 +2,12 @@ package io.snyk.plugin.services.download
 
 import io.mockk.confirmVerified
 import io.mockk.every
-import io.mockk.justRun
 import io.mockk.mockk
-import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
-import io.mockk.unmockkObject
 import io.mockk.verify
-import io.snyk.plugin.isCliInstalled
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.services.SnykApplicationSettingsStateService
-import io.snyk.plugin.ui.SnykBalloonNotificationHelper
 import org.junit.After
 import org.junit.Assert.assertNull
 import org.junit.Before
@@ -42,28 +37,5 @@ class SnykCliDownloaderServiceTest {
 
         verify { settingsStateService.manageBinariesAutomatically }
         confirmVerified(settingsStateService)
-    }
-
-    @Test
-    fun `downloadLatestRelease should return without doing anything if updates disabled`() {
-        val cut = SnykCliDownloaderService()
-        every { settingsStateService.manageBinariesAutomatically } returns false
-        every { settingsStateService.cliPath } returns "dummyPath"
-        every { isCliInstalled() } returns false
-        mockkObject(SnykBalloonNotificationHelper)
-        justRun { SnykBalloonNotificationHelper.showError(any(), any()) }
-
-        cut.downloadLatestRelease(mockk(), mockk())
-
-        verify { settingsStateService.manageBinariesAutomatically }
-        verify { settingsStateService.cliPath }
-        verify(exactly = 1) {
-            SnykBalloonNotificationHelper.showError(
-                any(), any()
-            )
-        }
-        confirmVerified(settingsStateService) // this makes sure, no publisher, no cli path, nothing is used
-        confirmVerified(SnykBalloonNotificationHelper)
-        unmockkObject(SnykBalloonNotificationHelper)
     }
 }


### PR DESCRIPTION
### Description

We have received several reports that CLI updates under Windows don't work. This is due to a file lock.

This PR ensures two things:

1. Independent of the number of projects, only one instance of the CLI is started in language server mode `snyk language-server` in the background.
2. CLI download, whether initial or an update, comes first, before the CLI is started in the background. This ensures the download does not run into a file lock under Windows.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

![image](https://github.com/snyk/snyk-intellij-plugin/assets/20150761/46dc72d4-026f-45e7-9a6e-d543058a178e)

Opened 5 projects, and verified only one snyk-win.exe process:
![image](https://github.com/snyk/snyk-intellij-plugin/assets/20150761/67a3efa9-7508-487d-842d-87aa6f3d35eb)

