### PR TITLE
fix: move everything to background thread when closing project [HEAD-1269]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [2.7.4]
 ### Fixed
-- move all clean-up tasks on project close to a background task
+- move all clean-up tasks on project close to a background task and limit execution to 5s
 
 ## [2.7.3]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Snyk Changelog
 
+## [2.7.4]
+### Fixed
+- move all clean-up tasks on project close to a background task
+
 ## [2.7.3]
 ### Fixed
 -  only send analytics when connected to an MT US environment

--- a/src/main/kotlin/io/snyk/plugin/SnykProjectManagerListener.kt
+++ b/src/main/kotlin/io/snyk/plugin/SnykProjectManagerListener.kt
@@ -1,30 +1,36 @@
 package io.snyk.plugin
 
+import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManagerListener
-import com.intellij.serviceContainer.AlreadyDisposedException
 import io.snyk.plugin.services.SnykTaskQueueService.Companion.ls
 import io.snyk.plugin.snykcode.core.AnalysisData
 import io.snyk.plugin.snykcode.core.RunUtils
 import io.snyk.plugin.snykcode.core.SnykCodeIgnoreInfoHolder
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+private const val TIMEOUT = 5L
 
 class SnykProjectManagerListener : ProjectManagerListener {
-
     override fun projectClosing(project: Project) {
         RunUtils.instance.runInBackground(
             project,
             "Project closing: " + project.name
         ) {
-            // lets all running ProgressIndicators release MUTEX first
-            RunUtils.instance.cancelRunningIndicators(project)
-            AnalysisData.instance.removeProjectFromCaches(project)
-            SnykCodeIgnoreInfoHolder.instance.removeProject(project)
-            if (ls.isInitialized) {
-                try {
-                    ls.updateWorkspaceFolders(emptySet(), ls.getWorkspaceFolders(project))
-                } catch (ignore: AlreadyDisposedException) {
-                    // ignore
-                }
+            // limit clean up to 5s
+            try {
+                Executors.newSingleThreadExecutor().submit {
+                    // lets all running ProgressIndicators release MUTEX first
+                    RunUtils.instance.cancelRunningIndicators(project)
+                    AnalysisData.instance.removeProjectFromCaches(project)
+                    SnykCodeIgnoreInfoHolder.instance.removeProject(project)
+                    if (ls.isInitialized) {
+                        ls.updateWorkspaceFolders(emptySet(), ls.getWorkspaceFolders(project))
+                    }
+                }.get(TIMEOUT, TimeUnit.SECONDS)
+            } catch (ignored: RuntimeException) {
+                logger<SnykProjectManagerListener>().info("Project closing clean up took too long", ignored)
             }
         }
     }

--- a/src/main/kotlin/io/snyk/plugin/SnykProjectManagerListener.kt
+++ b/src/main/kotlin/io/snyk/plugin/SnykProjectManagerListener.kt
@@ -3,7 +3,7 @@ package io.snyk.plugin
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManagerListener
 import com.intellij.serviceContainer.AlreadyDisposedException
-import io.snyk.plugin.services.SnykTaskQueueService
+import io.snyk.plugin.services.SnykTaskQueueService.Companion.ls
 import io.snyk.plugin.snykcode.core.AnalysisData
 import io.snyk.plugin.snykcode.core.RunUtils
 import io.snyk.plugin.snykcode.core.SnykCodeIgnoreInfoHolder
@@ -19,18 +19,12 @@ class SnykProjectManagerListener : ProjectManagerListener {
             RunUtils.instance.cancelRunningIndicators(project)
             AnalysisData.instance.removeProjectFromCaches(project)
             SnykCodeIgnoreInfoHolder.instance.removeProject(project)
-        }
-
-        // doesn't need to run in the background, as the called update is already running in a background thread
-        if (SnykTaskQueueService.ls.isInitialized) {
-            try {
-                SnykTaskQueueService.ls.updateWorkspaceFolders(
-                    project,
-                    emptySet(),
-                    SnykTaskQueueService.ls.getWorkspaceFolders(project)
-                )
-            } catch (ignore: AlreadyDisposedException) {
-                // ignore
+            if (ls.isInitialized) {
+                try {
+                    ls.updateWorkspaceFolders(emptySet(), ls.getWorkspaceFolders(project))
+                } catch (ignore: AlreadyDisposedException) {
+                    // ignore
+                }
             }
         }
     }

--- a/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
@@ -81,7 +81,7 @@ class SnykTaskQueueService(val project: Project) {
                 ls.initialize()
             }
         }
-        ls.updateWorkspaceFolders(project, ls.getWorkspaceFolders(project), emptySet())
+        ls.updateWorkspaceFolders(ls.getWorkspaceFolders(project), emptySet())
     }
 
     fun scan() {

--- a/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
@@ -6,7 +6,6 @@ import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.roots.ProjectRootManager
 import io.snyk.plugin.getCliFile
 import io.snyk.plugin.pluginSettings
-import io.snyk.plugin.snykcode.core.RunUtils
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -117,19 +116,14 @@ class LanguageServerWrapper(private val lsPath: String = getCliFile().absolutePa
         languageServer.initialize(params).get(INITIALIZATION_TIMEOUT, TimeUnit.SECONDS)
     }
 
-    fun updateWorkspaceFolders(project: Project, added: Set<WorkspaceFolder>, removed: Set<WorkspaceFolder>) {
-        RunUtils.instance.runInBackground(
-            project,
-            "Updating workspace folders for project: ${project.name}"
-        ) {
-            try {
-                ensureLanguageServerInitialized()
-                val params = DidChangeWorkspaceFoldersParams()
-                params.event = WorkspaceFoldersChangeEvent(added.toList(), removed.toList())
-                languageServer.workspaceService.didChangeWorkspaceFolders(params)
-            } catch (e: Exception) {
-                logger.error(e)
-            }
+    fun updateWorkspaceFolders(added: Set<WorkspaceFolder>, removed: Set<WorkspaceFolder>) {
+        try {
+            ensureLanguageServerInitialized()
+            val params = DidChangeWorkspaceFoldersParams()
+            params.event = WorkspaceFoldersChangeEvent(added.toList(), removed.toList())
+            languageServer.workspaceService.didChangeWorkspaceFolders(params)
+        } catch (e: Exception) {
+            logger.error(e)
         }
     }
 


### PR DESCRIPTION
### Description

When closing a project, IntelliJ is calling all ProjectListeners registered. Snyk has its own, and on project close, clean up tasks are executed:

- remove the closed project from Snyk Code cache
- remove the closed projects source roots from language server workspace folders

The determination of the content roots of the closed project was running in the foreground, while the rest was already backgrounded.

This PR moves the determination of the content roots into a background thread, too. It also limits overall clean up execution time to 5s.

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
