### PR TITLE
fix: remove duplicated annotator definition [IDE-192]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [2.7.9]
 ### Fixed
 - fix: shortened plugin name to just Snyk Security
+- (LS Preview) Fix long-running UI operation to run outside of UI thread
+- Remove duplicated annotations in Snyk Code
 
 ## [2.7.8]
 ### Fixed

--- a/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
@@ -58,7 +58,6 @@ class LanguageServerWrapper(
     /**
      * The language client is used to receive messages from LS
      */
-    @Suppress("MemberVisibilityCanBePrivate")
     lateinit var languageClient: SnykLanguageClient
 
     /**

--- a/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
+++ b/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
@@ -175,6 +175,12 @@ class SnykLanguageClient : LanguageClient {
         val map = snykScan.issues
             .groupBy { it.filePath }
             .mapNotNull { (file, issues) -> SnykCodeFile(project, file.toVirtualFile()) to issues.sorted() }
+            .map {
+                // initialize all calculated values before they are needed, so we don't have to do it in the UI thread
+                it.first.relativePath
+                it.second.forEach { i -> i.textRange }
+                it
+            }
             .filter { it.second.isNotEmpty() }
             .toMap()
         return map.toSortedMap(SnykCodeFileIssueComparator(map))

--- a/src/main/resources/META-INF/optional/withCsharp.xml
+++ b/src/main/resources/META-INF/optional/withCsharp.xml
@@ -1,6 +1,4 @@
 <idea-plugin>
   <extensions defaultExtensionNs="com.intellij">
-    <externalAnnotator language="C#" implementationClass="snyk.code.annotator.SnykCodeAnnotatorLS"/>
-    <externalAnnotator language="C#" implementationClass="snyk.code.annotator.SnykCodeAnnotator"/>
   </extensions>
 </idea-plugin>

--- a/src/main/resources/META-INF/optional/withGo.xml
+++ b/src/main/resources/META-INF/optional/withGo.xml
@@ -2,9 +2,5 @@
   <extensions defaultExtensionNs="com.intellij">
     <externalAnnotator language="vgo" implementationClass="snyk.oss.annotator.OSSGoModAnnotator"/>
     <externalAnnotator language="go" implementationClass="snyk.oss.annotator.OSSGoModAnnotator"/>
-    <externalAnnotator language="vgo" implementationClass="snyk.code.annotator.SnykCodeAnnotatorLS"/>
-    <externalAnnotator language="vgo" implementationClass="snyk.code.annotator.SnykCodeAnnotator"/>
-    <externalAnnotator language="go" implementationClass="snyk.code.annotator.SnykCodeAnnotatorLS"/>
-    <externalAnnotator language="go" implementationClass="snyk.code.annotator.SnykCodeAnnotator"/>
   </extensions>
 </idea-plugin>

--- a/src/main/resources/META-INF/optional/withHTML.xml
+++ b/src/main/resources/META-INF/optional/withHTML.xml
@@ -1,6 +1,4 @@
 <idea-plugin>
   <extensions defaultExtensionNs="com.intellij">
-    <externalAnnotator language="HTML" implementationClass="snyk.code.annotator.SnykCodeAnnotatorLS"/>
-    <externalAnnotator language="HTML" implementationClass="snyk.code.annotator.SnykCodeAnnotator"/>
   </extensions>
 </idea-plugin>

--- a/src/main/resources/META-INF/optional/withJava.xml
+++ b/src/main/resources/META-INF/optional/withJava.xml
@@ -2,9 +2,5 @@
   <extensions defaultExtensionNs="com.intellij">
     <externalAnnotator language="JAVA" implementationClass="snyk.oss.annotator.OSSMavenAnnotator"/>
     <externalAnnotator language="Groovy" implementationClass="snyk.oss.annotator.OSSGradleAnnotator"/>
-    <externalAnnotator language="JAVA" implementationClass="snyk.code.annotator.SnykCodeAnnotatorLS"/>
-    <externalAnnotator language="JAVA" implementationClass="snyk.code.annotator.SnykCodeAnnotator"/>
-    <externalAnnotator language="Groovy" implementationClass="snyk.code.annotator.SnykCodeAnnotatorLS"/>
-    <externalAnnotator language="Groovy" implementationClass="snyk.code.annotator.SnykCodeAnnotator"/>
   </extensions>
 </idea-plugin>

--- a/src/main/resources/META-INF/optional/withJavaScript.xml
+++ b/src/main/resources/META-INF/optional/withJavaScript.xml
@@ -1,6 +1,4 @@
 <idea-plugin>
   <extensions defaultExtensionNs="com.intellij">
-    <externalAnnotator language="JavaScript" implementationClass="snyk.code.annotator.SnykCodeAnnotatorLS"/>
-    <externalAnnotator language="JavaScript" implementationClass="snyk.code.annotator.SnykCodeAnnotator"/>
   </extensions>
 </idea-plugin>

--- a/src/main/resources/META-INF/optional/withKotlin.xml
+++ b/src/main/resources/META-INF/optional/withKotlin.xml
@@ -1,7 +1,5 @@
 <idea-plugin>
   <extensions defaultExtensionNs="com.intellij">
     <externalAnnotator language="kotlin" implementationClass="snyk.oss.annotator.OSSGradleAnnotator"/>
-    <externalAnnotator language="kotlin" implementationClass="snyk.code.annotator.SnykCodeAnnotatorLS"/>
-    <externalAnnotator language="kotlin" implementationClass="snyk.code.annotator.SnykCodeAnnotator"/>
   </extensions>
 </idea-plugin>

--- a/src/main/resources/META-INF/optional/withPHP.xml
+++ b/src/main/resources/META-INF/optional/withPHP.xml
@@ -1,6 +1,4 @@
 <idea-plugin>
   <extensions defaultExtensionNs="com.intellij">
-    <externalAnnotator language="PHP" implementationClass="snyk.code.annotator.SnykCodeAnnotatorLS"/>
-    <externalAnnotator language="PHP" implementationClass="snyk.code.annotator.SnykCodeAnnotator"/>
   </extensions>
 </idea-plugin>

--- a/src/main/resources/META-INF/optional/withPython.xml
+++ b/src/main/resources/META-INF/optional/withPython.xml
@@ -1,6 +1,4 @@
 <idea-plugin>
   <extensions defaultExtensionNs="com.intellij">
-    <externalAnnotator language="Python" implementationClass="snyk.code.annotator.SnykCodeAnnotatorLS"/>
-    <externalAnnotator language="Python" implementationClass="snyk.code.annotator.SnykCodeAnnotator"/>
   </extensions>
 </idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -43,7 +43,7 @@
 
     <registryKey key="snyk.preview.snyk.code.ls.enabled"
                  defaultValue="false"
-                 description="Preview: Use Language Server as Source for Snyk Code findings."
+                 description="Preview: Use language server as source for Snyk Code findings."
                  restartRequired="true"/>
 
     <notificationGroup id="Snyk" displayType="BALLOON" toolWindowId="Snyk"/>


### PR DESCRIPTION
### Description

Apparently specifying one annotator with language `""` is sufficient for any language. Also fixed late initialization of issues, to not be done in UI thread.

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
