### PR TITLE
fix: sync when starting up language server in a multi-project setup

### DIFF
--- a/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
@@ -41,7 +41,7 @@ import snyk.common.SnykError
 import snyk.common.lsp.LanguageServerWrapper
 import snyk.trust.confirmScanningAndSetWorkspaceTrustedStateIfNeeded
 
-@Service
+@Service(Service.Level.PROJECT)
 class SnykTaskQueueService(val project: Project) {
     private val logger = logger<SnykTaskQueueService>()
     private val taskQueue = BackgroundTaskQueue(project, "Snyk")
@@ -81,23 +81,29 @@ class SnykTaskQueueService(val project: Project) {
     }
 
     fun connectProjectToLanguageServer(project: Project) {
-        synchronized(LanguageServerWrapper) {
-
             // subscribe to the settings changed topic
-            getSnykToolWindowPanel(project)?.let {
+        val languageServerWrapper = LanguageServerWrapper.getInstance()
+        getSnykToolWindowPanel(project)?.let {
                 project.messageBus.connect(it)
                     .subscribe(
                         SnykSettingsListener.SNYK_SETTINGS_TOPIC,
                         object : SnykSettingsListener {
                             override fun settingsChanged() {
-                                val wrapper = LanguageServerWrapper.getInstance()
-                                wrapper.updateConfiguration()
+                                languageServerWrapper.updateConfiguration()
                             }
                         }
                     )
             }
-            LanguageServerWrapper.getInstance().addContentRoots(project)
-        }
+            // Try to connect project for up to 30s
+            for (tries in 1..300) {
+                if (!languageServerWrapper.isInitialized) {
+                    Thread.sleep(100)
+                    continue
+                }
+
+                languageServerWrapper.addContentRoots(project)
+                break
+            }
     }
 
     fun scan(isStartup: Boolean) {

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
@@ -542,15 +542,16 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
 
     private fun enableCodeScanAccordingToServerSetting() {
         pluginSettings().apply {
-            val sastSettings = try {
-                getSnykApiService().getSastSettings()
-            } catch (ignored: ClientException) {
-                null
+            try {
+                // update settings if we get a valid/correct response, else log the error and do nothing
+                val sastSettings = getSnykApiService().getSastSettings()
+                sastOnServerEnabled = sastSettings?.sastEnabled
+                val codeScanAllowed = sastOnServerEnabled == true
+                snykCodeSecurityIssuesScanEnable = snykCodeSecurityIssuesScanEnable && codeScanAllowed
+                snykCodeQualityIssuesScanEnable = snykCodeQualityIssuesScanEnable && codeScanAllowed
+            } catch (clientException: ClientException) {
+                logger.error(clientException)
             }
-            sastOnServerEnabled = sastSettings?.sastEnabled
-            val codeScanAllowed = sastOnServerEnabled == true
-            snykCodeSecurityIssuesScanEnable = this.snykCodeSecurityIssuesScanEnable && codeScanAllowed
-            snykCodeQualityIssuesScanEnable = this.snykCodeQualityIssuesScanEnable && codeScanAllowed
         }
     }
 


### PR DESCRIPTION
### Description

Previously, the initialization of language server was triggered several times.

This PR adds 
- asserts that 
  - content roots are only added after initialization
  - initialization is not occurring recursively
- retry mechanism to add a project to language server waiting up to 30s when starting up
- a fix when initializing with an API error on the sastEnabled call
- logging when shutting down

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
