### PR TITLE
fix: remove incorrect /v1 path [IDE-126]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [2.7.17]
 ### Fixed
 - Fixed problem in re-enablement of scan types when only one scan type was selected
+- Don't add /v1 to all API calls through the Language Server
 
 ### Added
 - Use https://api.XXX.snyk.io/v1 and https://api.XXX.snykgov.io/v1 as endpoint URLs

--- a/src/main/kotlin/snyk/common/CustomEndpoints.kt
+++ b/src/main/kotlin/snyk/common/CustomEndpoints.kt
@@ -73,8 +73,7 @@ fun getEndpointUrl(): String {
         ""
     }
     val customEndpointUrl = resolveCustomEndpoint(endpointUrl)
-    // we need to set v1 here, to make the sast-enabled calls work in LS
-    return customEndpointUrl.removeTrailingSlashesIfPresent().suffixIfNot("/v1")
+    return customEndpointUrl.removeTrailingSlashesIfPresent()
 }
 
 fun isSnykCodeAvailable(endpointUrl: String?): Boolean {


### PR DESCRIPTION
### Description

In https://github.com/snyk/snyk-intellij-plugin/pull/515/ the `/v1` was appended in IntelliJ for all calls, even though there are some that don't need it. Only old v1 APIs need this path, otherwise we should leave it out. We noticed this problem by having the `snykCodeConsistentIgnores` feature flag enabled, which enables a flow that calls some other APIs.

In order for this to not introduce a new bug, we need https://github.com/snyk/snyk-ls/pull/498 to get merged first.

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing
