### PR TITLE
fix: don't send analytics events about snyk code when ff enabled

### DIFF
--- a/src/main/kotlin/io/snyk/plugin/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/Utils.kt
@@ -29,7 +29,6 @@ import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
 import com.intellij.util.Alarm
-import com.intellij.util.FileContentUtil
 import com.intellij.util.messages.Topic
 import io.snyk.plugin.analytics.AnalyticsScanListener
 import io.snyk.plugin.net.ClientException

--- a/src/main/kotlin/io/snyk/plugin/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/Utils.kt
@@ -159,9 +159,6 @@ fun <L : Any> getSyncPublisher(project: Project, topic: Topic<L>): L? {
     return messageBus.syncPublisher(topic)
 }
 
-val <T> List<T>.tail: List<T>
-    get() = drop(1)
-
 val <T> List<T>.head: T
     get() = first()
 

--- a/src/main/kotlin/io/snyk/plugin/analytics/AnalyticsScanListener.kt
+++ b/src/main/kotlin/io/snyk/plugin/analytics/AnalyticsScanListener.kt
@@ -43,32 +43,6 @@ class AnalyticsScanListener(val project: Project) {
         )
     }
 
-    private val snykCodeScanListenerLS = object : SnykCodeScanListenerLS {
-        var start = 0L
-        override fun scanningStarted(snykScan: SnykScanParams) {
-            start = System.currentTimeMillis()
-        }
-
-        override fun scanningSnykCodeFinished(snykCodeResults: Map<SnykCodeFile, List<ScanIssue>>) {
-            val duration = System.currentTimeMillis() - start
-            val product = "Snyk Code"
-            val issues = snykCodeResults.values.flatten()
-            val scanDoneEvent = getScanDoneEvent(
-                duration,
-                product,
-                issues.count { it.getSeverityAsEnum() == Severity.CRITICAL },
-                issues.count { it.getSeverityAsEnum() == Severity.HIGH },
-                issues.count { it.getSeverityAsEnum() == Severity.MEDIUM },
-                issues.count { it.getSeverityAsEnum() == Severity.LOW },
-            )
-            LanguageServerWrapper.getInstance().sendReportAnalyticsCommand(scanDoneEvent)
-        }
-
-        override fun scanningSnykCodeError(snykScan: SnykScanParams) {
-            // do nothing
-        }
-    }
-
     val snykScanListener = object : SnykScanListener {
         var start: Long = 0
 
@@ -148,11 +122,5 @@ class AnalyticsScanListener(val project: Project) {
             SnykScanListener.SNYK_SCAN_TOPIC,
             snykScanListener,
         )
-
-        if (isSnykCodeLSEnabled())
-            project.messageBus.connect().subscribe(
-                SnykCodeScanListenerLS.SNYK_SCAN_TOPIC,
-                snykCodeScanListenerLS,
-            )
     }
 }

--- a/src/main/kotlin/io/snyk/plugin/analytics/AnalyticsScanListener.kt
+++ b/src/main/kotlin/io/snyk/plugin/analytics/AnalyticsScanListener.kt
@@ -2,16 +2,10 @@ package io.snyk.plugin.analytics
 
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.project.Project
-import io.snyk.plugin.Severity
-import io.snyk.plugin.events.SnykCodeScanListenerLS
 import io.snyk.plugin.events.SnykScanListener
-import io.snyk.plugin.isSnykCodeLSEnabled
 import io.snyk.plugin.snykcode.SnykCodeResults
-import io.snyk.plugin.snykcode.core.SnykCodeFile
 import snyk.common.SnykError
 import snyk.common.lsp.LanguageServerWrapper
-import snyk.common.lsp.ScanIssue
-import snyk.common.lsp.SnykScanParams
 import snyk.common.lsp.commands.ScanDoneEvent
 import snyk.container.ContainerResult
 import snyk.iac.IacResult


### PR DESCRIPTION
### Description

When LS is used for Snyk Code scanning, IntelliJ does not need to report analytics data,
as this is already handled after each scan by Language Server. Actually, it is duplicating the data.

This PR removes the listener that listens on Snyk Code via LS scan results.

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
