### PR TITLE
fix: check trust for content root before triggering Snyk Code scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Snyk Changelog
 
+## [2.7.8]
+### Fixed
+- (LS Preview) check trust for content root before triggering Snyk Code scans
+
 ## [2.7.7]
 ### Fixed
 - (LS Preview) Snyk Code scans when having multiple projects open


### PR DESCRIPTION
### Description

Previously, the trust setting was not checked before triggering a scan. This PR fixes this.

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
