### PR TITLE
refactor: use native IntelliJ color properties for theme consistency [IDE-269]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Snyk Security Changelog
 
+## [2.7.18]
+### Added
+- Improved theming in the Code Issue Panel by applying IntelliJ theme colors dynamically to JCEF components. This ensures consistency of UI elements with the rest of the IDE.
+
 ## [2.7.17]
 ### Fixed
 - Fixed problem in re-enablement of scan types when only one scan type was selected


### PR DESCRIPTION
### Description

This PR uses the native Kotlin APIs to adapt to the IntelliJ theme settings maintaining visual consistency.

- Fetch theme-appropriate colors with `JBColor.namedColor` and `UIUtil` methods.
- Add `toCssHex` utility for converting Color objects to CSS HEX format to be injected into the JBCefBrowser.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

|🌒 Dark|☀️ Light|🧛‍♀️ Darcula|
|-|-|-|
|![dark-theme](https://github.com/snyk/snyk-intellij-plugin/assets/1948377/e96443d5-d6b1-49ee-bcd4-c8420d4ec5cd)|![light-theme](https://github.com/snyk/snyk-intellij-plugin/assets/1948377/721bbe62-1947-453d-b03e-94474a11b439)|![darcula-theme](https://github.com/snyk/snyk-intellij-plugin/assets/1948377/46e9ba1b-c37b-497c-9c3a-4d4adbfa005d)|






