### PR TITLE
fix: remove deprecated API call, build against 2024.1 platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## [2.7.14]
 ### Added
 - force download of compatible CLI on mismatched LS protocol versions
+- build against 2024.1 platform
 
 ## [2.7.13]
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,13 +5,13 @@ pluginName=Snyk Security
 # see https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild=233
 pluginUntilBuild=241.*
-platformVersion=2023.3
+platformVersion=2024.1
 platformDownloadSources=true
 
 # plugin dependencies (comma-separated)
 # example: platformPlugins = com.intellij.java, org.jetbrains.plugins.yaml
 # see https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
-platformPlugins=org.intellij.plugins.hcl:233.11799.172,org.jetbrains.plugins.yaml,org.jetbrains.kotlin,com.intellij.java,org.intellij.groovy
+platformPlugins=org.intellij.plugins.hcl:241.14494.150,org.jetbrains.plugins.yaml,org.jetbrains.kotlin,com.intellij.java,org.intellij.groovy
 # list of versions for which to check the plugin for api compatibility
 pluginVerifierIdeVersions=2023.3,2024.1
 localIdeDirectory=

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindow.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindow.kt
@@ -99,7 +99,7 @@ class SnykToolWindow(private val project: Project) : SimpleToolWindowPanel(false
     }
 
     private fun updateActionsPresentation() =
-        ApplicationManager.getApplication().invokeLater { actionToolbar.updateActionsImmediately() }
+        ApplicationManager.getApplication().invokeLater { actionToolbar.updateActionsAsync() }
 
     var isDisposed = false
     override fun dispose() {


### PR DESCRIPTION
### Description

2024.1 introduces new API deprecations. This PR fixes the deprecation of updating the actions, and introduces building against the 2024.1 platform.

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
