### PR TITLE
fix: uri mapping between intellij and ls [IDE-239]

### DIFF
--- a/src/main/kotlin/io/snyk/plugin/snykcode/SnykCodeBulkFileListener.kt
+++ b/src/main/kotlin/io/snyk/plugin/snykcode/SnykCodeBulkFileListener.kt
@@ -20,6 +20,7 @@ import io.snyk.plugin.snykcode.core.RunUtils
 import io.snyk.plugin.snykcode.core.SnykCodeFile
 import io.snyk.plugin.snykcode.core.SnykCodeIgnoreInfoHolder
 import io.snyk.plugin.snykcode.core.SnykCodeUtils
+import io.snyk.plugin.toLanguageServerURL
 import org.eclipse.lsp4j.DidSaveTextDocumentParams
 import org.eclipse.lsp4j.TextDocumentIdentifier
 import snyk.common.lsp.LanguageServerWrapper
@@ -94,7 +95,7 @@ class SnykCodeBulkFileListener : SnykBulkFileListener() {
                 "Snyk: forwarding save event to Language Server"
             ) {
                 override fun run(indicator: ProgressIndicator) {
-                    val param = DidSaveTextDocumentParams(TextDocumentIdentifier(file.url), file.readText())
+                    val param = DidSaveTextDocumentParams(TextDocumentIdentifier(file.toLanguageServerURL()), file.readText())
                     languageServer.textDocumentService.didSave(param)
                 }
             })

--- a/src/main/kotlin/snyk/code/annotator/SnykCodeAnnotatorLS.kt
+++ b/src/main/kotlin/snyk/code/annotator/SnykCodeAnnotatorLS.kt
@@ -17,6 +17,7 @@ import io.snyk.plugin.Severity
 import io.snyk.plugin.getSnykCachedResults
 import io.snyk.plugin.isSnykCodeLSEnabled
 import io.snyk.plugin.isSnykCodeRunning
+import io.snyk.plugin.toLanguageServerURL
 import io.snyk.plugin.ui.toolwindow.SnykToolWindowPanel
 import org.eclipse.lsp4j.CodeAction
 import org.eclipse.lsp4j.CodeActionContext
@@ -75,7 +76,7 @@ class SnykCodeAnnotatorLS : ExternalAnnotator<PsiFile, Unit>() {
                         .create()
 
                     val params = CodeActionParams(
-                        TextDocumentIdentifier(psiFile.virtualFile.url),
+                        TextDocumentIdentifier(psiFile.virtualFile.toLanguageServerURL()),
                         issue.range,
                         CodeActionContext(emptyList())
                     )

--- a/src/main/kotlin/snyk/common/lsp/LSCodeVisionProvider.kt
+++ b/src/main/kotlin/snyk/common/lsp/LSCodeVisionProvider.kt
@@ -18,6 +18,7 @@ import com.intellij.psi.PsiDocumentManager
 import icons.SnykIcons
 import io.snyk.plugin.isSnykCodeLSEnabled
 import io.snyk.plugin.isSnykCodeRunning
+import io.snyk.plugin.toLanguageServerURL
 import org.eclipse.lsp4j.CodeLens
 import org.eclipse.lsp4j.CodeLensParams
 import org.eclipse.lsp4j.ExecuteCommandParams
@@ -54,7 +55,7 @@ class LSCodeVisionProvider : CodeVisionProvider<Unit> {
             val document = editor.document
             val file = PsiDocumentManager.getInstance(project).getPsiFile(document)
                 ?: return@compute CodeVisionState.READY_EMPTY
-            val params = CodeLensParams(TextDocumentIdentifier(file.virtualFile.url))
+            val params = CodeLensParams(TextDocumentIdentifier(file.virtualFile.toLanguageServerURL()))
             val lenses = mutableListOf<Pair<TextRange, CodeVisionEntry>>()
             val codeLenses = try {
                 LanguageServerWrapper.getInstance().languageServer.textDocumentService.codeLens(params)

--- a/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
@@ -11,6 +11,7 @@ import io.snyk.plugin.getContentRootVirtualFiles
 import io.snyk.plugin.getUserAgentString
 import io.snyk.plugin.isSnykCodeLSEnabled
 import io.snyk.plugin.pluginSettings
+import io.snyk.plugin.toLanguageServerURL
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -139,7 +140,7 @@ class LanguageServerWrapper(
 
     fun getWorkspaceFolders(project: Project): Set<WorkspaceFolder> {
         val normalizedRoots = getTrustedContentRoots(project)
-        return normalizedRoots.map { WorkspaceFolder(it.url, it.name) }.toSet()
+        return normalizedRoots.map {WorkspaceFolder(it.toLanguageServerURL(), it.name)                   }.toSet()
     }
 
     private fun getTrustedContentRoots(project: Project): MutableSet<VirtualFile> {


### PR DESCRIPTION
### Description

IntelliJ VirtualFiles do not conform to the URI spec followed by our Language Server under WIndows.

If a drive-letter is part of the URL, an additional slash needs to be added before the drive letter. When receiving URIs, this additional slash needs to be removed, as IntelliJ does not understand it.

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
