### PR TITLE
fix: scans breaking, when CLI existent and downloads disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Snyk Changelog
 
+## [2.7.2]
+### Fixed
+- manually downloaded binaries were causing problems initiating scans
+
 ## [2.7.1]
 ### Fixed
 - only start up language server after CLI update (fixes lock error on Windows)

--- a/src/main/kotlin/io/snyk/plugin/SnykPostStartupActivity.kt
+++ b/src/main/kotlin/io/snyk/plugin/SnykPostStartupActivity.kt
@@ -81,12 +81,12 @@ class SnykPostStartupActivity : ProjectActivity {
         AnnotatorCommon.initRefreshing(project)
 
         if (!ApplicationManager.getApplication().isUnitTestMode) {
-            getSnykTaskQueueService(project)?.waitUntilCliDownloadedIfNeeded(EmptyProgressIndicator())
             try {
+                getSnykTaskQueueService(project)?.waitUntilCliDownloadedIfNeeded(EmptyProgressIndicator())
                 getSnykTaskQueueService(project)?.connectProjectToLanguageServer(project)
                 getAnalyticsScanListener(project)?.initScanListener()
             } catch (e: Exception) {
-                Logger.getInstance(SnykPostStartupActivity::class.java).error(e)
+                Logger.getInstance(SnykPostStartupActivity::class.java).warn(e)
             }
         }
 

--- a/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
@@ -290,7 +290,6 @@ class SnykTaskQueueService(val project: Project) {
                         "Please put a Snyk CLI executable in ${pluginSettings().cliPath} and retry."
                 SnykBalloonNotificationHelper.showError(msg, project)
             }
-            indicator.cancel()
             return
         }
         val cliDownloader = getSnykCliDownloaderService()

--- a/src/test/kotlin/io/snyk/plugin/services/SnykTaskQueueServiceTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/services/SnykTaskQueueServiceTest.kt
@@ -128,6 +128,7 @@ class SnykTaskQueueServiceTest : LightPlatformTestCase() {
         val settings = setupAppSettingsForDownloadTests()
         settings.manageBinariesAutomatically = false
         val snykTaskQueueService = project.service<SnykTaskQueueService>()
+        every { isCliInstalled() } returns true
 
         snykTaskQueueService.scan()
 


### PR DESCRIPTION
### Description

Disabling automatic dependency management caused the scans not to work anymore

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
