### PR TITLE
feat: mark findings as ignored in tree view [IDE-193]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Snyk Security Changelog
 
+## [2.7.12]
+### Added
+- Mark ignored findings as ignored behind a feature flag.
+
 ## [2.7.11]
 ### Added
 - Consistent ignores for Snyk Code behind a feature flag.

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykTreeCellRenderer.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykTreeCellRenderer.kt
@@ -111,7 +111,14 @@ class SnykTreeCellRenderer : ColoredTreeCellRenderer() {
                 val issue = value.userObject as ScanIssue
                 nodeIcon = SnykIcons.getSeverityIcon(issue.getSeverityAsEnum())
                 val range = issue.range
-                text = "${if (issue.additionalData.hasAIFix) "⚡️" else ""} ${
+                var showIgnoredLabel = false
+                var showAIFix = false
+                if (pluginSettings().isGlobalIgnoresFeatureEnabled && issue.isIgnored == true) {
+                    showIgnoredLabel = true
+                } else if (issue.additionalData.hasAIFix) {
+                    showAIFix = true
+                }
+                text = "${if (showIgnoredLabel) " [ Ignored ]" else ""}${if (showAIFix) " ⚡️" else ""} ${
                     if (issue.additionalData.isSecurityType) {
                         issue.title.split(":")[0]
                     } else {


### PR DESCRIPTION
### Description

Adds the `[ Ignored ]` text in front of ignored findings. It needs to be behind a feature flag because the backend will always return the ignore data, so the frontend needs to gate it.

In [this](https://snyk.slack.com/archives/C06LTKLFY2F/p1711376124767019) thread we decided not to show AI fixes if the finding is ignored.

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

<img width="583" alt="Screenshot 2024-03-25 at 14 11 26" src="https://github.com/snyk/snyk-intellij-plugin/assets/81559517/1ce9cbd5-874e-42bf-8304-2dd0f5bff4b6">

