### PR TITLE
feat: scan all products on startup if enabled [IDE-241]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - force download of compatible CLI on mismatched LS protocol versions
 - bumped LS protocol version to ensure built-in LS in CLI has necessary commands for global ignores
+- (LS Preview) trigger scan on startup if auto-scan is enabled in Settings
 
 ## [2.7.13]
 ### Added

--- a/src/main/kotlin/io/snyk/plugin/SnykPostStartupActivity.kt
+++ b/src/main/kotlin/io/snyk/plugin/SnykPostStartupActivity.kt
@@ -112,7 +112,11 @@ class SnykPostStartupActivity : ProjectActivity {
         getAmplitudeExperimentService().fetch(experimentUser)
 
         if (isContainerEnabled()) {
-            getKubernetesImageCache(project)?.scanProjectForKubernetesFiles()
+            getKubernetesImageCache(project)?.cacheKubernetesFileFromProject()
+        }
+
+        if (settings.scanOnSave && isSnykCodeLSEnabled()) {
+            getSnykTaskQueueService(project)?.scan()
         }
 
         ExtensionPointsUtil.controllerManager.extensionList.forEach {

--- a/src/main/kotlin/io/snyk/plugin/ui/settings/ScanTypesPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/settings/ScanTypesPanel.kt
@@ -106,7 +106,7 @@ class ScanTypesPanel(
                     correctLastProductDisabled(it)
                     settings.containerScanEnabled = this.isSelected
                     val imagesCache = getKubernetesImageCache(project)
-                    if (this.isSelected) imagesCache?.scanProjectForKubernetesFiles() else imagesCache?.clear()
+                    if (this.isSelected) imagesCache?.cacheKubernetesFileFromProject() else imagesCache?.clear()
                 }
             }
         }

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
@@ -449,7 +449,7 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
         if (isContainerEnabled()) {
             getKubernetesImageCache(project)?.let {
                 it.clear()
-                it.scanProjectForKubernetesFiles()
+                it.cacheKubernetesFileFromProject()
             }
         }
 

--- a/src/main/kotlin/snyk/container/KubernetesImageCache.kt
+++ b/src/main/kotlin/snyk/container/KubernetesImageCache.kt
@@ -19,7 +19,7 @@ class KubernetesImageCache(val project: Project) {
         images.clear()
     }
 
-    fun scanProjectForKubernetesFiles() {
+    fun cacheKubernetesFileFromProject() {
         val callable = Callable {
             ProjectRootManager.getInstance(project).fileIndex.iterateContent { virtualFile ->
                 extractFromFileAndAddToCache(virtualFile)

--- a/src/test/kotlin/io/snyk/plugin/ui/toolwindow/settings/ScanTypesPanelTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/toolwindow/settings/ScanTypesPanelTest.kt
@@ -110,11 +110,11 @@ class ScanTypesPanelTest : LightPlatform4TestCase() {
     @Test
     fun `KubernetesImageCache rescan after container enablement`() {
         val cacheMock = setUpContainerScanTypePanelTests()
-        justRun { cacheMock.scanProjectForKubernetesFiles() }
+        justRun { cacheMock.cacheKubernetesFileFromProject() }
 
         getContainerCheckBox(initialValue = false, switchSelection = true)
 
-        verify(exactly = 1) { cacheMock.scanProjectForKubernetesFiles() }
+        verify(exactly = 1) { cacheMock.cacheKubernetesFileFromProject() }
     }
 
     @Test


### PR DESCRIPTION
### Description

Ensures if the auto-scan functionality is enabled and the new Snyk Code LS feature is enabled we schedule a scan for all products. Also refactors a function name because it was a bit confusing in this context.

I've tested it by clearing out the scan results and running the sandbox IDE with `runIDE`:
- before this change there would still be no results
- after this change scans get triggered and new results appear

I don't see any unit tests for this file, so I didn't add any.

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing