### PR TITLE
fix: trim starting whitespaces in code lines [IDE-242]

### DIFF
--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/SuggestionDescriptionPanelFromLS.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/SuggestionDescriptionPanelFromLS.kt
@@ -239,7 +239,7 @@ class SuggestionDescriptionPanelFromLS(
         }
         stepPanel.add(positionLabel, baseGridConstraintsAnchorWest(0, indent = 1))
 
-        val codeLine = codeLine(flow.content)
+        val codeLine = codeLine(flow.content.trimStart())
         codeLine.isOpaque = false
         stepPanel.add(
             codeLine,


### PR DESCRIPTION
### Description

Trim whitespaces in dataflow code lines

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

![image](https://github.com/snyk/snyk-intellij-plugin/assets/20150761/a013e981-ce50-486d-8dbe-1abde3d4fd3b)