### PR TITLE
fix: (LS Preview) Snyk Code scans when having multiple projects open [IDE-160]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Snyk Changelog
 
+## [2.7.7]
+### Fixed
+- Snyk Code scans when having multiple projects open (LS Preview) [IDE-160]
+
 ## [2.7.6]
 ### Fixed
 - some code refactorings and code smells

--- a/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
@@ -77,12 +77,10 @@ class SnykTaskQueueService(val project: Project) {
 
     fun connectProjectToLanguageServer(project: Project) {
         synchronized(LanguageServerWrapper) {
-            val languageServerWrapper = LanguageServerWrapper.getInstance()
-            if (!languageServerWrapper.isInitialized && !languageServerWrapper.isInitializing) {
-                languageServerWrapper.initialize()
-                val added = languageServerWrapper.getWorkspaceFolders(project)
-                languageServerWrapper.updateWorkspaceFolders(added, emptySet())
-            }
+            val wrapper = LanguageServerWrapper.getInstance()
+            wrapper.ensureLanguageServerInitialized()
+            val added = wrapper.getWorkspaceFolders(project)
+            wrapper.updateWorkspaceFolders(added, emptySet())
         }
     }
 

--- a/src/main/kotlin/snyk/common/lsp/ScanState.kt
+++ b/src/main/kotlin/snyk/common/lsp/ScanState.kt
@@ -1,8 +1,11 @@
 package snyk.common.lsp
 
+import com.intellij.openapi.vfs.VirtualFile
+import snyk.common.ProductType
 import java.util.Collections
 
 object ScanState {
-    const val SNYK_CODE = "code"
-    val scanInProgress: MutableMap<String, Boolean> = Collections.synchronizedMap(mutableMapOf())
+    val scanInProgress: MutableMap<ScanInProgressKey, Boolean> = Collections.synchronizedMap(mutableMapOf())
 }
+
+data class ScanInProgressKey(val folderPath: VirtualFile, val productType: ProductType)

--- a/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
+++ b/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
@@ -40,6 +40,7 @@ import org.eclipse.lsp4j.WorkDoneProgressKind.report
 import org.eclipse.lsp4j.WorkDoneProgressReport
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification
 import org.eclipse.lsp4j.services.LanguageClient
+import snyk.common.ProductType
 import snyk.common.SnykCodeFileIssueComparator
 import snyk.trust.WorkspaceTrustService
 import java.util.Collections
@@ -82,36 +83,52 @@ class SnykLanguageClient : LanguageClient {
     }
 
     override fun refreshInlineValues(): CompletableFuture<Void> {
-        val activeProject = ProjectUtil.getActiveProject() ?: return CompletableFuture.completedFuture(null)
+        val completedFuture: CompletableFuture<Void> = CompletableFuture.completedFuture(null)
+        if (!isSnykCodeLSEnabled()) return completedFuture
+        val activeProject = ProjectUtil.getActiveProject() ?: return completedFuture
+
         DaemonCodeAnalyzer.getInstance(activeProject).restart()
-        return CompletableFuture.completedFuture(null)
+        return completedFuture
     }
 
     @JsonNotification(value = "$/snyk.scan")
     fun snykScan(snykScan: SnykScanParams) {
-        if (snykScan.product != ScanState.SNYK_CODE || !isSnykCodeLSEnabled()) return
+        if (!isSnykCodeLSEnabled()) return
         try {
             getScanPublishersFor(snykScan).forEach { (project, scanPublisher) ->
-                when (snykScan.status) {
-                    "inProgress" -> {
-                        if (ScanState.scanInProgress[snykScan.product] == true) return
-                        ScanState.scanInProgress[snykScan.product] = true
-                        scanPublisher.scanningStarted(snykScan)
-                    }
-
-                    "success" -> {
-                        ScanState.scanInProgress[snykScan.product] = false
-                        processSuccessfulScan(snykScan, scanPublisher, project)
-                    }
-
-                    "error" -> {
-                        ScanState.scanInProgress[snykScan.product] = false
-                        scanPublisher.scanningSnykCodeError(snykScan)
-                    }
-                }
+                processSnykScan(snykScan, scanPublisher, project)
             }
         } catch (e: Exception) {
             logger.error("Error processing snyk scan", e)
+        }
+    }
+
+    private fun processSnykScan(
+        snykScan: SnykScanParams,
+        scanPublisher: SnykCodeScanListenerLS,
+        project: Project
+    ) {
+        val product = when (snykScan.product) {
+            "code" -> ProductType.CODE_SECURITY
+            else -> return
+        }
+        val key = ScanInProgressKey(snykScan.folderPath.toVirtualFile(), product)
+        when (snykScan.status) {
+            "inProgress" -> {
+                if (ScanState.scanInProgress[key] == true) return
+                ScanState.scanInProgress[key] = true
+                scanPublisher.scanningStarted(snykScan)
+            }
+
+            "success" -> {
+                ScanState.scanInProgress[key] = false
+                processSuccessfulScan(snykScan, scanPublisher, project)
+            }
+
+            "error" -> {
+                ScanState.scanInProgress[key] = false
+                scanPublisher.scanningSnykCodeError(snykScan)
+            }
         }
     }
 
@@ -150,11 +167,13 @@ class SnykLanguageClient : LanguageClient {
             }.toSet()
     }
 
+    @Suppress("UselessCallOnNotNull") // because lsp4j doesn't care about Kotlin non-null safety
     private fun getSnykCodeResult(project: Project, snykScan: SnykScanParams): Map<SnykCodeFile, List<ScanIssue>> {
         check(snykScan.product == "code") { "Expected Snyk Code scan result" }
+        if (snykScan.issues.isNullOrEmpty()) return emptyMap()
         val map = snykScan.issues
             .groupBy { it.filePath }
-            .map { (file, issues) -> SnykCodeFile(project, file.toVirtualFile()) to issues.sorted() }
+            .mapNotNull { (file, issues) -> SnykCodeFile(project, file.toVirtualFile()) to issues.sorted() }
             .filter { it.second.isNotEmpty() }
             .toMap()
         return map.toSortedMap(SnykCodeFileIssueComparator(map))


### PR DESCRIPTION
### Description

Previously, when more than one project was opened, Snyk Code scans via Language Server were not working. This PR fixes that behaviour, by 

a) maintaining a content-root specific scan state and
b) triggering scans by content root

Content roots are mirrored in Language Server as WorkspaceFolders

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
