### PR TITLE
fix: settings for scan types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Snyk Security Changelog
 
+## [2.7.15]
+### Fixed
+- Re-enable scan results when re-enabling different scan types
 
 ## [2.7.14]
 ### Added

--- a/src/main/kotlin/io/snyk/plugin/settings/SnykProjectSettingsConfigurable.kt
+++ b/src/main/kotlin/io/snyk/plugin/settings/SnykProjectSettingsConfigurable.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.progress.runBackgroundableTask
 import com.intellij.openapi.project.Project
 import io.snyk.plugin.events.SnykProductsOrSeverityListener
 import io.snyk.plugin.events.SnykResultsFilteringListener
+import io.snyk.plugin.events.SnykScanListener
 import io.snyk.plugin.events.SnykSettingsListener
 import io.snyk.plugin.getAmplitudeExperimentService
 import io.snyk.plugin.getSnykAnalyticsService
@@ -46,6 +47,7 @@ class SnykProjectSettingsConfigurable(val project: Project) : SearchableConfigur
         isCrashReportingModified() ||
         snykSettingsDialog.isScanTypeChanged() ||
         snykSettingsDialog.isSeverityEnablementChanged() ||
+        snykSettingsDialog.isIssueOptionChanged() ||
         snykSettingsDialog.manageBinariesAutomatically() != settingsStateService.manageBinariesAutomatically ||
         snykSettingsDialog.getCliPath() != settingsStateService.cliPath ||
         snykSettingsDialog.getCliBaseDownloadURL() != settingsStateService.cliBaseDownloadURL ||
@@ -92,6 +94,7 @@ class SnykProjectSettingsConfigurable(val project: Project) : SearchableConfigur
 
         snykSettingsDialog.saveScanTypeChanges()
         snykSettingsDialog.saveSeveritiesEnablementChanges()
