### PR TITLE
fix: make sure to have annotators available for languages [IDE-181]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [2.7.7]
 ### Fixed
 - (LS Preview) do not hang on missing answers to message requests, timeout after 5s
+- Provide language-specific annotators for Snyk Code issues
 
 ## [2.7.6]
 ### Fixed

--- a/src/main/resources/META-INF/optional/withCsharp.xml
+++ b/src/main/resources/META-INF/optional/withCsharp.xml
@@ -1,4 +1,6 @@
 <idea-plugin>
   <extensions defaultExtensionNs="com.intellij">
+    <externalAnnotator language="C#" implementationClass="snyk.code.annotator.SnykCodeAnnotatorLS"/>
+    <externalAnnotator language="C#" implementationClass="snyk.code.annotator.SnykCodeAnnotator"/>
   </extensions>
 </idea-plugin>

--- a/src/main/resources/META-INF/optional/withGo.xml
+++ b/src/main/resources/META-INF/optional/withGo.xml
@@ -2,5 +2,9 @@
   <extensions defaultExtensionNs="com.intellij">
     <externalAnnotator language="vgo" implementationClass="snyk.oss.annotator.OSSGoModAnnotator"/>
     <externalAnnotator language="go" implementationClass="snyk.oss.annotator.OSSGoModAnnotator"/>
+    <externalAnnotator language="vgo" implementationClass="snyk.code.annotator.SnykCodeAnnotatorLS"/>
+    <externalAnnotator language="vgo" implementationClass="snyk.code.annotator.SnykCodeAnnotator"/>
+    <externalAnnotator language="go" implementationClass="snyk.code.annotator.SnykCodeAnnotatorLS"/>
+    <externalAnnotator language="go" implementationClass="snyk.code.annotator.SnykCodeAnnotator"/>
   </extensions>
 </idea-plugin>

--- a/src/main/resources/META-INF/optional/withHTML.xml
+++ b/src/main/resources/META-INF/optional/withHTML.xml
@@ -1,4 +1,6 @@
 <idea-plugin>
   <extensions defaultExtensionNs="com.intellij">
+    <externalAnnotator language="HTML" implementationClass="snyk.code.annotator.SnykCodeAnnotatorLS"/>
+    <externalAnnotator language="HTML" implementationClass="snyk.code.annotator.SnykCodeAnnotator"/>
   </extensions>
 </idea-plugin>

--- a/src/main/resources/META-INF/optional/withJava.xml
+++ b/src/main/resources/META-INF/optional/withJava.xml
@@ -2,5 +2,9 @@
   <extensions defaultExtensionNs="com.intellij">
     <externalAnnotator language="JAVA" implementationClass="snyk.oss.annotator.OSSMavenAnnotator"/>
     <externalAnnotator language="Groovy" implementationClass="snyk.oss.annotator.OSSGradleAnnotator"/>
+    <externalAnnotator language="JAVA" implementationClass="snyk.code.annotator.SnykCodeAnnotatorLS"/>
+    <externalAnnotator language="JAVA" implementationClass="snyk.code.annotator.SnykCodeAnnotator"/>
+    <externalAnnotator language="Groovy" implementationClass="snyk.code.annotator.SnykCodeAnnotatorLS"/>
+    <externalAnnotator language="Groovy" implementationClass="snyk.code.annotator.SnykCodeAnnotator"/>
   </extensions>
 </idea-plugin>

--- a/src/main/resources/META-INF/optional/withJavaScript.xml
+++ b/src/main/resources/META-INF/optional/withJavaScript.xml
@@ -1,4 +1,6 @@
 <idea-plugin>
   <extensions defaultExtensionNs="com.intellij">
+    <externalAnnotator language="JavaScript" implementationClass="snyk.code.annotator.SnykCodeAnnotatorLS"/>
+    <externalAnnotator language="JavaScript" implementationClass="snyk.code.annotator.SnykCodeAnnotator"/>
   </extensions>
 </idea-plugin>

--- a/src/main/resources/META-INF/optional/withKotlin.xml
+++ b/src/main/resources/META-INF/optional/withKotlin.xml
@@ -1,5 +1,7 @@
 <idea-plugin>
   <extensions defaultExtensionNs="com.intellij">
     <externalAnnotator language="kotlin" implementationClass="snyk.oss.annotator.OSSGradleAnnotator"/>
+    <externalAnnotator language="kotlin" implementationClass="snyk.code.annotator.SnykCodeAnnotatorLS"/>
+    <externalAnnotator language="kotlin" implementationClass="snyk.code.annotator.SnykCodeAnnotator"/>
   </extensions>
 </idea-plugin>

--- a/src/main/resources/META-INF/optional/withPHP.xml
+++ b/src/main/resources/META-INF/optional/withPHP.xml
@@ -1,4 +1,6 @@
 <idea-plugin>
   <extensions defaultExtensionNs="com.intellij">
+    <externalAnnotator language="PHP" implementationClass="snyk.code.annotator.SnykCodeAnnotatorLS"/>
+    <externalAnnotator language="PHP" implementationClass="snyk.code.annotator.SnykCodeAnnotator"/>
   </extensions>
 </idea-plugin>

--- a/src/main/resources/META-INF/optional/withPython.xml
+++ b/src/main/resources/META-INF/optional/withPython.xml
@@ -1,4 +1,6 @@
 <idea-plugin>
   <extensions defaultExtensionNs="com.intellij">
+    <externalAnnotator language="Python" implementationClass="snyk.code.annotator.SnykCodeAnnotatorLS"/>
+    <externalAnnotator language="Python" implementationClass="snyk.code.annotator.SnykCodeAnnotator"/>
   </extensions>
 </idea-plugin>


### PR DESCRIPTION
### Description

IntelliJ sometimes uses the annotator without explicit language definition (""), e.g for Java, but sometimes, e.g. for Kotlin, it needs a dedicated definition. This is just empirical on my machine, but as it doesn't cost much to define them, here they are.

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
