### PR TITLE
fix: (LS-Preview) do not hang on missing answers to message requests, timeout after 5s [IDE-161]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Snyk Changelog
 
+## [2.7.7]
+### Fixed
+- (LS Preview) do not hang on missing answers to message requests, timeout after 5s
+
 ## [2.7.6]
 ### Fixed
 - some code refactorings and code smells

--- a/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
+++ b/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
@@ -45,6 +45,7 @@ import snyk.trust.WorkspaceTrustService
 import java.util.Collections
 import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
 
 class SnykLanguageClient : LanguageClient {
     // TODO FIX Log Level
@@ -256,20 +257,20 @@ class SnykLanguageClient : LanguageClient {
 
     override fun showMessageRequest(requestParams: ShowMessageRequestParams): CompletableFuture<MessageActionItem> {
         val project = ProjectUtil.getActiveProject() ?: return CompletableFuture.completedFuture(MessageActionItem(""))
+        showMessageRequestFutures.clear()
         val actions = requestParams.actions
             .map {
                 object : AnAction(it.title) {
                     override fun actionPerformed(p0: AnActionEvent) {
-                        val future = CompletableFuture.completedFuture(MessageActionItem(it.title))
-                        showMessageRequestFutures.put(future)
+                        showMessageRequestFutures.put(MessageActionItem(it.title))
                     }
                 }
             }.toSet().toTypedArray()
 
         val notification = SnykBalloonNotificationHelper.showInfo(requestParams.message, project, *actions)
-        val future = showMessageRequestFutures.take()
+        val messageActionItem = showMessageRequestFutures.poll(5, TimeUnit.SECONDS)
         notification.hideBalloon()
-        return future
+        return CompletableFuture.completedFuture(messageActionItem ?: MessageActionItem(""))
     }
 
     override fun logMessage(message: MessageParams?) {
@@ -286,6 +287,6 @@ class SnykLanguageClient : LanguageClient {
 
     companion object {
         // we only allow one message request at a time
-        val showMessageRequestFutures = ArrayBlockingQueue<CompletableFuture<MessageActionItem>>(1)
+        val showMessageRequestFutures = ArrayBlockingQueue<MessageActionItem>(1)
     }
 }


### PR DESCRIPTION
### Description

Before, not answering a request message prompt from language server blocked subsequent interactions with language server. This fixes that.

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