+        snykSettingsDialog.saveIssueOptionChanges()
 
         if (isProjectSettingsAvailable(project)) {
             val snykProjectSettingsService = getSnykProjectSettingsService(project)

--- a/src/main/kotlin/io/snyk/plugin/ui/SnykSettingsDialog.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/SnykSettingsDialog.kt
@@ -603,6 +603,10 @@ class SnykSettingsDialog(
 
     fun saveSeveritiesEnablementChanges() = severityEnablementPanel.apply()
 
+    fun isIssueOptionChanged() = issueViewOptionsPanel.isModified()
+
+    fun saveIssueOptionChanges() = issueViewOptionsPanel.apply()
+
     fun getAdditionalParameters(): String = additionalParametersTextField.text
 
     private fun initializeValidation() {

--- a/src/main/kotlin/io/snyk/plugin/ui/settings/SeveritiesEnablementPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/settings/SeveritiesEnablementPanel.kt
@@ -8,7 +8,6 @@ import com.intellij.util.ui.JBUI
 import io.snyk.plugin.Severity
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.ui.SnykBalloonNotificationHelper
-import java.awt.event.ItemEvent
 
 class SeveritiesEnablementPanel {
     private val settings
@@ -25,10 +24,11 @@ class SeveritiesEnablementPanel {
                 name = text
             }
             .actionListener{ event, it ->
-                val hasBeenSelected = it.isSelected
-                // we need to change the settings in here in order for the validation to work pre-apply
-                settings.criticalSeverityEnabled = hasBeenSelected
-                isLastSeverityDisabling(it, !hasBeenSelected)
+                val isSelected = it.isSelected
+                if (canBeChanged(it, isSelected)) {
+                    // we need to change the settings in here in order for the validation to work pre-apply
+                    currentCriticalSeverityEnabled = isSelected
+                }
             }
             // bindSelected is needed to trigger apply() on the settings dialog that this panel is rendered in
             // that way we trigger the re-rendering of the Tree Nodes
@@ -39,9 +39,10 @@ class SeveritiesEnablementPanel {
                 name = text
             }
             .actionListener{ event, it ->
-                val hasBeenSelected = it.isSelected
-                settings.highSeverityEnabled = hasBeenSelected
-                isLastSeverityDisabling(it, !hasBeenSelected)
+                val isSelected = it.isSelected
+                if(canBeChanged(it, isSelected)) {
+                    currentHighSeverityEnabled = isSelected
+                }
             }
             .bindSelected(settings::highSeverityEnabled)
         }
@@ -50,9 +51,10 @@ class SeveritiesEnablementPanel {
                 name = text
             }
             .actionListener{ event, it ->
-                val hasBeenSelected = it.isSelected
-                settings.mediumSeverityEnabled = hasBeenSelected
-                isLastSeverityDisabling(it, !hasBeenSelected)
+                val isSelected = it.isSelected
+                if (canBeChanged(it, isSelected)) {
+                    currentMediumSeverityEnabled = isSelected
+                }
             }
             .bindSelected(settings::mediumSeverityEnabled)
         }
@@ -61,9 +63,10 @@ class SeveritiesEnablementPanel {
                 name = text
             }
             .actionListener{ event, it ->
-                val hasBeenSelected = it.isSelected
-                settings.lowSeverityEnabled = hasBeenSelected
-                isLastSeverityDisabling(it, !hasBeenSelected)
+                val isSelected = it.isSelected
+                if (canBeChanged(it, isSelected)) {
+                    currentLowSeverityEnabled = isSelected
+                }
             }
             .bindSelected(settings::lowSeverityEnabled)
         }
@@ -72,7 +75,7 @@ class SeveritiesEnablementPanel {
         border = JBUI.Borders.empty(2)
     }
 
-    private fun isLastSeverityDisabling(component: JBCheckBox, wasEnabled: Boolean): Boolean {
+    private fun canBeChanged(component: JBCheckBox, isSelected: Boolean): Boolean {
         val onlyOneEnabled = arrayOf(
             currentCriticalSeverityEnabled,
             currentHighSeverityEnabled,
@@ -80,13 +83,14 @@ class SeveritiesEnablementPanel {
             currentLowSeverityEnabled
         ).count { it } == 1
 
-        if (onlyOneEnabled && wasEnabled) {
-            component.isSelected = true
+        if (onlyOneEnabled && !isSelected) {
             SnykBalloonNotificationHelper.showWarnBalloonForComponent(
                 "At least one Severity type should be selected",
                 component
             )
+            component.isSelected = true
+            return false
         }
-        return onlyOneEnabled
+        return true
     }
 }

--- a/src/main/kotlin/io/snyk/plugin/ui/settings/SeveritiesEnablementPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/settings/SeveritiesEnablementPanel.kt
@@ -1,6 +1,8 @@
 package io.snyk.plugin.ui.settings
 
 import com.intellij.ui.components.JBCheckBox
+import com.intellij.ui.dsl.builder.actionListener
+import com.intellij.ui.dsl.builder.bindSelected
 import com.intellij.ui.dsl.builder.panel
 import com.intellij.util.ui.JBUI
 import io.snyk.plugin.Severity
@@ -21,51 +23,53 @@ class SeveritiesEnablementPanel {
         row {
             checkBox(Severity.CRITICAL.toPresentableString()).applyToComponent {
                 name = text
-                isSelected = settings.criticalSeverityEnabled
-                this.addItemListener {
-                    correctLastSeverityDisabled(it)
-                    settings.criticalSeverityEnabled = this.isSelected
-                }
             }
+            .actionListener{ event, it ->
+                val hasBeenSelected = it.isSelected
+                // we need to change the settings in here in order for the validation to work pre-apply
+                settings.criticalSeverityEnabled = hasBeenSelected
+                isLastSeverityDisabling(it, !hasBeenSelected)
+            }
+            // bindSelected is needed to trigger apply() on the settings dialog that this panel is rendered in
+            // that way we trigger the re-rendering of the Tree Nodes
+            .bindSelected(settings::criticalSeverityEnabled)
         }
         row {
             checkBox(Severity.HIGH.toPresentableString()).applyToComponent {
                 name = text
-                isSelected = settings.highSeverityEnabled
-                this.addItemListener {
-                    correctLastSeverityDisabled(it)
-                    settings.highSeverityEnabled = this.isSelected
-                }
             }
+            .actionListener{ event, it ->
+                val hasBeenSelected = it.isSelected
+                settings.highSeverityEnabled = hasBeenSelected
+                isLastSeverityDisabling(it, !hasBeenSelected)
+            }
+            .bindSelected(settings::highSeverityEnabled)
         }
         row {
             checkBox(Severity.MEDIUM.toPresentableString()).applyToComponent {
                 name = text
-                isSelected = settings.mediumSeverityEnabled
-                this.addItemListener {
-                    correctLastSeverityDisabled(it)
-                    settings.mediumSeverityEnabled = this.isSelected
-                }
             }
+            .actionListener{ event, it ->
+                val hasBeenSelected = it.isSelected
+                settings.mediumSeverityEnabled = hasBeenSelected
+                isLastSeverityDisabling(it, !hasBeenSelected)
+            }
+            .bindSelected(settings::mediumSeverityEnabled)
         }
         row {
             checkBox(Severity.LOW.toPresentableString()).applyToComponent {
                 name = text
-                isSelected = settings.lowSeverityEnabled
-                this.addItemListener {
-                    correctLastSeverityDisabled(it)
-                    settings.lowSeverityEnabled = this.isSelected
-                }
             }
+            .actionListener{ event, it ->
+                val hasBeenSelected = it.isSelected
+                settings.lowSeverityEnabled = hasBeenSelected
+                isLastSeverityDisabling(it, !hasBeenSelected)
+            }
+            .bindSelected(settings::lowSeverityEnabled)
         }
     }.apply {
         name = "severityEnablementPanel"
         border = JBUI.Borders.empty(2)
-    }
-
-    private fun JBCheckBox.correctLastSeverityDisabled(it: ItemEvent) {
-        val deselected = it.stateChange == ItemEvent.DESELECTED
-        isLastSeverityDisabling(this, deselected)
     }
 
     private fun isLastSeverityDisabling(component: JBCheckBox, wasEnabled: Boolean): Boolean {


### PR DESCRIPTION
### Description

At the moment when we change the scan type selection the Tree Nodes associated with them don't get re-enabled. This seems to be because the changes in the `ScanTypesPanel` don't actually get trickled up to `SnykProjectSettingsConfigurable` in order for the `apply()` method to run when `isModified()` returns `true`. The reason for this is that when the selections change the `Dialog.isModified()` function called in `isScanTypeChanged` in `SnykSettingsDialog` hasn't registered that there has been a change. We're now achieving that with the use of `bindSelected`.

We have some validation in place so that pre-apply we don't allow people to deselect all scan types. The new selections only get "persisted" globally once the `apply()` function gets called so the new action listener we added for each checkbox also needs to locally persist the selection changes in order for the validation to work.

Docs about these panels that led to this implementation:
- https://plugins.jetbrains.com/docs/intellij/kotlin-ui-dsl.html#integrating-panels-with-property-bindings
- https://plugins.jetbrains.com/docs/intellij/kotlin-ui-dsl-version-2.html#cellbind

There are two more panels that probably have this issue. The `SeveritiesEnablementPanel` and `IssueViewOptionsPanel`. Before I make those changes there I want to see if this approach is okay.

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

