### PR TITLE
fix: custom endpoint validation and default [IDE-131]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@
 ### Added
 - Improved theming in the Code Issue Panel by applying IntelliJ theme colors dynamically to JCEF components. This ensures consistency of UI elements with the rest of the IDE.
 
+### Fixed
+- Don't add /v1 to all API calls through the Language Server
+- Default to using the correct API for the custom endpoint.
+
 ## [2.7.17]
 ### Fixed
 - Fixed problem in re-enablement of scan types when only one scan type was selected
-- Don't add /v1 to all API calls through the Language Server
 
 ### Added
 - Use https://api.XXX.snyk.io/v1 and https://api.XXX.snykgov.io/v1 as endpoint URLs

--- a/src/main/kotlin/snyk/common/CustomEndpoints.kt
+++ b/src/main/kotlin/snyk/common/CustomEndpoints.kt
@@ -100,8 +100,7 @@ internal fun resolveCustomEndpoint(endpointUrl: String?): String {
 
 fun URI.isSnykTenant() =
     isSnykDomain()
-        && ((host.lowercase().startsWith("app.") && path.lowercase().endsWith("/api"))
-        || (host.lowercase() == "snyk.io" && path.lowercase().endsWith("/api"))
+        && ((host.lowercase() == "snyk.io" && path.lowercase().endsWith("/api"))
         || (host.lowercase().startsWith("api.") && !path.lowercase().endsWith("/api"))
         || isDev())
 
@@ -134,7 +133,7 @@ fun URI.isOauth() = isSnykGov()
 fun URI.isDev() = isSnykDomain() && host.lowercase().startsWith("dev.")
 
 fun URI.isAnalyticsPermitted() = host != null &&
-    (host.lowercase() == "app.snyk.io" || host.lowercase() == "app.us.snyk.io" || host.lowercase() == "snyk.io")
+    (host.lowercase() == "api.snyk.io" || host.lowercase() == "api.us.snyk.io" || host.lowercase() == "snyk.io")
 
 fun isAnalyticsPermitted(): Boolean {
     val settings = pluginSettings()

--- a/src/test/kotlin/snyk/common/CustomEndpointsTest.kt
+++ b/src/test/kotlin/snyk/common/CustomEndpointsTest.kt
@@ -208,9 +208,9 @@ class CustomEndpointsTest {
     @Test
     fun `isAnalyticsPermitted false for URIs not allowed`() {
         val uris = listOf(
-            "https://app.fedramp.snykgov.io",
-            "https://app.eu.snyk.io/api",
-            "https://app.au.snyk.io/api"
+            "https://api.fedramp.snykgov.io",
+            "https://api.eu.snyk.io",
+            "https://api.au.snyk.io"
         )
         uris.forEach { uri ->
             assertFalse(URI(uri).isAnalyticsPermitted())
@@ -221,10 +221,10 @@ class CustomEndpointsTest {
     fun `isAnalyticsPermitted true for the right URIs`() {
         val uris = listOf(
             "https://snyk.io/api",
-            "https://app.snyk.io",
-            "https://app.us.snyk.io",
-            "https://app.snyk.io/api",
-            "https://app.snyk.io/v1"
+            "https://api.snyk.io",
+            "https://api.us.snyk.io",
+            "https://api.snyk.io",
+            "https://api.snyk.io/v1"
         )
 
         uris.forEach { uri ->

--- a/src/test/kotlin/snyk/errorHandler/SentryErrorReporterTest.kt
+++ b/src/test/kotlin/snyk/errorHandler/SentryErrorReporterTest.kt
@@ -67,7 +67,7 @@ class SentryErrorReporterTest {
         val settings = mockPluginInformation()
         setUnitTesting(false)
         settings.crashReportingEnabled = true
-        settings.customEndpointUrl = "https://app.snyk.io"
+        settings.customEndpointUrl = "https://api.snyk.io"
 
         SentryErrorReporter.captureException(RuntimeException("test"))
 


### PR DESCRIPTION
### Description

Improves the validation so that only `http(s)://api.` APIs are configured in the custom endpoint field.

Tested manually by running the extension with the latest CLI.


### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs
<img width="725" alt="Screenshot 2024-05-01 at 09 42 50" src="https://github.com/snyk/snyk-intellij-plugin/assets/81559517/c4042fde-cea8-4bf3-b444-d15040ea7e62">
<img width="713" alt="Screenshot 2024-05-01 at 09 42 42" src="https://github.com/snyk/snyk-intellij-plugin/assets/81559517/132b44a1-5b5b-406d-8c40-420bf56682cb">
<img width="706" alt="Screenshot 2024-05-01 at 09 42 38" src="https://github.com/snyk/snyk-intellij-plugin/assets/81559517/242c7bbe-00b4-403f-b7c9-080606934bac">
![Screenshot 2024-05-01 at 16 58 50](https://github.com/snyk/snyk-intellij-plugin/assets/81559517/dfff26d0-9cf4-4b70-8d6e-b75e2266d069)
