### PR TITLE
fix: trigger scan on startup for non-code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [2.7.15]
 ### Fixed
 - Re-enable scan results when re-enabling different scan types
+- (LS Preview) do not trigger scan on startup for Snyk Code multiple times
 
 ## [2.7.14]
 ### Added

--- a/src/main/kotlin/io/snyk/plugin/SnykPostStartupActivity.kt
+++ b/src/main/kotlin/io/snyk/plugin/SnykPostStartupActivity.kt
@@ -115,8 +115,8 @@ class SnykPostStartupActivity : ProjectActivity {
             getKubernetesImageCache(project)?.cacheKubernetesFileFromProject()
         }
 
-        if (settings.scanOnSave && isSnykCodeLSEnabled()) {
-            getSnykTaskQueueService(project)?.scan()
+        if (settings.scanOnSave && (isSnykCodeLSEnabled() || isSnykOSSLSEnabled() || isSnykIaCLSEnabled())) {
+            getSnykTaskQueueService(project)?.scan(true)
         }
 
         ExtensionPointsUtil.controllerManager.extensionList.forEach {

--- a/src/main/kotlin/io/snyk/plugin/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/Utils.kt
@@ -262,6 +262,11 @@ fun isFileListenerEnabled(): Boolean = pluginSettings().fileListenerEnabled
 
 fun isSnykCodeLSEnabled(): Boolean = Registry.`is`("snyk.preview.snyk.code.ls.enabled", true)
 
+fun isSnykOSSLSEnabled(): Boolean = false
+
+fun isSnykIaCLSEnabled(): Boolean = false
+
+
 fun getWaitForResultsTimeout(): Long =
     Registry.intValue(
         "snyk.timeout.results.waiting",

--- a/src/main/kotlin/io/snyk/plugin/extensions/SnykControllerImpl.kt
+++ b/src/main/kotlin/io/snyk/plugin/extensions/SnykControllerImpl.kt
@@ -13,7 +13,7 @@ class SnykControllerImpl(val project: Project) : SnykController {
      * scan enqueues a scan of the project for vulnerabilities.
      */
     override fun scan() {
-        getSnykTaskQueueService(project)?.scan()
+        getSnykTaskQueueService(project)?.scan(false)
     }
 
     /**

--- a/src/main/kotlin/io/snyk/plugin/ui/actions/SnykRunScanAction.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/actions/SnykRunScanAction.kt
@@ -19,7 +19,7 @@ import snyk.analytics.AnalysisIsTriggered
 class SnykRunScanAction : AnAction(AllIcons.Actions.Execute), DumbAware {
 
     override fun actionPerformed(actionEvent: AnActionEvent) {
-        getSnykTaskQueueService(actionEvent.project!!)?.scan()
+        getSnykTaskQueueService(actionEvent.project!!)?.scan(false)
 
         getSnykAnalyticsService().logAnalysisIsTriggered(
             AnalysisIsTriggered.builder()

--- a/src/main/kotlin/io/snyk/plugin/ui/settings/IssueViewOptionsPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/settings/IssueViewOptionsPanel.kt
@@ -28,7 +28,7 @@ class IssueViewOptionsPanel(
             .actionListener{ event, it ->
                 if (canBeChanged(it, it.isSelected)) {
                     currentOpenIssuesEnabled = it.isSelected
-                    getSnykTaskQueueService(project)?.scan()
+                    getSnykTaskQueueService(project)?.scan(false)
                 }
             }
             // bindSelected is needed to trigger apply() on the settings dialog that this panel is rendered in
@@ -44,7 +44,7 @@ class IssueViewOptionsPanel(
                 .actionListener{ event, it ->
                     if (canBeChanged(it, it.isSelected)) {
                         currentIgnoredIssuesEnabled = it.isSelected
-                        getSnykTaskQueueService(project)?.scan()
+                        getSnykTaskQueueService(project)?.scan(false)
                     }
                 }
                 .bindSelected(settings::ignoredIssuesEnabled)

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
@@ -521,7 +521,7 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
                 .build()
         )
 
-        getSnykTaskQueueService(project)?.scan()
+        getSnykTaskQueueService(project)?.scan(false)
     }
 
     fun displayAuthPanel() {

--- a/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
@@ -12,6 +12,8 @@ import io.snyk.plugin.getSnykTaskQueueService
 import io.snyk.plugin.getUserAgentString
 import io.snyk.plugin.isCliInstalled
 import io.snyk.plugin.isSnykCodeLSEnabled
+import io.snyk.plugin.isSnykIaCLSEnabled
+import io.snyk.plugin.isSnykOSSLSEnabled
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.toLanguageServerURL
 import io.snyk.plugin.ui.SnykBalloonNotificationHelper
@@ -306,10 +308,10 @@ class LanguageServerWrapper(
     fun getSettings(): LanguageServerSettings {
         val ps = pluginSettings()
         return LanguageServerSettings(
-            activateSnykOpenSource = false.toString(),
+            activateSnykOpenSource = isSnykOSSLSEnabled().toString(),
             activateSnykCodeSecurity = (isSnykCodeLSEnabled() && ps.snykCodeSecurityIssuesScanEnable).toString(),
             activateSnykCodeQuality = (isSnykCodeLSEnabled() && ps.snykCodeQualityIssuesScanEnable).toString(),
-            activateSnykIac = false.toString(),
+            activateSnykIac = isSnykIaCLSEnabled().toString(),
             organization = ps.organization,
             insecure = ps.ignoreUnknownCA.toString(),
             endpoint = getEndpointUrl(),

--- a/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanelIntegTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanelIntegTest.kt
@@ -177,7 +177,7 @@ class SnykToolWindowPanelIntegTest : HeavyPlatformTestCase() {
         } returns (iacGoofJson)
         getIacService(project)?.setConsoleCommandRunner(mockRunner)
 
-        project.service<SnykTaskQueueService>().scan()
+        project.service<SnykTaskQueueService>().scan(false)
         PlatformTestUtil.waitWhileBusy(toolWindowPanel.getTree())
     }
 
@@ -598,7 +598,7 @@ class SnykToolWindowPanelIntegTest : HeavyPlatformTestCase() {
         every { getIacService(project)?.scan() } returns iacResultWithError
 
         // actual test run
-        project.service<SnykTaskQueueService>().scan()
+        project.service<SnykTaskQueueService>().scan(false)
 
         PlatformTestUtil.waitWhileBusy(toolWindowPanel.getTree())
 
@@ -704,7 +704,7 @@ class SnykToolWindowPanelIntegTest : HeavyPlatformTestCase() {
         setUpContainerTest(containerResultWithError)
 
         // actual test run
-        project.service<SnykTaskQueueService>().scan()
+        project.service<SnykTaskQueueService>().scan(false)
 
         PlatformTestUtil.waitWhileBusy(toolWindowPanel.getTree())
 
@@ -731,7 +731,7 @@ class SnykToolWindowPanelIntegTest : HeavyPlatformTestCase() {
         setUpContainerTest(fakeContainerResult)
 
         // actual test run
-        project.service<SnykTaskQueueService>().scan()
+        project.service<SnykTaskQueueService>().scan(false)
         PlatformTestUtil.waitWhileBusy(toolWindowPanel.getTree())
 
         // Assertions
@@ -765,7 +765,7 @@ class SnykToolWindowPanelIntegTest : HeavyPlatformTestCase() {
         mockkObject(SnykBalloonNotificationHelper)
 
         // actual test run
-        project.service<SnykTaskQueueService>().scan()
+        project.service<SnykTaskQueueService>().scan(false)
         PlatformTestUtil.waitWhileBusy(toolWindowPanel.getTree())
 
         // Assertions
@@ -797,7 +797,7 @@ class SnykToolWindowPanelIntegTest : HeavyPlatformTestCase() {
         setUpContainerTest(fakeContainerResult)
 
         // actual test run
-        project.service<SnykTaskQueueService>().scan()
+        project.service<SnykTaskQueueService>().scan(false)
         PlatformTestUtil.waitWhileBusy(toolWindowPanel.getTree())
 
         // Assertions
@@ -879,7 +879,7 @@ class SnykToolWindowPanelIntegTest : HeavyPlatformTestCase() {
         setUpContainerTest(containerResult)
 
         // actual test run
-        project.service<SnykTaskQueueService>().scan()
+        project.service<SnykTaskQueueService>().scan(false)
         PlatformTestUtil.waitWhileBusy(toolWindowPanel.getTree())
 
         return containerResult

--- a/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanelTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanelTest.kt
@@ -126,7 +126,7 @@ class SnykToolWindowPanelTest : LightPlatform4TestCase() {
             true,
             LocalCodeEngine(false, "", false),
         )
-        justRun { taskQueueService.scan() }
+        justRun { taskQueueService.scan(false) }
 
         cut = SnykToolWindowPanel(project)
 
@@ -135,7 +135,7 @@ class SnykToolWindowPanelTest : LightPlatform4TestCase() {
         assertNotNull(descriptionPanel)
         assertEquals(findOnePixelSplitter(vulnerabilityTree), descriptionPanel!!.parent)
 
-        verify(exactly = 1) { taskQueueService.scan() }
+        verify(exactly = 1) { taskQueueService.scan(false) }
         verify(exactly = 1) { analyticsService.logAnalysisIsTriggered(any()) }
     }
 


### PR DESCRIPTION
### Description

When I implemented https://github.com/snyk/snyk-intellij-plugin/pull/510 I didn't realise that the LS actually has logic for scanning on startup. So because of that, we end up triggering multiple code scans and ending up in a loop because https://github.com/snyk/snyk-intellij-plugin/blob/5282559023d2d1987bd893ea78f1df585ff553e9/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt ends up saving the docs and then triggering another scan for Snyk Code. 

The fix involves only triggering scan for non-Snyk Code when in LS on start-up. I've refactored the code a bit so that we are preparing ourselves for when we enable OSS and IaC in LS too for IntelliJ.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing
