### PR TITLE
fix: workspace folder and content root handling [IDE-204]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Snyk Security Changelog
 
+## [2.7.10]
+### Fixed
+- (LS Preview) Fix content root handling for Snyk Code scans
+
 ## [2.7.9]
 ### Fixed
 - fix: shortened plugin name to just Snyk Security

--- a/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
+++ b/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
@@ -40,12 +40,14 @@ import org.eclipse.lsp4j.WorkDoneProgressKind.report
 import org.eclipse.lsp4j.WorkDoneProgressReport
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification
 import org.eclipse.lsp4j.services.LanguageClient
+import org.jetbrains.kotlin.idea.util.application.executeOnPooledThread
 import snyk.common.ProductType
 import snyk.common.SnykCodeFileIssueComparator
 import snyk.trust.WorkspaceTrustService
 import java.util.Collections
 import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
 
 class SnykLanguageClient : LanguageClient {
@@ -234,9 +236,7 @@ class SnykLanguageClient : LanguageClient {
             }
 
             report -> {
-                while (progresses[token] == null) {
-                    Thread.sleep(1000)
-                }
+                executeOnPooledThread { while (progresses[token] == null) { Thread.sleep(1000) } }.get(5, TimeUnit.SECONDS)
                 val indicator = progresses[token] ?: return
                 val report: WorkDoneProgressReport = workDoneProgressNotification as WorkDoneProgressReport
                 indicator.text = report.message
@@ -248,9 +248,7 @@ class SnykLanguageClient : LanguageClient {
             }
 
             end -> {
-                while (progresses[token] == null) {
-                    Thread.sleep(1000)
-                }
+                executeOnPooledThread { while (progresses[token] == null) { Thread.sleep(1000) } }.get(5, TimeUnit.SECONDS)
                 val indicator = progresses[token] ?: return
                 val workDoneProgressEnd = workDoneProgressNotification as WorkDoneProgressEnd
                 indicator.text = workDoneProgressEnd.message

--- a/src/test/java/snyk/common/lsp/LanguageServerWrapperTest.kt
+++ b/src/test/java/snyk/common/lsp/LanguageServerWrapperTest.kt
@@ -22,13 +22,17 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import snyk.pluginInfo
+import snyk.trust.WorkspaceTrustService
 import java.util.concurrent.CompletableFuture
 
 class LanguageServerWrapperTest {
 
+    private val applicationMock: Application = mockk()
     private val projectMock: Project = mockk()
     private val lsMock: LanguageServer = mockk()
     private val settings = SnykApplicationSettingsStateService()
+    private val trustServiceMock = mockk<WorkspaceTrustService>(relaxed = true)
+
     private lateinit var cut: LanguageServerWrapper
 
     @Before
@@ -37,8 +41,8 @@ class LanguageServerWrapperTest {
         mockkStatic("io.snyk.plugin.UtilsKt")
         mockkStatic(ApplicationManager::class)
         mockkStatic(ApplicationManager::class)
-        val applicationMock = mockk<Application>()
         every { ApplicationManager.getApplication() } returns applicationMock
+        every { applicationMock.getService(WorkspaceTrustService::class.java) } returns trustServiceMock
 
         val projectManagerMock = mockk<ProjectManager>()
         every { applicationMock.getService(ProjectManager::class.java) } returns projectManagerMock


### PR DESCRIPTION
### Description

Previously, content roots were not normalized, so that duplications could occur, e.g. when a child root would be included, even though the parent was already there.

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
