### PR TITLE
feat: respect LS protocol version when updating CLI [IDE-157]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Snyk Security Changelog
 
 
+## [2.7.14]
+### Added
+- force download of compatible CLI on mismatched LS protocol versions
+
 ## [2.7.13]
 ### Added
 - Render Snyk Code vulnerabilities using HTML served by the Language Server behind a feature flag.

--- a/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
@@ -27,7 +27,7 @@ import java.util.UUID
 )
 class SnykApplicationSettingsStateService : PersistentStateComponent<SnykApplicationSettingsStateService> {
 
-    val requiredLsProtocolVersion = 11
+    val requiredLsProtocolVersion = 10
 
     var isGlobalIgnoresFeatureEnabled = false
     var cliBaseDownloadURL: String = "https://static.snyk.io"

--- a/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
@@ -27,6 +27,7 @@ import java.util.UUID
 )
 class SnykApplicationSettingsStateService : PersistentStateComponent<SnykApplicationSettingsStateService> {
 
+    var currentLSProtocolVersion: Int? = 0
     val requiredLsProtocolVersion = 10
 
     var isGlobalIgnoresFeatureEnabled = false

--- a/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
@@ -27,6 +27,8 @@ import java.util.UUID
 )
 class SnykApplicationSettingsStateService : PersistentStateComponent<SnykApplicationSettingsStateService> {
 
+    val requiredLsProtocolVersion = 11
+
     var isGlobalIgnoresFeatureEnabled = false
     var cliBaseDownloadURL: String = "https://static.snyk.io"
     var cliPath: String = getPluginPath() + separator + Platform.current().snykWrapperFileName

--- a/src/main/kotlin/io/snyk/plugin/services/download/CliDownloaderService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/download/CliDownloaderService.kt
@@ -99,8 +99,14 @@ class SnykCliDownloaderService {
         }
     }
 
