### PR TITLE
chore: cleanup changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,6 @@
 - (LS Preview) Fix long-running UI operation to run outside of UI thread
 - Remove duplicated annotations in Snyk Code
 
-## [2.8.0]
-### Added
-- Consistent ignores for Snyk Code behind a feature flag.
-
 ## [2.7.8]
 ### Fixed
 - (LS Preview) UI freezes and initialization errors caused by CodeVision and Code annotations


### PR DESCRIPTION
### Description

In https://github.com/snyk/snyk-intellij-plugin/pull/490 I updated the changelog but it had changed in the meantime and GitHub did not ask me to merge conflicts, so the minor version update got lost in the middle of the changelog and the release was only version `2.7.10`: https://github.com/snyk/snyk-intellij-plugin/releases/tag/v2.7.10

It doesn't really matter what version the release is because it contains the code anyway, but now we need to cleanup the changelog so it doesn't look weird.