### PR TITLE
fix: close down language server during download, fix trust service [HEAD-1242][HEAD-1249]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [2.7.4]
 ### Fixed
 - move all clean-up tasks on project close to a background task and limit execution to 5s
+- close down & re-initialize language server when new CLI file is activated
+- change trust service to work on project content roots instead of project base dir
 
 ## [2.7.3]
 ### Fixed

--- a/src/main/kotlin/io/snyk/plugin/SnykPostStartupActivity.kt
+++ b/src/main/kotlin/io/snyk/plugin/SnykPostStartupActivity.kt
@@ -7,7 +7,6 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.extensions.ExtensionPointName
-import com.intellij.openapi.progress.EmptyProgressIndicator
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.startup.ProjectActivity
@@ -82,8 +81,12 @@ class SnykPostStartupActivity : ProjectActivity {
 
         if (!ApplicationManager.getApplication().isUnitTestMode) {
             try {
-                getSnykTaskQueueService(project)?.waitUntilCliDownloadedIfNeeded(EmptyProgressIndicator())
-                getSnykTaskQueueService(project)?.connectProjectToLanguageServer(project)
+                // this returns if no download possible (isDownloading == false)
+                getSnykTaskQueueService(project)?.waitUntilCliDownloadedIfNeeded()
+
+                if (isCliInstalled()) {
+                    getSnykTaskQueueService(project)?.connectProjectToLanguageServer(project)
+                }
                 getAnalyticsScanListener(project)?.initScanListener()
             } catch (e: Exception) {
                 Logger.getInstance(SnykPostStartupActivity::class.java).warn(e)

--- a/src/main/kotlin/io/snyk/plugin/SnykProjectManagerListener.kt
+++ b/src/main/kotlin/io/snyk/plugin/SnykProjectManagerListener.kt
@@ -3,10 +3,10 @@ package io.snyk.plugin
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManagerListener
-import io.snyk.plugin.services.SnykTaskQueueService.Companion.ls
 import io.snyk.plugin.snykcode.core.AnalysisData
 import io.snyk.plugin.snykcode.core.RunUtils
 import io.snyk.plugin.snykcode.core.SnykCodeIgnoreInfoHolder
+import snyk.common.lsp.LanguageServerWrapper
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
@@ -25,6 +25,7 @@ class SnykProjectManagerListener : ProjectManagerListener {
                     RunUtils.instance.cancelRunningIndicators(project)
                     AnalysisData.instance.removeProjectFromCaches(project)
                     SnykCodeIgnoreInfoHolder.instance.removeProject(project)
+                    val ls = LanguageServerWrapper.getInstance()
                     if (ls.isInitialized) {
                         ls.updateWorkspaceFolders(emptySet(), ls.getWorkspaceFolders(project))
                     }

--- a/src/main/kotlin/io/snyk/plugin/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/Utils.kt
@@ -406,9 +406,11 @@ fun VirtualFile.toPsiFile(project: Project): PsiFile? {
     return PsiManager.getInstance(project).findFile(this)
 }
 
-fun Project.getContentRoots(): SortedSet<Path> {
-    return ProjectRootManager.getInstance(this).contentRoots
-        .filter { it.exists() && it.isDirectory }
+fun Project.getContentRootPaths(): SortedSet<Path> {
+    return getContentRootVirtualFiles()
         .mapNotNull { it.path.toNioPathOrNull() }
         .toSortedSet()
 }
+
+fun Project.getContentRootVirtualFiles() = ProjectRootManager.getInstance(this).contentRoots
+    .filter { it.exists() && it.isDirectory }.toSet()

--- a/src/main/kotlin/io/snyk/plugin/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/Utils.kt
@@ -406,7 +406,7 @@ fun VirtualFile.toPsiFile(project: Project): PsiFile? {
     return PsiManager.getInstance(project).findFile(this)
 }
 
-fun Project.getContentRoots() : SortedSet<Path> {
+fun Project.getContentRoots(): SortedSet<Path> {
     return ProjectRootManager.getInstance(this).contentRoots
         .filter { it.exists() && it.isDirectory }
         .mapNotNull { it.path.toNioPathOrNull() }

--- a/src/main/kotlin/io/snyk/plugin/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/Utils.kt
@@ -14,6 +14,7 @@ import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.openapi.util.io.toNioPathOrNull
 import com.intellij.openapi.util.registry.Registry
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.wm.ToolWindow
@@ -59,6 +60,7 @@ import java.net.URI
 import java.nio.file.Path
 import java.security.KeyStore
 import java.util.Objects.nonNull
+import java.util.SortedSet
 import java.util.concurrent.TimeUnit
 import javax.net.ssl.SSLContext
 import javax.net.ssl.TrustManager
@@ -402,4 +404,11 @@ fun getArch(): String {
 
 fun VirtualFile.toPsiFile(project: Project): PsiFile? {
     return PsiManager.getInstance(project).findFile(this)
+}
+
+fun Project.getContentRoots() : SortedSet<Path> {
+    return ProjectRootManager.getInstance(this).contentRoots
+        .filter { it.exists() && it.isDirectory }
+        .mapNotNull { it.path.toNioPathOrNull() }
+        .toSortedSet()
 }

--- a/src/main/kotlin/io/snyk/plugin/analytics/AnalyticsScanListener.kt
+++ b/src/main/kotlin/io/snyk/plugin/analytics/AnalyticsScanListener.kt
@@ -3,9 +3,9 @@ package io.snyk.plugin.analytics
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.project.Project
 import io.snyk.plugin.events.SnykScanListener
-import io.snyk.plugin.services.SnykTaskQueueService
 import io.snyk.plugin.snykcode.SnykCodeResults
 import snyk.common.SnykError
+import snyk.common.lsp.LanguageServerWrapper
 import snyk.common.lsp.commands.ScanDoneEvent
 import snyk.container.ContainerResult
 import snyk.iac.IacResult
@@ -48,7 +48,7 @@ class AnalyticsScanListener(val project: Project) {
                 ossResult.mediumSeveritiesCount(),
                 ossResult.lowSeveritiesCount()
             )
-            SnykTaskQueueService.ls.sendReportAnalyticsCommand(scanDoneEvent)
+            LanguageServerWrapper.getInstance().sendReportAnalyticsCommand(scanDoneEvent)
         }
 
         override fun scanningSnykCodeFinished(snykCodeResults: SnykCodeResults?) {
@@ -66,7 +66,7 @@ class AnalyticsScanListener(val project: Project) {
             } else {
                 getScanDoneEvent(duration, product, 0, 0, 0, 0)
             }
-            SnykTaskQueueService.ls.sendReportAnalyticsCommand(scanDoneEvent)
+            LanguageServerWrapper.getInstance().sendReportAnalyticsCommand(scanDoneEvent)
         }
 
         override fun scanningIacFinished(iacResult: IacResult) {
@@ -78,7 +78,7 @@ class AnalyticsScanListener(val project: Project) {
                 iacResult.mediumSeveritiesCount(),
                 iacResult.lowSeveritiesCount()
             )
-            SnykTaskQueueService.ls.sendReportAnalyticsCommand(scanDoneEvent)
+            LanguageServerWrapper.getInstance().sendReportAnalyticsCommand(scanDoneEvent)
         }
 
         override fun scanningContainerFinished(containerResult: ContainerResult) {
@@ -90,7 +90,7 @@ class AnalyticsScanListener(val project: Project) {
                 containerResult.mediumSeveritiesCount(),
                 containerResult.lowSeveritiesCount()
             )
-            SnykTaskQueueService.ls.sendReportAnalyticsCommand(scanDoneEvent)
+            LanguageServerWrapper.getInstance().sendReportAnalyticsCommand(scanDoneEvent)
         }
 
         override fun scanningOssError(snykError: SnykError) {

--- a/src/main/kotlin/io/snyk/plugin/services/SnykCliAuthenticationService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykCliAuthenticationService.kt
@@ -55,7 +55,7 @@ class SnykCliAuthenticationService(val project: Project) {
         val downloadCliTask: () -> Unit = {
             if (!getCliFile().exists()) {
                 val currentIndicator = ProgressManager.getInstance().progressIndicator
-                getSnykTaskQueueService(project)?.downloadLatestRelease(currentIndicator)
+                getSnykTaskQueueService(project)?.downloadLatestRelease()
             } else {
                 logger.debug("Skip CLI download, since it was already downloaded")
             }

--- a/src/main/kotlin/io/snyk/plugin/services/SnykCliAuthenticationService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykCliAuthenticationService.kt
@@ -54,7 +54,6 @@ class SnykCliAuthenticationService(val project: Project) {
     private fun downloadCliIfNeeded() {
         val downloadCliTask: () -> Unit = {
             if (!getCliFile().exists()) {
-                val currentIndicator = ProgressManager.getInstance().progressIndicator
                 getSnykTaskQueueService(project)?.downloadLatestRelease()
             } else {
                 logger.debug("Skip CLI download, since it was already downloaded")

--- a/src/main/kotlin/io/snyk/plugin/services/SnykCliAuthenticationService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykCliAuthenticationService.kt
@@ -61,7 +61,7 @@ class SnykCliAuthenticationService(val project: Project) {
                     } else {
                         ProgressManager.getInstance().progressIndicator
                     }
-                getSnykTaskQueueService(project)?.downloadLatestRelease(progress)
+                getSnykTaskQueueService(project)?.downloadLatestRelease()
             } else {
                 logger.debug("Skip CLI download, since it was already downloaded")
             }

--- a/src/main/kotlin/io/snyk/plugin/services/SnykCliAuthenticationService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykCliAuthenticationService.kt
@@ -5,7 +5,6 @@ import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.ide.CopyPasteManager
-import com.intellij.openapi.progress.EmptyProgressIndicator
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.Task
@@ -55,12 +54,6 @@ class SnykCliAuthenticationService(val project: Project) {
     private fun downloadCliIfNeeded() {
         val downloadCliTask: () -> Unit = {
             if (!getCliFile().exists()) {
-                val progress =
-                    if (!ProgressManager.getInstance().hasProgressIndicator()) {
-                        EmptyProgressIndicator()
-                    } else {
-                        ProgressManager.getInstance().progressIndicator
-                    }
                 getSnykTaskQueueService(project)?.downloadLatestRelease()
             } else {
                 logger.debug("Skip CLI download, since it was already downloaded")

--- a/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
@@ -114,7 +114,7 @@ class SnykTaskQueueService(val project: Project) {
 
     fun waitUntilCliDownloadedIfNeeded(indicator: ProgressIndicator) {
         indicator.text = "Snyk waits for CLI to be downloaded..."
-        downloadLatestRelease()
+        downloadLatestRelease(indicator)
         do {
             indicator.checkCanceled()
             Thread.sleep(WAIT_FOR_DOWNLOAD_MILLIS)
@@ -278,7 +278,7 @@ class SnykTaskQueueService(val project: Project) {
         })
     }
 
-    fun downloadLatestRelease() {
+    fun downloadLatestRelease(indicator: ProgressIndicator) {
         // abort even before submitting a task
         if (!pluginSettings().manageBinariesAutomatically) {
             if (!isCliInstalled()) {
@@ -292,7 +292,7 @@ class SnykTaskQueueService(val project: Project) {
         val cliDownloader = getSnykCliDownloaderService()
 
         taskQueue.run(object : Task.Backgroundable(project, "Check Snyk CLI presence", true) {
-            override fun run(indicator: ProgressIndicator) {
+            override fun run(ignored: ProgressIndicator) {
                 cliDownloadPublisher.checkCliExistsStarted()
                 if (project.isDisposed) return
 

--- a/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
@@ -34,7 +34,6 @@ import org.jetbrains.annotations.TestOnly
 import snyk.common.SnykError
 import snyk.common.lsp.LanguageServerWrapper
 import snyk.trust.confirmScanningAndSetWorkspaceTrustedStateIfNeeded
-import java.nio.file.Paths
 
 @Service
 class SnykTaskQueueService(val project: Project) {
@@ -88,10 +87,7 @@ class SnykTaskQueueService(val project: Project) {
     fun scan() {
         taskQueue.run(object : Task.Backgroundable(project, "Snyk: initializing...", true) {
             override fun run(indicator: ProgressIndicator) {
-                // FIXME: this should be using content roots instead of basePath
-                project.basePath?.let {
-                    if (!confirmScanningAndSetWorkspaceTrustedStateIfNeeded(project, Paths.get(it))) return
-                }
+                if (!confirmScanningAndSetWorkspaceTrustedStateIfNeeded(project)) return
 
                 ApplicationManager.getApplication().invokeAndWait {
                     FileDocumentManager.getInstance().saveAllDocuments()

--- a/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
@@ -79,8 +79,9 @@ class SnykTaskQueueService(val project: Project) {
             val languageServerWrapper = LanguageServerWrapper.getInstance()
             if (!languageServerWrapper.isInitialized && !languageServerWrapper.isInitializing) {
                 languageServerWrapper.initialize()
+                val added = languageServerWrapper.getWorkspaceFolders(project)
+                languageServerWrapper.updateWorkspaceFolders(added, emptySet())
             }
-            languageServerWrapper.updateWorkspaceFolders(languageServerWrapper.getWorkspaceFolders(project), emptySet())
         }
     }
 

--- a/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
@@ -76,12 +76,13 @@ class SnykTaskQueueService(val project: Project) {
     }
 
     fun connectProjectToLanguageServer(project: Project) {
-        synchronized(ls) {
-            if (!ls.isInitialized && !ls.isInitializing) {
-                ls.initialize()
+        synchronized(LanguageServerWrapper) {
+            val languageServerWrapper = LanguageServerWrapper.getInstance()
+            if (!languageServerWrapper.isInitialized && !languageServerWrapper.isInitializing) {
+                languageServerWrapper.initialize()
             }
+            languageServerWrapper.updateWorkspaceFolders(languageServerWrapper.getWorkspaceFolders(project), emptySet())
         }
-        ls.updateWorkspaceFolders(ls.getWorkspaceFolders(project), emptySet())
     }
 
     fun scan() {
@@ -117,7 +118,7 @@ class SnykTaskQueueService(val project: Project) {
 
     fun waitUntilCliDownloadedIfNeeded(indicator: ProgressIndicator) {
         indicator.text = "Snyk waits for CLI to be downloaded..."
-        downloadLatestRelease(indicator)
+        downloadLatestRelease()
         do {
             indicator.checkCanceled()
             Thread.sleep(WAIT_FOR_DOWNLOAD_MILLIS)
@@ -281,7 +282,7 @@ class SnykTaskQueueService(val project: Project) {
         })
     }
 
-    fun downloadLatestRelease(indicator: ProgressIndicator) {
+    fun downloadLatestRelease() {
         // abort even before submitting a task
         if (!pluginSettings().manageBinariesAutomatically) {
             if (!isCliInstalled()) {
@@ -327,6 +328,5 @@ class SnykTaskQueueService(val project: Project) {
 
     companion object {
         private const val WAIT_FOR_DOWNLOAD_MILLIS = 1000L
-        val ls = LanguageServerWrapper()
     }
 }

--- a/src/main/kotlin/io/snyk/plugin/services/download/CliDownloader.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/download/CliDownloader.kt
@@ -47,6 +47,7 @@ class CliDownloader {
             val message = "Cannot create file in the configured CLI path directory ${cliFile.parent}. " +
                 "Please either change the CLI path to a writeable directory or give the " +
                 "current directory write permissions."
+            indicator.cancel()
             throw IOException(message, e)
         }
         try {

--- a/src/main/kotlin/io/snyk/plugin/services/download/CliDownloader.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/download/CliDownloader.kt
@@ -40,7 +40,7 @@ class CliDownloader {
 
     fun downloadFile(cliFile: File, expectedSha: String, indicator: ProgressIndicator): File {
         indicator.checkCanceled()
-        val downloadFile = File.createTempFile(cliFile.name, ".download", cliFile.parentFile)
+        val downloadFile = File.createTempFile(cliFile.name, ".download", null)
         try {
             downloadFile.deleteOnExit()
 
@@ -52,6 +52,7 @@ class CliDownloader {
 
             indicator.checkCanceled()
             if (cliFile.exists()) {
+
                 cliFile.delete()
             }
             try {

--- a/src/main/kotlin/io/snyk/plugin/services/download/CliDownloader.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/download/CliDownloader.kt
@@ -5,6 +5,7 @@ import io.snyk.plugin.cli.Platform
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.services.download.HttpRequestHelper.createRequest
 import java.io.File
+import java.io.IOException
 import java.nio.file.AtomicMoveNotSupportedException
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
@@ -40,7 +41,14 @@ class CliDownloader {
 
     fun downloadFile(cliFile: File, expectedSha: String, indicator: ProgressIndicator): File {
         indicator.checkCanceled()
-        val downloadFile = File.createTempFile(cliFile.name, ".download", null)
+        val downloadFile = try {
+            File.createTempFile(cliFile.name, ".download", cliFile.parentFile)
+        } catch (e: Exception) {
+            val message = "Cannot create file in the configured CLI path directory ${cliFile.parent}. " +
+                "Please either change the CLI path to a writeable directory or give the " +
+                "current directory write permissions."
+            throw IOException(message, e)
+        }
         try {
             downloadFile.deleteOnExit()
 
@@ -52,7 +60,6 @@ class CliDownloader {
 
             indicator.checkCanceled()
             if (cliFile.exists()) {
-
                 cliFile.delete()
             }
             try {
@@ -62,7 +69,7 @@ class CliDownloader {
                     StandardCopyOption.ATOMIC_MOVE,
                     StandardCopyOption.REPLACE_EXISTING
                 )
-            } catch (e: AtomicMoveNotSupportedException) {
+            } catch (ignored: AtomicMoveNotSupportedException) {
                 // fallback to renameTo because of e
                 downloadFile.renameTo(cliFile)
             }

--- a/src/main/kotlin/io/snyk/plugin/services/download/CliDownloaderErrorHandler.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/download/CliDownloaderErrorHandler.kt
@@ -44,7 +44,7 @@ class CliDownloaderErrorHandler {
     }
 
     fun getNetworkErrorNotificationMessage(exception: IOException) =
-        "The download of the Snyk CLI was interrupted by a network error (${exception.localizedMessage}). " +
+        "The download of the Snyk CLI was interrupted by an error (${exception.localizedMessage}). " +
             "Do you want to try again?"
 
     fun handleHttpStatusException(exception: HttpRequests.HttpStatusException, project: Project) {

--- a/src/main/kotlin/io/snyk/plugin/services/download/CliDownloaderErrorHandler.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/download/CliDownloaderErrorHandler.kt
@@ -31,9 +31,10 @@ class CliDownloaderErrorHandler {
 
     private fun retryDownload(project: Project, indicator: ProgressIndicator, message: String) {
         runBackgroundableTask("Retry Snyk CLI Download", project, false) {
+            val cliDownloaderService = project.getService(SnykCliDownloaderService::class.java)
             try {
                 // not using the service here to not causing an endless recursion (the service triggers a retry)
-                val downloader = project.getService(SnykCliDownloaderService::class.java).downloader
+                val downloader = cliDownloaderService.downloader
                 downloader.downloadFile(getCliFile(), downloader.expectedSha(), indicator)
             } catch (throwable: Throwable) { // we must catch throwable as IntelliJ could throw AssertionError
                 // IntelliJ throws an exception if we log an error, and in this case it is just the retry that failed

--- a/src/main/kotlin/io/snyk/plugin/services/download/CliDownloaderService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/download/CliDownloaderService.kt
@@ -3,6 +3,7 @@ package io.snyk.plugin.services.download
 import com.google.gson.annotations.SerializedName
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
+import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.project.Project
 import com.intellij.util.io.HttpRequests
@@ -12,10 +13,12 @@ import io.snyk.plugin.getCliFile
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.services.download.HttpRequestHelper.createRequest
 import io.snyk.plugin.tail
+import snyk.common.lsp.LanguageServerWrapper
 import java.io.IOException
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 import java.util.Date
+import java.util.concurrent.TimeUnit
 
 @Service
 class SnykCliDownloaderService {
@@ -77,7 +80,16 @@ class SnykCliDownloaderService {
             indicator.text = "Downloading latest Snyk CLI release..."
             indicator.checkCanceled()
 
+            val languageServerWrapper = LanguageServerWrapper.getInstance()
             try {
+                if (languageServerWrapper.isInitialized) {
+                    try {
+                        languageServerWrapper.shutdown().get(2, TimeUnit.SECONDS)
+                    } catch (e: RuntimeException) {
+                        logger<SnykCliDownloaderService>()
+                            .warn("Language server shutdown for download took too long, couldn't shutdown", e)
+                    }
+                }
                 downloader.downloadFile(cliFile, downloader.expectedSha(), indicator)
                 pluginSettings().cliVersion = cliVersionNumbers(cliVersion)
                 pluginSettings().lastCheckDate = Date()
@@ -88,6 +100,8 @@ class SnykCliDownloaderService {
                 errorHandler.handleIOException(e, indicator, project)
             } catch (e: ChecksumVerificationException) {
                 errorHandler.handleChecksumVerificationException(e, indicator, project)
+            } finally {
+                languageServerWrapper.initialize()
             }
         } finally {
             currentProgressIndicator = null

--- a/src/main/kotlin/io/snyk/plugin/services/download/CliDownloaderService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/download/CliDownloaderService.kt
@@ -101,11 +101,11 @@ class SnykCliDownloaderService {
             } catch (e: ChecksumVerificationException) {
                 errorHandler.handleChecksumVerificationException(e, indicator, project)
             } finally {
-                languageServerWrapper.initialize()
+                if (succeeded) languageServerWrapper.initialize() else stopCliDownload()
             }
         } finally {
-            currentProgressIndicator = null
             cliDownloadPublisher.cliDownloadFinished(succeeded)
+            stopCliDownload()
         }
     }
 

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/nodes/leaf/SuggestionTreeNode.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/nodes/leaf/SuggestionTreeNode.kt
@@ -20,6 +20,7 @@ class SuggestionTreeNode(
     override val navigateToSource: () -> Unit
 ) : DefaultMutableTreeNode(Pair(suggestion, rangeIndex)), NavigatableToSourceTreeNode, DescriptionHolderTreeNode {
 
+    @Suppress("UNCHECKED_CAST")
     override fun getDescriptionPanel(logEventNeeded: Boolean): IssueDescriptionPanelBase {
         if (logEventNeeded) getSnykAnalyticsService().logIssueInTreeIsClicked(
             IssueInTreeIsClicked.builder()

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/SnykAuthPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/SnykAuthPanel.kt
@@ -15,7 +15,7 @@ import icons.SnykIcons
 import io.snyk.plugin.events.SnykCliDownloadListener
 import io.snyk.plugin.events.SnykSettingsListener
 import io.snyk.plugin.getAmplitudeExperimentService
-import io.snyk.plugin.getContentRoots
+import io.snyk.plugin.getContentRootPaths
 import io.snyk.plugin.getSnykAnalyticsService
 import io.snyk.plugin.getSnykCliAuthenticationService
 import io.snyk.plugin.getSnykCliDownloaderService
@@ -65,7 +65,7 @@ class SnykAuthPanel(val project: Project) : JPanel(), Disposable {
                     // scan can be auto-triggered depending on "settings.pluginFirstRun" value
                     jButton.setText("Trusting project paths...")
                     val trustService = service<WorkspaceTrustService>()
-                    val paths = project.getContentRoots()
+                    val paths = project.getContentRootPaths()
                     for (path in paths) {
                         trustService.addTrustedPath(path)
                     }

--- a/src/main/kotlin/snyk/PluginInformation.kt
+++ b/src/main/kotlin/snyk/PluginInformation.kt
@@ -26,7 +26,7 @@ private fun getPluginInformation(): PluginInformation {
     return PluginInformation(
         integrationName = "JETBRAINS_IDE",
         integrationVersion = snykPluginVersion,
-        integrationEnvironment = integrationEnvironment.toUpperCase(),
+        integrationEnvironment = integrationEnvironment.uppercase(),
         integrationEnvironmentVersion = applicationInfo.fullVersion
     )
 }

--- a/src/main/kotlin/snyk/common/UIComponentFinder.kt
+++ b/src/main/kotlin/snyk/common/UIComponentFinder.kt
@@ -7,11 +7,10 @@ import kotlin.reflect.cast
 
 object UIComponentFinder {
 
-    @OptIn(ExperimentalStdlibApi::class)
     fun <T : Component> getComponentByName(parent: Container, clazz: KClass<T>, name: String? = null): T? =
         getComponentByCondition(parent, clazz) { name == null || name == it.name }
 
-    @OptIn(ExperimentalStdlibApi::class)
+    @Suppress("UNCHECKED_CAST")
     fun <T : Component> getComponentByCondition(parent: Container, clazz: KClass<T>, condition: (T) -> Boolean): T? {
         val components = parent.components
         var found: T? = null

--- a/src/main/kotlin/snyk/common/lsp/LanguageServerSettings.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerSettings.kt
@@ -4,7 +4,7 @@ package snyk.common.lsp
 
 import com.google.gson.annotations.SerializedName
 import io.snyk.plugin.pluginSettings
-import org.apache.commons.lang.SystemUtils
+import org.apache.commons.lang3.SystemUtils
 import snyk.pluginInfo
 
 data class LanguageServerSettings(

--- a/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
@@ -183,7 +183,7 @@ class LanguageServerWrapper(
     }
 
     companion object {
-        private val INSTANCE = LanguageServerWrapper(executorService = Executors.newCachedThreadPool())
-        fun getInstance() = INSTANCE
+        private var INSTANCE: LanguageServerWrapper? = null
+        fun getInstance() = INSTANCE ?: LanguageServerWrapper().also { INSTANCE = it }
     }
 }

--- a/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
@@ -68,14 +68,14 @@ class LanguageServerWrapper(
         get() = ::languageClient.isInitialized &&
             ::languageServer.isInitialized &&
             ::process.isInitialized &&
-            process.info()
-                .startInstant().isPresent &&
+            process.info().startInstant().isPresent &&
             process.isAlive
 
     @OptIn(DelicateCoroutinesApi::class)
     internal fun initialize() {
         if (lsPath.toNioPathOrNull()?.exists() == false) {
-            SnykBalloonNotificationHelper.showError("Snyk Language Server not found. Please make sure the Snyk CLI is installed at $lsPath.", null)
+            val message = "Snyk Language Server not found. Please make sure the Snyk CLI is installed at $lsPath."
+            SnykBalloonNotificationHelper.showError(message, null)
             return
         }
         try {

--- a/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
@@ -3,9 +3,9 @@ package snyk.common.lsp
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
-import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.util.io.toNioPathOrNull
 import io.snyk.plugin.getCliFile
+import io.snyk.plugin.getContentRootVirtualFiles
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.ui.SnykBalloonNotificationHelper
 import kotlinx.coroutines.DelicateCoroutinesApi
@@ -121,8 +121,7 @@ class LanguageServerWrapper(
     }
 
     fun getWorkspaceFolders(project: Project) =
-        ProjectRootManager.getInstance(project).contentRoots.filter { it.exists() }.filter { it.isDirectory }
-            .mapNotNull { WorkspaceFolder(it.url, it.name) }.toSet()
+        project.getContentRootVirtualFiles().mapNotNull { WorkspaceFolder(it.url, it.name) }.toSet()
 
     fun sendInitializeMessage() {
         val workspaceFolders = determineWorkspaceFolders()

--- a/src/main/kotlin/snyk/trust/TrustedProjects.kt
+++ b/src/main/kotlin/snyk/trust/TrustedProjects.kt
@@ -1,4 +1,5 @@
 @file:JvmName("TrustedProjectsKt")
+
 package snyk.trust
 
 import com.intellij.openapi.application.invokeAndWaitIfNeeded
@@ -7,9 +8,8 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.MessageDialogBuilder
 import com.intellij.openapi.ui.Messages
+import io.snyk.plugin.getContentRoots
 import snyk.SnykBundle
-import java.nio.file.Files
-import java.nio.file.Path
 
 private val LOG = Logger.getInstance("snyk.trust.TrustedProjects")
 
@@ -19,29 +19,29 @@ private val LOG = Logger.getInstance("snyk.trust.TrustedProjects")
  *
  * @return `false` if the user chose not to scan the project at all; `true` otherwise
  */
-fun confirmScanningAndSetWorkspaceTrustedStateIfNeeded(project: Project, projectFileOrDir: Path): Boolean {
-    val projectDir = if (Files.isDirectory(projectFileOrDir)) projectFileOrDir else projectFileOrDir.parent
-
+fun confirmScanningAndSetWorkspaceTrustedStateIfNeeded(project: Project): Boolean {
+    val paths = project.getContentRoots()
     val trustService = service<WorkspaceTrustService>()
-    val trustedState = trustService.isPathTrusted(projectDir)
-    if (!trustedState) {
-        LOG.info("Asking user to trust the project ${projectDir.fileName}")
-        return when (confirmScanningUntrustedProject(project, projectDir)) {
+    for (path in paths) {
+        val trustedState = trustService.isPathTrusted(path)
+        if (trustedState) continue
+
+        LOG.info("Asking user to trust the project ${project.name}")
+        val trustProject = confirmScanningUntrustedProject(project)
+        return when (trustProject) {
             ScanUntrustedProjectChoice.TRUST_AND_SCAN -> {
-                trustService.addTrustedPath(projectDir)
+                paths.forEach { p -> trustService.addTrustedPath(p) }
                 true
             }
 
             ScanUntrustedProjectChoice.CANCEL -> false
         }
     }
-
     return true
 }
 
-private fun confirmScanningUntrustedProject(project: Project, projectDir: Path): ScanUntrustedProjectChoice {
-    val fileName = projectDir.fileName ?: projectDir.toString()
-    val title = SnykBundle.message("snyk.trust.dialog.warning.title", fileName)
+private fun confirmScanningUntrustedProject(project: Project): ScanUntrustedProjectChoice {
+    val title = SnykBundle.message("snyk.trust.dialog.warning.title", project.name)
     val message = SnykBundle.message("snyk.trust.dialog.warning.text")
     val trustButton = SnykBundle.message("snyk.trust.dialog.warning.button.trust")
     val distrustButton = SnykBundle.message("snyk.trust.dialog.warning.button.distrust")
@@ -57,10 +57,10 @@ private fun confirmScanningUntrustedProject(project: Project, projectDir: Path):
             .ask(project)
 
         choice = if (result) {
-            LOG.info("User trusts the project $fileName for scans")
+            LOG.info("User trusts the project $project for scans")
             ScanUntrustedProjectChoice.TRUST_AND_SCAN
         } else {
-            LOG.info("User doesn't trust the project $fileName for scans")
+            LOG.info("User doesn't trust the project $project for scans")
             ScanUntrustedProjectChoice.CANCEL
         }
     }

--- a/src/main/kotlin/snyk/trust/TrustedProjects.kt
+++ b/src/main/kotlin/snyk/trust/TrustedProjects.kt
@@ -8,7 +8,7 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.MessageDialogBuilder
 import com.intellij.openapi.ui.Messages
-import io.snyk.plugin.getContentRoots
+import io.snyk.plugin.getContentRootPaths
 import snyk.SnykBundle
 
 private val LOG = Logger.getInstance("snyk.trust.TrustedProjects")
@@ -20,7 +20,7 @@ private val LOG = Logger.getInstance("snyk.trust.TrustedProjects")
  * @return `false` if the user chose not to scan the project at all; `true` otherwise
  */
 fun confirmScanningAndSetWorkspaceTrustedStateIfNeeded(project: Project): Boolean {
-    val paths = project.getContentRoots()
+    val paths = project.getContentRootPaths()
     val trustService = service<WorkspaceTrustService>()
     for (path in paths) {
         val trustedState = trustService.isPathTrusted(path)

--- a/src/main/kotlin/snyk/trust/WorkspaceTrustService.kt
+++ b/src/main/kotlin/snyk/trust/WorkspaceTrustService.kt
@@ -16,6 +16,10 @@ class WorkspaceTrustService {
 
     fun addTrustedPath(path: Path) {
         LOG.debug("Adding trusted path: $path")
+        if (settings.getTrustedPaths().contains(path.toString())) {
+            LOG.debug("Path is already trusted: $path")
+            return
+        }
         settings.addTrustedPath(path.toString())
     }
 

--- a/src/test/java/snyk/common/lsp/LanguageServerWrapperTest.kt
+++ b/src/test/java/snyk/common/lsp/LanguageServerWrapperTest.kt
@@ -67,6 +67,7 @@ class LanguageServerWrapperTest {
         val processMock = mockk<Process>(relaxed = true)
         cut.process = processMock
         every { processMock.info().startInstant().isPresent } returns true
+        every { processMock.isAlive } returns true
         every {
             lsMock.workspaceService.executeCommand(any<ExecuteCommandParams>())
         } returns CompletableFuture.completedFuture(null)

--- a/src/test/java/snyk/common/lsp/LanguageServerWrapperTest.kt
+++ b/src/test/java/snyk/common/lsp/LanguageServerWrapperTest.kt
@@ -19,6 +19,7 @@ import org.junit.Before
 import org.junit.Test
 import snyk.pluginInfo
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executors
 
 class LanguageServerWrapperTest {
 
@@ -39,7 +40,7 @@ class LanguageServerWrapperTest {
         every { pluginInfo.integrationEnvironment } returns "IntelliJ IDEA"
         every { pluginInfo.integrationEnvironmentVersion } returns "2020.3.2"
 
-        cut = LanguageServerWrapper("dummy")
+        cut = LanguageServerWrapper("dummy", Executors.newCachedThreadPool())
         cut.languageServer = lsMock
     }
 

--- a/src/test/kotlin/io/snyk/plugin/TestUtils.kt
+++ b/src/test/kotlin/io/snyk/plugin/TestUtils.kt
@@ -11,6 +11,7 @@ import io.mockk.mockkObject
 import io.snyk.plugin.services.SnykApplicationSettingsStateService
 import io.snyk.plugin.services.SnykProjectSettingsStateService
 import io.snyk.plugin.services.download.HttpRequestHelper
+import snyk.common.lsp.LanguageServerWrapper
 import java.io.File
 import java.nio.file.Path
 
@@ -42,6 +43,7 @@ fun resetSettings(project: Project?) {
         SnykProjectSettingsStateService(),
         project
     )
+    LanguageServerWrapper.getInstance().shutdown()
 }
 
 /** low level avoiding download the CLI file */

--- a/src/test/kotlin/io/snyk/plugin/analytics/AnalyticsScanListenerTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/analytics/AnalyticsScanListenerTest.kt
@@ -12,7 +12,6 @@ import io.snyk.plugin.getArch
 import io.snyk.plugin.getOS
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.services.SnykApplicationSettingsStateService
-import io.snyk.plugin.services.SnykTaskQueueService
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertNotNull
 import org.junit.After
@@ -34,8 +33,8 @@ class AnalyticsScanListenerTest {
         mockkStatic("io.snyk.plugin.UtilsKt")
         every { pluginSettings() } returns settings
 
-        mockkObject(SnykTaskQueueService.Companion)
-        every { SnykTaskQueueService.ls } returns languageServerWrapper
+        mockkObject(LanguageServerWrapper.Companion)
+        every { LanguageServerWrapper.getInstance() } returns languageServerWrapper
         justRun { languageServerWrapper.sendReportAnalyticsCommand(any()) }
 
         mockkStatic("snyk.PluginInformationKt")

--- a/src/test/kotlin/io/snyk/plugin/extensions/SnykControllerImplTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/extensions/SnykControllerImplTest.kt
@@ -1,7 +1,5 @@
 package io.snyk.plugin.extensions
 
-import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.components.service
 import com.intellij.testFramework.LightPlatformTestCase
 import com.intellij.testFramework.PlatformTestUtil
 import com.intellij.testFramework.replaceService
@@ -10,31 +8,16 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.spyk
 import io.mockk.unmockkAll
-import io.mockk.verify
-import io.snyk.plugin.extensions.SnykControllerImpl
-import io.snyk.plugin.getCliFile
-import io.snyk.plugin.getContainerService
-import io.snyk.plugin.getIacService
 import io.snyk.plugin.getOssService
 import io.snyk.plugin.getSnykCachedResults
 import io.snyk.plugin.getSnykCliDownloaderService
 import io.snyk.plugin.isCliInstalled
-import io.snyk.plugin.isContainerEnabled
-import io.snyk.plugin.isIacEnabled
-import io.snyk.plugin.net.CliConfigSettings
-import io.snyk.plugin.net.LocalCodeEngine
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.removeDummyCliFile
 import io.snyk.plugin.resetSettings
-import io.snyk.plugin.services.SnykApiService
-import io.snyk.plugin.services.SnykTaskQueueService
-import io.snyk.plugin.services.download.CliDownloader
 import io.snyk.plugin.services.download.LatestReleaseInfo
 import io.snyk.plugin.services.download.SnykCliDownloaderService
-import io.snyk.plugin.setupDummyCliFile
 import org.awaitility.Awaitility.await
-import snyk.container.ContainerResult
-import snyk.iac.IacResult
 import snyk.oss.OssResult
 import snyk.oss.OssService
 import snyk.trust.confirmScanningAndSetWorkspaceTrustedStateIfNeeded
@@ -62,7 +45,7 @@ class SnykControllerImplTest : LightPlatformTestCase() {
         )
         every { getSnykCliDownloaderService() } returns downloaderServiceMock
         every { downloaderServiceMock.isFourDaysPassedSinceLastCheck() } returns false
-        every { confirmScanningAndSetWorkspaceTrustedStateIfNeeded(any(), any()) } returns true
+        every { confirmScanningAndSetWorkspaceTrustedStateIfNeeded(any()) } returns true
     }
 
     override fun tearDown() {

--- a/src/test/kotlin/io/snyk/plugin/services/SnykTaskQueueServiceTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/services/SnykTaskQueueServiceTest.kt
@@ -31,6 +31,7 @@ import io.snyk.plugin.services.download.LatestReleaseInfo
 import io.snyk.plugin.services.download.SnykCliDownloaderService
 import io.snyk.plugin.setupDummyCliFile
 import org.awaitility.Awaitility.await
+import snyk.common.lsp.LanguageServerWrapper
 import snyk.container.ContainerResult
 import snyk.iac.IacResult
 import snyk.oss.OssResult
@@ -67,10 +68,10 @@ class SnykTaskQueueServiceTest : LightPlatformTestCase() {
 
         every { getSnykCliDownloaderService() } returns downloaderServiceMock
         every { downloaderServiceMock.isFourDaysPassedSinceLastCheck() } returns false
-        every { confirmScanningAndSetWorkspaceTrustedStateIfNeeded(any(), any()) } returns true
+        every { confirmScanningAndSetWorkspaceTrustedStateIfNeeded(any()) } returns true
 
-        mockkObject(SnykTaskQueueService.Companion)
-        every { SnykTaskQueueService.ls } returns mockk(relaxed = true)
+        mockkObject(LanguageServerWrapper.Companion)
+        every { LanguageServerWrapper.getInstance() } returns mockk(relaxed = true)
     }
 
     private fun mockSnykApiServiceSastEnabled() {

--- a/src/test/kotlin/io/snyk/plugin/services/SnykTaskQueueServiceTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/services/SnykTaskQueueServiceTest.kt
@@ -2,7 +2,6 @@ package io.snyk.plugin.services
 
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.service
-import com.intellij.openapi.progress.EmptyProgressIndicator
 import com.intellij.testFramework.LightPlatformTestCase
 import com.intellij.testFramework.PlatformTestUtil
 import com.intellij.testFramework.replaceService
@@ -104,7 +103,7 @@ class SnykTaskQueueServiceTest : LightPlatformTestCase() {
 
         assertTrue(snykTaskQueueService.getTaskQueue().isEmpty)
 
-        snykTaskQueueService.downloadLatestRelease(EmptyProgressIndicator())
+        snykTaskQueueService.downloadLatestRelease()
         PlatformTestUtil.dispatchAllInvocationEventsInIdeEventQueue()
 
         assertTrue(snykTaskQueueService.getTaskQueue().isEmpty)
@@ -165,7 +164,7 @@ class SnykTaskQueueServiceTest : LightPlatformTestCase() {
         setProject(null) // to avoid double disposing effort in tearDown
 
         // the Task should roll out gracefully without any Exception or Error
-        snykTaskQueueService.downloadLatestRelease(EmptyProgressIndicator())
+        snykTaskQueueService.downloadLatestRelease()
     }
 
     fun testSastEnablementCheckInScan() {

--- a/src/test/kotlin/io/snyk/plugin/services/SnykTaskQueueServiceTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/services/SnykTaskQueueServiceTest.kt
@@ -104,7 +104,7 @@ class SnykTaskQueueServiceTest : LightPlatformTestCase() {
 
         assertTrue(snykTaskQueueService.getTaskQueue().isEmpty)
 
-        snykTaskQueueService.downloadLatestRelease(indicator)
+        snykTaskQueueService.downloadLatestRelease()
         PlatformTestUtil.dispatchAllInvocationEventsInIdeEventQueue()
 
         assertTrue(snykTaskQueueService.getTaskQueue().isEmpty)
@@ -165,7 +165,7 @@ class SnykTaskQueueServiceTest : LightPlatformTestCase() {
         setProject(null) // to avoid double disposing effort in tearDown
 
         // the Task should roll out gracefully without any Exception or Error
-        snykTaskQueueService.downloadLatestRelease(indicator)
+        snykTaskQueueService.downloadLatestRelease()
     }
 
     fun testSastEnablementCheckInScan() {

--- a/src/test/kotlin/io/snyk/plugin/services/SnykTaskQueueServiceTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/services/SnykTaskQueueServiceTest.kt
@@ -104,7 +104,7 @@ class SnykTaskQueueServiceTest : LightPlatformTestCase() {
 
         assertTrue(snykTaskQueueService.getTaskQueue().isEmpty)
 
-        snykTaskQueueService.downloadLatestRelease()
+        snykTaskQueueService.downloadLatestRelease(indicator)
         PlatformTestUtil.dispatchAllInvocationEventsInIdeEventQueue()
 
         assertTrue(snykTaskQueueService.getTaskQueue().isEmpty)
@@ -165,7 +165,7 @@ class SnykTaskQueueServiceTest : LightPlatformTestCase() {
         setProject(null) // to avoid double disposing effort in tearDown
 
         // the Task should roll out gracefully without any Exception or Error
-        snykTaskQueueService.downloadLatestRelease()
+        snykTaskQueueService.downloadLatestRelease(indicator)
     }
 
     fun testSastEnablementCheckInScan() {

--- a/src/test/kotlin/io/snyk/plugin/services/download/CliDownloaderServiceIntegTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/services/download/CliDownloaderServiceIntegTest.kt
@@ -7,6 +7,7 @@ import com.intellij.util.io.HttpRequests
 import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
+import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.spyk
 import io.mockk.unmockkAll
@@ -18,6 +19,7 @@ import io.snyk.plugin.removeDummyCliFile
 import io.snyk.plugin.resetSettings
 import io.snyk.plugin.services.SnykApplicationSettingsStateService
 import org.apache.http.HttpStatus
+import snyk.common.lsp.LanguageServerWrapper
 import java.io.File
 import java.net.SocketTimeoutException
 import java.time.LocalDate
@@ -37,6 +39,8 @@ class CliDownloaderServiceIntegTest : LightPlatformTestCase() {
         unmockkAll()
         resetSettings(project)
         mockkStatic("io.snyk.plugin.UtilsKt")
+        mockkObject(LanguageServerWrapper.Companion)
+        every { LanguageServerWrapper.getInstance() } returns mockk(relaxed = true)
         every { pluginSettings() } returns SnykApplicationSettingsStateService()
         cliFile = getCliFile()
         cut = project.service()

--- a/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanelIntegTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanelIntegTest.kt
@@ -47,6 +47,7 @@ import io.snyk.plugin.ui.toolwindow.panels.VulnerabilityDescriptionPanel
 import org.junit.Test
 import snyk.common.SnykError
 import snyk.common.UIComponentFinder
+import snyk.common.lsp.LanguageServerWrapper
 import snyk.container.ContainerIssue
 import snyk.container.ContainerIssuesForImage
 import snyk.container.ContainerResult
@@ -96,13 +97,15 @@ class SnykToolWindowPanelIntegTest : HeavyPlatformTestCase() {
         unmockkAll()
         resetSettings(project)
         mockkStatic("snyk.trust.TrustedProjectsKt")
+        mockkObject(LanguageServerWrapper.Companion)
+        every { LanguageServerWrapper.getInstance() } returns mockk(relaxed = true)
         pluginSettings().token = fakeApiToken // needed to avoid forced Auth panel showing
         pluginSettings().pluginFirstRun = false
         // ToolWindow need to be reinitialised for every test as Project is recreated for Heavy tests
         // also we MUST do it *before* any actual test code due to initialisation of SnykScanListener in init{}
         toolWindowPanel = project.service()
         setupDummyCliFile()
-        every { confirmScanningAndSetWorkspaceTrustedStateIfNeeded(any(), any()) } returns true
+        every { confirmScanningAndSetWorkspaceTrustedStateIfNeeded(any()) } returns true
         mockkStatic(GotoFileCellRenderer::class)
         every { GotoFileCellRenderer.getRelativePath(any(), any()) } returns "abc/"
     }


### PR DESCRIPTION
### Description

- close down language server during download of CLI
- better messaging when CLI directory is not writeable
- use content roots for trust instead of the project, as project.basePath is not accurate for this.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

![image](https://github.com/snyk/snyk-intellij-plugin/assets/20150761/5432dd9f-1c05-44f6-8a30-072a31943266)