+
+    // no cli -> download (currentVersion = 0 -> != 10
+    // cli -> current version == requiredVersion -> 4 days passed -> download
+    // cli -> current version == requiredVersion -> 4 days NOT passed -> no download
+    // cli -> current version != requiredVersion -> 4 days passed -> download
+    // cli -> current version != requiredVersion -> 4 days NOT passed -> download
     fun cliSilentAutoUpdate(indicator: ProgressIndicator, project: Project) {
-        if (isFourDaysPassedSinceLastCheck()) {
+        if (isFourDaysPassedSinceLastCheck() || !matchesRequiredLsProtocolVersion()) {
             val latestReleaseInfo = requestLatestReleasesInformation()
 
             indicator.checkCanceled()
@@ -115,6 +121,10 @@ class SnykCliDownloaderService {
                 settings.lastCheckDate = Date()
             }
         }
+    }
+
+    private fun matchesRequiredLsProtocolVersion(): Boolean {
+        return pluginSettings().currentLSProtocolVersion == pluginSettings().requiredLsProtocolVersion
     }
 
     fun isFourDaysPassedSinceLastCheck(): Boolean {

--- a/src/main/kotlin/io/snyk/plugin/services/download/CliDownloaderService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/download/CliDownloaderService.kt
@@ -153,8 +153,6 @@ class SnykCliDownloaderService {
         return checkIsNewVersionAvailable(currentCliVersion!!.split('.'), newCliVersion!!.split('.'))
     }
 
-    fun getLatestReleaseInfo(): LatestReleaseInfo? = this.latestReleaseInfo
-
     /**
      * Clear version number: v1.143.1 => 1.143.1
 

--- a/src/main/kotlin/io/snyk/plugin/services/download/CliDownloaderService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/download/CliDownloaderService.kt
@@ -1,6 +1,5 @@
 package io.snyk.plugin.services.download
 
-import com.google.gson.annotations.SerializedName
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.logger
@@ -31,8 +30,6 @@ class SnykCliDownloaderService {
 
     private val cliDownloadPublisher
         get() = ApplicationManager.getApplication().messageBus.syncPublisher(SnykCliDownloadListener.CLI_DOWNLOAD_TOPIC)
-
-    private var latestReleaseInfo: LatestReleaseInfo? = null
 
     private var currentProgressIndicator: ProgressIndicator? = null
 
@@ -160,11 +157,6 @@ class SnykCliDownloaderService {
      *
      * @return String
      */
-    private fun cliVersionNumbers(sourceVersion: String): String = sourceVersion.substring(1, sourceVersion.length)
+    private fun cliVersionNumbers(sourceVersion: String): String =
+        sourceVersion.replaceFirst("v", "")
 }
-
-class LatestReleaseInfo(
-    val url: String,
-    val name: String,
-    @SerializedName("tag_name") val tagName: String
-)

--- a/src/main/kotlin/io/snyk/plugin/services/download/CliDownloaderService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/download/CliDownloaderService.kt
@@ -100,11 +100,21 @@ class SnykCliDownloaderService {
     }
 
 
-    // no cli -> download (currentVersion = 0 -> != 10
-    // cli -> current version == requiredVersion -> 4 days passed -> download
-    // cli -> current version == requiredVersion -> 4 days NOT passed -> no download
-    // cli -> current version != requiredVersion -> 4 days passed -> download
-    // cli -> current version != requiredVersion -> 4 days NOT passed -> download
+    /**
+     * Check if the CLI version is outdated and download the latest release if needed.
+     *
+     * Scenarios:
+     * 1. No CLI installed -> download
+     * 2. CLI installed and current LS protocol version matches required version
+     *   - check if 4 days passed since last check
+     *   - if yes -> download
+     *   - if no -> do nothing
+     * 3. CLI installed and current LS protocol version does not match required version -> download
+     * 4. CLI installed, more than 4 days have passed and new version available -> download
+     *
+     * @param indicator - progress indicator
+     * @param project - current project
+     */
     fun cliSilentAutoUpdate(indicator: ProgressIndicator, project: Project) {
         if (isFourDaysPassedSinceLastCheck() || !matchesRequiredLsProtocolVersion()) {
             val latestReleaseInfo = requestLatestReleasesInformation()

--- a/src/main/kotlin/io/snyk/plugin/ui/jcef/OpenFileLoadHandlerGenerator.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/jcef/OpenFileLoadHandlerGenerator.kt
@@ -2,6 +2,7 @@ package io.snyk.plugin.ui.jcef
 
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.ui.jcef.JBCefBrowser
+import com.intellij.ui.jcef.JBCefBrowserBase
 import com.intellij.ui.jcef.JBCefJSQuery
 import io.snyk.plugin.getDocument
 import io.snyk.plugin.navigateToSource
@@ -15,11 +16,11 @@ class OpenFileLoadHandlerGenerator(snykCodeFile: SnykCodeFile) {
     private val virtualFile = snykCodeFile.virtualFile
 
     fun openFile(value: String): JBCefJSQuery.Response {
-        var values = value.replace("\n", "").split(":")
-        var startLine = values[1].toInt()
-        var endLine = values[2].toInt()
-        var startCharacter = values[3].toInt()
-        var endCharacter = values[4].toInt()
+        val values = value.replace("\n", "").split(":")
+        val startLine = values[1].toInt()
+        val endLine = values[2].toInt()
+        val startCharacter = values[3].toInt()
+        val endCharacter = values[4].toInt()
 
         ApplicationManager.getApplication().invokeLater {
             val document = virtualFile.getDocument()
@@ -34,7 +35,7 @@ class OpenFileLoadHandlerGenerator(snykCodeFile: SnykCodeFile) {
         return JBCefJSQuery.Response("success")
     }
 
-    fun generate(jbCefBrowser: JBCefBrowser): CefLoadHandlerAdapter {
+    fun generate(jbCefBrowser: JBCefBrowserBase): CefLoadHandlerAdapter {
         val openFileQuery = JBCefJSQuery.create(jbCefBrowser)
         openFileQuery.addHandler { openFile(it) }
 

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/SuggestionDescriptionPanelFromLS.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/SuggestionDescriptionPanelFromLS.kt
@@ -7,6 +7,7 @@ import com.intellij.ui.components.JBTabbedPane
 import com.intellij.uiDesigner.core.GridConstraints
 import com.intellij.uiDesigner.core.GridLayoutManager
 import com.intellij.util.ui.JBInsets
+import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.UIUtil
 import io.snyk.plugin.getDocument
 import io.snyk.plugin.navigateToSource
@@ -17,8 +18,8 @@ import io.snyk.plugin.ui.DescriptionHeaderPanel
 import io.snyk.plugin.ui.SnykBalloonNotificationHelper
 import io.snyk.plugin.ui.baseGridConstraintsAnchorWest
 import io.snyk.plugin.ui.descriptionHeaderPanel
-import io.snyk.plugin.ui.jcef.OpenFileLoadHandlerGenerator
 import io.snyk.plugin.ui.jcef.JCEFUtils
+import io.snyk.plugin.ui.jcef.OpenFileLoadHandlerGenerator
 import io.snyk.plugin.ui.panelGridConstraints
 import io.snyk.plugin.ui.toolwindow.SnykToolWindowPanel
 import io.snyk.plugin.ui.wrapWithScrollPane
@@ -28,7 +29,6 @@ import java.awt.BorderLayout
 import java.awt.Color
 import java.awt.Dimension
 import java.awt.Font
-import java.awt.Insets
 import javax.swing.JComponent
 import javax.swing.JLabel
 import javax.swing.JPanel
@@ -45,12 +45,15 @@ class SuggestionDescriptionPanelFromLS(
     severity = issue.getSeverityAsEnum()
 ) {
     val project = snykCodeFile.project
-    private val unexpectedErrorMessage = "Snyk encountered an issue while rendering the vulnerability description. Please try again, or contact support if the problem persists. We apologize for any inconvenience caused.";
+    private val unexpectedErrorMessage =
+        "Snyk encountered an issue while rendering the vulnerability description. Please try again, or contact support if the problem persists. We apologize for any inconvenience caused."
 
     init {
         if (pluginSettings().isGlobalIgnoresFeatureEnabled && issue.additionalData.details != null) {
             val openFileLoadHandlerGenerator = OpenFileLoadHandlerGenerator(snykCodeFile)
-            val jbCefBrowserComponent  = JCEFUtils.getJBCefBrowserComponentIfSupported(issue.additionalData.details, { openFileLoadHandlerGenerator.generate(it) })
+            val jbCefBrowserComponent = JCEFUtils.getJBCefBrowserComponentIfSupported(issue.additionalData.details) {
+                openFileLoadHandlerGenerator.generate(it)
+            }
             if (jbCefBrowserComponent == null) {
                 val statePanel = StatePanel(SnykToolWindowPanel.SELECT_ISSUE_TEXT)
                 this.add(wrapWithScrollPane(statePanel), BorderLayout.CENTER)
@@ -58,7 +61,7 @@ class SuggestionDescriptionPanelFromLS(
             } else {
                 val lastRowToAddSpacer = 5
                 val panel = JPanel(
-                    GridLayoutManager(lastRowToAddSpacer + 1, 1, Insets(0, 10, 20, 10), -1, 20)
+                    GridLayoutManager(lastRowToAddSpacer + 1, 1, JBUI.insets(0, 10, 20, 10), -1, 20)
                 ).apply {
                     this.add(
                         jbCefBrowserComponent,
@@ -84,11 +87,11 @@ class SuggestionDescriptionPanelFromLS(
     override fun createMainBodyPanel(): Pair<JPanel, Int> {
         val lastRowToAddSpacer = 5
         val panel = JPanel(
-            GridLayoutManager(lastRowToAddSpacer + 1, 1, Insets(0, 10, 20, 10), -1, 20)
+            GridLayoutManager(lastRowToAddSpacer + 1, 1, JBUI.insets(0, 10, 20, 10), -1, 20)
         ).apply {
             this.add(overviewPanel(), panelGridConstraints(2))
 
-            dataFlowPanel()?.let { this.add(it, panelGridConstraints(3)) }
+            dataFlowPanel().let { this.add(it, panelGridConstraints(3)) }
 
             this.add(fixExamplesPanel(), panelGridConstraints(4))
         }
@@ -97,7 +100,7 @@ class SuggestionDescriptionPanelFromLS(
 
     private fun overviewPanel(): JComponent {
         val panel = JPanel()
-        panel.layout = GridLayoutManager(2, 1, Insets(0, 0, 0, 0), -1, -1)
+        panel.layout = GridLayoutManager(2, 1, JBUI.emptyInsets(), -1, -1)
         val label = JLabel("<html>" + getOverviewText() + "</html>").apply {
             this.isOpaque = false
             this.background = UIUtil.getPanelBackground()
@@ -142,11 +145,11 @@ class SuggestionDescriptionPanelFromLS(
         }
     }
 
-    private fun dataFlowPanel(): JPanel? {
+    private fun dataFlowPanel(): JPanel {
         val dataFlow = issue.additionalData.dataFlow
 
         val panel = JPanel()
-        panel.layout = GridLayoutManager(1 + dataFlow.size, 1, Insets(0, 0, 0, 0), -1, 5)
+        panel.layout = GridLayoutManager(1 + dataFlow.size, 1, JBUI.emptyInsets(), -1, 5)
 
         panel.add(
             defaultFontLabel("Data Flow - ${dataFlow.size} step${if (dataFlow.size > 1) "s" else ""}", true),
@@ -163,7 +166,7 @@ class SuggestionDescriptionPanelFromLS(
 
     private fun stepsPanel(dataflow: List<DataFlow>): JPanel {
         val panel = JPanel()
-        panel.layout = GridLayoutManager(dataflow.size, 1, Insets(0, 0, 0, 0), 0, 0)
+        panel.layout = GridLayoutManager(dataflow.size, 1, JBUI.emptyInsets(), 0, 0)
         panel.background = UIUtil.getTextFieldBackground()
 
         val maxFilenameLength = dataflow.asSequence()
@@ -201,7 +204,7 @@ class SuggestionDescriptionPanelFromLS(
         allStepPanels: MutableList<JPanel>
     ): JPanel {
         val stepPanel = JPanel()
-        stepPanel.layout = GridLayoutManager(1, 3, Insets(0, 0, 4, 0), 0, 0)
+        stepPanel.layout = GridLayoutManager(1, 3, JBUI.insetsBottom(4), 0, 0)
         stepPanel.background = UIUtil.getTextFieldBackground()
 
         val paddedStepNumber = (index + 1).toString().padStart(2, ' ')
@@ -256,7 +259,7 @@ class SuggestionDescriptionPanelFromLS(
         val examplesCount = fixes.size.coerceAtMost(3)
 
         val panel = JPanel()
-        panel.layout = GridLayoutManager(3, 1, Insets(0, 0, 0, 0), -1, 5)
+        panel.layout = GridLayoutManager(3, 1, JBUI.emptyInsets(), -1, 5)
 
         panel.add(
             defaultFontLabel("External example fixes", true),
@@ -282,7 +285,7 @@ class SuggestionDescriptionPanelFromLS(
         tabbedPane.font = io.snyk.plugin.ui.getFont(-1, 14, tabbedPane.font)
 
         val tabbedPanel = JPanel()
-        tabbedPanel.layout = GridLayoutManager(1, 1, Insets(10, 0, 0, 0), -1, -1)
+        tabbedPanel.layout = GridLayoutManager(1, 1, JBUI.insetsTop(10), -1, -1)
         tabbedPanel.add(tabbedPane, panelGridConstraints(0))
 
         panel.add(tabbedPanel, panelGridConstraints(2, indent = 1))
@@ -329,7 +332,7 @@ class SuggestionDescriptionPanelFromLS(
         )
 
         val panel = JPanel()
-        panel.layout = GridLayoutManager(rowCount, 1, Insets(0, 0, 0, 0), -1, 0)
+        panel.layout = GridLayoutManager(rowCount, 1, JBUI.emptyInsets(), -1, 0)
         panel.background = baseColor
 
         exampleCommitFix.lines.forEachIndexed { index, exampleLine ->

--- a/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
@@ -345,12 +345,16 @@ class LanguageServerWrapper(
     }
 
     private fun ensureLanguageServerProtocolVersion(project: Project) {
-        if ((initializeResult?.serverInfo?.version ?: "") == pluginSettings().requiredLsProtocolVersion.toString()) {
+        val protocolVersion = initializeResult?.serverInfo?.version
+        pluginSettings().currentLSProtocolVersion = protocolVersion?.toIntOrNull()
+
+        if ((protocolVersion ?: "") == pluginSettings().requiredLsProtocolVersion.toString()) {
             return
         }
+
         getSnykTaskQueueService(project)?.waitUntilCliDownloadedIfNeeded()
         if (!isCliInstalled()) {
-            val message = "Snyk Language Server version ${initializeResult?.serverInfo?.version} " +
+            val message = "Snyk Language Server version $protocolVersion " +
                 "does not match the required version ${pluginSettings().requiredLsProtocolVersion}. " +
                 "Please update the Snyk CLI."
             SnykBalloonNotificationHelper.showError(message, project)

--- a/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
@@ -8,10 +8,13 @@ import com.intellij.openapi.util.io.toNioPathOrNull
 import com.intellij.openapi.vfs.VirtualFile
 import io.snyk.plugin.getCliFile
 import io.snyk.plugin.getContentRootVirtualFiles
+import io.snyk.plugin.getSnykTaskQueueService
 import io.snyk.plugin.getUserAgentString
+import io.snyk.plugin.isCliInstalled
 import io.snyk.plugin.isSnykCodeLSEnabled
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.toLanguageServerURL
+import io.snyk.plugin.ui.SnykBalloonNotificationHelper
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -25,6 +28,7 @@ import org.eclipse.lsp4j.DidChangeConfigurationParams
 import org.eclipse.lsp4j.DidChangeWorkspaceFoldersParams
 import org.eclipse.lsp4j.ExecuteCommandParams
 import org.eclipse.lsp4j.InitializeParams
+import org.eclipse.lsp4j.InitializeResult
 import org.eclipse.lsp4j.InitializedParams
 import org.eclipse.lsp4j.InlineValueWorkspaceCapabilities
 import org.eclipse.lsp4j.TextDocumentClientCapabilities
@@ -55,6 +59,7 @@ class LanguageServerWrapper(
     private val lsPath: String = getCliFile().absolutePath,
     private val executorService: ExecutorService = Executors.newCachedThreadPool(),
 ) {
+    private var initializeResult: InitializeResult? = null
     private val gson = com.google.gson.Gson()
     val logger = Logger.getInstance("Snyk Language Server")
 
@@ -182,7 +187,7 @@ class LanguageServerWrapper(
         params.workspaceFolders = workspaceFolders
         params.capabilities = getCapabilities()
 
-        languageServer.initialize(params).get(INITIALIZATION_TIMEOUT, TimeUnit.SECONDS)
+        initializeResult = languageServer.initialize(params).get(INITIALIZATION_TIMEOUT, TimeUnit.SECONDS)
         languageServer.initialized(InitializedParams())
     }
 
@@ -334,8 +339,22 @@ class LanguageServerWrapper(
 
     fun addContentRoots(project: Project) {
         if (!isInitialized) return
+        ensureLanguageServerProtocolVersion(project)
         val added = getWorkspaceFolders(project)
         updateWorkspaceFolders(added, emptySet())
+    }
+
+    private fun ensureLanguageServerProtocolVersion(project: Project) {
+        if ((initializeResult?.serverInfo?.version ?: "") == pluginSettings().requiredLsProtocolVersion.toString()) {
+            return
+        }
+        getSnykTaskQueueService(project)?.waitUntilCliDownloadedIfNeeded()
+        if (!isCliInstalled()) {
+            val message = "Snyk Language Server version ${initializeResult?.serverInfo?.version} " +
+                "does not match the required version ${pluginSettings().requiredLsProtocolVersion}. " +
+                "Please update the Snyk CLI."
+            SnykBalloonNotificationHelper.showError(message, project)
+        }
     }
 
     companion object {

--- a/src/test/kotlin/io/snyk/plugin/TestUtils.kt
+++ b/src/test/kotlin/io/snyk/plugin/TestUtils.kt
@@ -11,8 +11,8 @@ import io.mockk.mockkObject
 import io.snyk.plugin.services.SnykApplicationSettingsStateService
 import io.snyk.plugin.services.SnykProjectSettingsStateService
 import io.snyk.plugin.services.download.HttpRequestHelper
+import io.snyk.plugin.services.download.HttpRequestHelper.createRequest
 import snyk.common.lsp.LanguageServerWrapper
-import java.io.File
 import java.nio.file.Path
 
 fun setupDummyCliFile() {
@@ -50,8 +50,10 @@ fun resetSettings(project: Project?) {
 fun mockCliDownload(): RequestBuilder {
     val requestBuilderMockk = mockk<RequestBuilder>(relaxed = true)
     mockkObject(HttpRequestHelper)
-    every { HttpRequestHelper.createRequest(any()) } returns requestBuilderMockk
-    justRun { requestBuilderMockk.saveToFile(any<File>(), any()) }
+    every { createRequest(any()) } returns requestBuilderMockk
+    // release version
+    every { requestBuilderMockk.readString() } returns "1.2.3"
+    // download
     justRun { requestBuilderMockk.saveToFile(any<Path>(), any()) }
     return requestBuilderMockk
 }

--- a/src/test/kotlin/io/snyk/plugin/extensions/SnykControllerImplTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/extensions/SnykControllerImplTest.kt
@@ -16,7 +16,6 @@ import io.snyk.plugin.isCliInstalled
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.removeDummyCliFile
 import io.snyk.plugin.resetSettings
-import io.snyk.plugin.services.download.LatestReleaseInfo
 import io.snyk.plugin.services.download.SnykCliDownloaderService
 import org.awaitility.Awaitility.await
 import snyk.common.lsp.LanguageServerWrapper

--- a/src/test/kotlin/io/snyk/plugin/extensions/SnykControllerImplTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/extensions/SnykControllerImplTest.kt
@@ -24,7 +24,6 @@ import snyk.oss.OssService
 import snyk.trust.confirmScanningAndSetWorkspaceTrustedStateIfNeeded
 import java.util.concurrent.TimeUnit
 
-@Suppress("FunctionName")
 class SnykControllerImplTest : LightPlatformTestCase() {
 
     private lateinit var ossServiceMock: OssService

--- a/src/test/kotlin/io/snyk/plugin/extensions/SnykControllerImplTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/extensions/SnykControllerImplTest.kt
@@ -40,11 +40,7 @@ class SnykControllerImplTest : LightPlatformTestCase() {
         mockkStatic("io.snyk.plugin.UtilsKt")
         mockkStatic("snyk.trust.TrustedProjectsKt")
         downloaderServiceMock = spyk(SnykCliDownloaderService())
-        every { downloaderServiceMock.requestLatestReleasesInformation() } returns LatestReleaseInfo(
-            "http://testUrl",
-            "testReleaseInfo",
-            "testTag"
-        )
+        every { downloaderServiceMock.requestLatestReleasesInformation() } returns "testTag"
         every { getSnykCliDownloaderService() } returns downloaderServiceMock
         every { downloaderServiceMock.isFourDaysPassedSinceLastCheck() } returns false
         every { confirmScanningAndSetWorkspaceTrustedStateIfNeeded(any()) } returns true

--- a/src/test/kotlin/io/snyk/plugin/services/SnykTaskQueueServiceTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/services/SnykTaskQueueServiceTest.kt
@@ -60,11 +60,7 @@ class SnykTaskQueueServiceTest : LightPlatformTestCase() {
         mockkStatic("snyk.trust.TrustedProjectsKt")
 
         downloaderServiceMock = spyk(SnykCliDownloaderService())
-        every { downloaderServiceMock.requestLatestReleasesInformation() } returns LatestReleaseInfo(
-            "http://testUrl",
-            "testReleaseInfo",
-            "testTag"
-        )
+        every { downloaderServiceMock.requestLatestReleasesInformation() } returns "testTag"
 
         every { getSnykCliDownloaderService() } returns downloaderServiceMock
         every { downloaderServiceMock.isFourDaysPassedSinceLastCheck() } returns false

--- a/src/test/kotlin/io/snyk/plugin/services/SnykTaskQueueServiceTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/services/SnykTaskQueueServiceTest.kt
@@ -27,7 +27,6 @@ import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.removeDummyCliFile
 import io.snyk.plugin.resetSettings
 import io.snyk.plugin.services.download.CliDownloader
-import io.snyk.plugin.services.download.LatestReleaseInfo
 import io.snyk.plugin.services.download.SnykCliDownloaderService
 import io.snyk.plugin.setupDummyCliFile
 import org.awaitility.Awaitility.await

--- a/src/test/kotlin/io/snyk/plugin/services/download/CliDownloaderErrorHandlerIntegTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/services/download/CliDownloaderErrorHandlerIntegTest.kt
@@ -14,6 +14,7 @@ import io.mockk.spyk
 import io.mockk.unmockkAll
 import io.mockk.verify
 import io.snyk.plugin.getCliFile
+import io.snyk.plugin.getSnykCliDownloaderService
 import io.snyk.plugin.resetSettings
 import io.snyk.plugin.ui.SnykBalloonNotificationHelper
 import java.io.IOException
@@ -37,6 +38,8 @@ class CliDownloaderErrorHandlerIntegTest : LightPlatformTestCase() {
         every { ProgressManager.getInstance() } returns progressManager
 
         cliDownloaderServiceMock = mockk()
+        mockkStatic("io.snyk.plugin.UtilsKt")
+        every { getSnykCliDownloaderService() } returns cliDownloaderServiceMock
         cliDownloaderMock = mockk()
         projectSpy = spyk(project)
         cut = CliDownloaderErrorHandler()
@@ -52,13 +55,13 @@ class CliDownloaderErrorHandlerIntegTest : LightPlatformTestCase() {
     }
 
     fun testHandleIOExceptionShouldRetryDownloadAndShowBalloonIfItFails() {
-        val e = IOException("Expected Test Exception, don't panic")
+        val e = IOException("ignore me, I'm just a test exception and expected")
         every { cliDownloaderMock.expectedSha(any()) } returns "testVersion"
         every { cliDownloaderMock.downloadFile(any(), any(), any()) } throws e
 
         cut.handleIOException(e, "testVersion", indicator, projectSpy)
 
-        verify(exactly = 1) { cliDownloaderMock.downloadFile(getCliFile(), any(), indicator) }
+        verify(exactly = 1) { cliDownloaderMock.downloadFile(any(), any(), any()) }
         verify(exactly = 1) { progressManager.run(any<Task.Backgroundable>()) }
         verify(exactly = 1) {
             SnykBalloonNotificationHelper.showError(
@@ -68,13 +71,13 @@ class CliDownloaderErrorHandlerIntegTest : LightPlatformTestCase() {
     }
 
     fun testHandleChecksumVerificationExceptionShouldRetryDownloadAndShowBalloonIfItFails() {
-        val e = ChecksumVerificationException("Expected Test Exception, don't panic")
+        val e = ChecksumVerificationException("ignore me, I'm just a test exception and expected")
         every { cliDownloaderMock.expectedSha(any()) } returns "testVersion"
         every { cliDownloaderMock.downloadFile(any(), any(), any()) } throws e
 
         cut.handleChecksumVerificationException(e, "testVersion", indicator, projectSpy)
 
-        verify(exactly = 1) { cliDownloaderMock.downloadFile(getCliFile(), any(), indicator) }
+        verify(exactly = 1) { cliDownloaderMock.downloadFile(any(), any(), any()) }
         verify(exactly = 1) { progressManager.run(any<Task.Backgroundable>()) }
         verify(exactly = 1) {
             SnykBalloonNotificationHelper.showError(

--- a/src/test/kotlin/io/snyk/plugin/services/download/CliDownloaderErrorHandlerIntegTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/services/download/CliDownloaderErrorHandlerIntegTest.kt
@@ -53,10 +53,10 @@ class CliDownloaderErrorHandlerIntegTest : LightPlatformTestCase() {
 
     fun testHandleIOExceptionShouldRetryDownloadAndShowBalloonIfItFails() {
         val e = IOException("Expected Test Exception, don't panic")
-        every { cliDownloaderMock.expectedSha() } returns "test"
+        every { cliDownloaderMock.expectedSha(any()) } returns "testVersion"
         every { cliDownloaderMock.downloadFile(any(), any(), any()) } throws e
 
-        cut.handleIOException(e, indicator, projectSpy)
+        cut.handleIOException(e, "testVersion", indicator, projectSpy)
 
         verify(exactly = 1) { cliDownloaderMock.downloadFile(getCliFile(), any(), indicator) }
         verify(exactly = 1) { progressManager.run(any<Task.Backgroundable>()) }
@@ -69,10 +69,10 @@ class CliDownloaderErrorHandlerIntegTest : LightPlatformTestCase() {
 
     fun testHandleChecksumVerificationExceptionShouldRetryDownloadAndShowBalloonIfItFails() {
         val e = ChecksumVerificationException("Expected Test Exception, don't panic")
-        every { cliDownloaderMock.expectedSha() } returns "test"
+        every { cliDownloaderMock.expectedSha(any()) } returns "testVersion"
         every { cliDownloaderMock.downloadFile(any(), any(), any()) } throws e
 
-        cut.handleChecksumVerificationException(e, indicator, projectSpy)
+        cut.handleChecksumVerificationException(e, "testVersion", indicator, projectSpy)
 
         verify(exactly = 1) { cliDownloaderMock.downloadFile(getCliFile(), any(), indicator) }
         verify(exactly = 1) { progressManager.run(any<Task.Backgroundable>()) }

--- a/src/test/kotlin/io/snyk/plugin/services/download/CliDownloaderServiceIntegTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/services/download/CliDownloaderServiceIntegTest.kt
@@ -18,8 +18,6 @@ import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.removeDummyCliFile
 import io.snyk.plugin.resetSettings
 import io.snyk.plugin.services.SnykApplicationSettingsStateService
-import junit.framework.TestCase
-import junit.framework.TestCase.*
 import org.apache.http.HttpStatus
 import org.junit.Assert.assertNotEquals
 import snyk.common.lsp.LanguageServerWrapper

--- a/src/test/kotlin/io/snyk/plugin/services/download/CliDownloaderServiceIntegTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/services/download/CliDownloaderServiceIntegTest.kt
@@ -19,7 +19,6 @@ import io.snyk.plugin.removeDummyCliFile
 import io.snyk.plugin.resetSettings
 import io.snyk.plugin.services.SnykApplicationSettingsStateService
 import org.apache.http.HttpStatus
-import org.junit.Assert.assertNotEquals
 import snyk.common.lsp.LanguageServerWrapper
 import java.io.File
 import java.net.SocketTimeoutException
@@ -62,16 +61,6 @@ class CliDownloaderServiceIntegTest : LightPlatformTestCase() {
     }
 
     /**
-     * Needs an internet connection - real test if release info can be downloaded
-     */
-    fun testGetLatestReleasesInformation() {
-        val latestReleaseInfo = project.service<SnykCliDownloaderService>().requestLatestReleasesInformation()
-
-        assertNotNull(latestReleaseInfo)
-        assertNotEquals("", latestReleaseInfo)
-    }
-
-    /**
      * Should be THE ONLY test where we actually do download the CLI
      * !!! Do __MOCK__ cli download in ANY other test to reduce testing time needed !!!
      */
@@ -83,7 +72,6 @@ class CliDownloaderServiceIntegTest : LightPlatformTestCase() {
         val downloadedFile = cliFile
 
         assertTrue(downloadedFile.exists())
-        assertEquals(cutSpy.getLatestReleaseInfo()!!.tagName, "v" + pluginSettings().cliVersion)
 
         verify { downloader.downloadFile(cliFile, any(), indicator) }
         verify { downloader.verifyChecksum(any(), any()) }
@@ -167,10 +155,6 @@ class CliDownloaderServiceIntegTest : LightPlatformTestCase() {
 
         assertTrue(getCliFile().exists())
         assertEquals(currentDate.toLocalDate(), pluginSettings().getLastCheckDate())
-        assertEquals(
-            cutSpy.getLatestReleaseInfo()!!.tagName,
-            "v" + pluginSettings().cliVersion
-        )
     }
 
     fun testCliSilentAutoUpdateWhenPreviousUpdateInfoIsNull() {

--- a/src/test/kotlin/io/snyk/plugin/services/download/CliDownloaderTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/services/download/CliDownloaderTest.kt
@@ -50,21 +50,12 @@ class CliDownloaderTest {
     }
 
     @Test
-    fun `should download cli information from base url`() {
+    fun `should download protocol version from base url`() {
         assertEquals(
-            "${CliDownloader.BASE_URL}/cli/latest/${Platform.current().snykWrapperFileName}",
-            CliDownloader.LATEST_RELEASE_DOWNLOAD_URL
+            "${CliDownloader.BASE_URL}/cli/latest/ls-protocol-version-${pluginSettings().requiredLsProtocolVersion}",
+            CliDownloader.LATEST_RELEASES_URL
         )
     }
-
-    @Test
-    fun `should download sha256 from base url`() {
-        assertEquals(
-            "${CliDownloader.BASE_URL}/cli/latest/${Platform.current().snykWrapperFileName}.sha256",
-            CliDownloader.SHA256_DOWNLOAD_URL
-        )
-    }
-
     @Test
     fun `should not delete file if checksum verification fails`() {
         val testFile = Files.createTempFile("test", "test").toFile()

--- a/src/test/kotlin/io/snyk/plugin/services/download/CliDownloaderTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/services/download/CliDownloaderTest.kt
@@ -4,7 +4,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
-import io.snyk.plugin.cli.Platform
 import io.snyk.plugin.mockCliDownload
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.services.SnykApplicationSettingsStateService
@@ -46,7 +45,14 @@ class CliDownloaderTest {
 
     @Test
     fun `should download version information from base url`() {
-        assertEquals("${CliDownloader.BASE_URL}/cli/latest/version", CliDownloader.LATEST_RELEASES_URL)
+        val expected =
+            "${CliDownloader.BASE_URL}/cli/latest/ls-protocol-version-" +
+                SnykApplicationSettingsStateService().requiredLsProtocolVersion
+
+        assertEquals(
+            expected,
+            CliDownloader.LATEST_RELEASES_URL
+        )
     }
 
     @Test


### PR DESCRIPTION
### Description

The LS Protocol version synchronizes feature sets between server and client outside of the LS capability mechanism. In order to download the right version of the CLI, the download process had to be adjusted to

- look up the right version at https://static.snyk.io/cli/latest/ls-protocol-version-{needed-protocol-version}
- extract the latest CLI version from there and 
- download it.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
