### PR TITLE
feat: load Snyk OSS issues in the Tree view via LS [IDE-238]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 # Snyk Security Changelog
 
-## [2.7.19]
-- Refactors some files so they can be used by more than just Snyk Code
-- Registry flag for integrating Snyk OSS scans in JetBrains via the LS
-
-## [2.7.18]
+## [2.7.20]
 ### Added
+- (LS OSS) Starts rendering the Tree Nodes for OSS via the LS
+
+## [2.7.19]
+### Added
+- Refactors some files so they can be used by more than just Snyk Code
 - De-duplicated code which will be used by all products loaded via the Language Server
+- Registry flag for integrating Snyk OSS scans in JetBrains via the LS
 
 ## [2.7.18]
 ### Added

--- a/src/main/kotlin/io/snyk/plugin/SnykFile.kt
+++ b/src/main/kotlin/io/snyk/plugin/SnykFile.kt
@@ -4,7 +4,6 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Iconable
 import com.intellij.openapi.vfs.VirtualFile
-import io.snyk.plugin.getPsiFile
 import snyk.common.RelativePathHelper
 import javax.swing.Icon
 
@@ -17,3 +16,6 @@ data class SnykFile(val project: Project, val virtualFile: VirtualFile) {
         }
     }
 }
+
+fun toSnykFileSet(project: Project, virtualFiles: Set<VirtualFile>) =
+    virtualFiles.map { SnykFile(project, it) }.toSet()

--- a/src/main/kotlin/io/snyk/plugin/events/SnykScanListenerLS.kt
+++ b/src/main/kotlin/io/snyk/plugin/events/SnykScanListenerLS.kt
@@ -15,5 +15,7 @@ interface SnykScanListenerLS {
 
     fun scanningSnykCodeFinished(snykResults: Map<SnykFile, List<ScanIssue>>)
 
-    fun scanningSnykCodeError(snykScan: SnykScanParams)
+    fun scanningOssFinished(snykResults: Map<SnykFile, List<ScanIssue>>)
+
+    fun scanningError(snykScan: SnykScanParams)
 }

--- a/src/main/kotlin/io/snyk/plugin/snykcode/SnykCodeBulkFileListener.kt
+++ b/src/main/kotlin/io/snyk/plugin/snykcode/SnykCodeBulkFileListener.kt
@@ -21,6 +21,7 @@ import io.snyk.plugin.SnykFile
 import io.snyk.plugin.snykcode.core.SnykCodeIgnoreInfoHolder
 import io.snyk.plugin.snykcode.core.SnykCodeUtils
 import io.snyk.plugin.toLanguageServerURL
+import io.snyk.plugin.toSnykFileSet
 import org.eclipse.lsp4j.DidSaveTextDocumentParams
 import org.eclipse.lsp4j.TextDocumentIdentifier
 import snyk.common.lsp.LanguageServerWrapper
@@ -110,7 +111,4 @@ class SnykCodeBulkFileListener : SnykBulkFileListener() {
         VirtualFileManager.getInstance().asyncRefresh()
         DaemonCodeAnalyzer.getInstance(project).restart()
     }
-
-    private fun toSnykFileSet(project: Project, virtualFiles: Set<VirtualFile>) =
-        virtualFiles.map { SnykFile(project, it) }.toSet()
 }

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/nodes/leaf/SuggestionTreeNodeFromLS.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/nodes/leaf/SuggestionTreeNodeFromLS.kt
@@ -4,12 +4,10 @@ import io.snyk.plugin.getSnykAnalyticsService
 import io.snyk.plugin.SnykFile
 import io.snyk.plugin.ui.toolwindow.nodes.DescriptionHolderTreeNode
 import io.snyk.plugin.ui.toolwindow.nodes.NavigatableToSourceTreeNode
-import io.snyk.plugin.ui.toolwindow.nodes.secondlevel.SnykFileTreeNodeFromLS
+import io.snyk.plugin.ui.toolwindow.nodes.secondlevel.FileTreeNodeFromLS
 import io.snyk.plugin.ui.toolwindow.panels.IssueDescriptionPanelBase
 import io.snyk.plugin.ui.toolwindow.panels.SuggestionDescriptionPanelFromLS
 import snyk.analytics.IssueInTreeIsClicked.Ide
-import snyk.analytics.IssueInTreeIsClicked.IssueType.CODE_QUALITY_ISSUE
-import snyk.analytics.IssueInTreeIsClicked.IssueType.CODE_SECURITY_VULNERABILITY
 import snyk.analytics.IssueInTreeIsClicked.Severity
 import snyk.analytics.IssueInTreeIsClicked.builder
 import snyk.common.ProductType
@@ -23,17 +21,11 @@ class SuggestionTreeNodeFromLS(
 
     @Suppress("UNCHECKED_CAST")
     override fun getDescriptionPanel(logEventNeeded: Boolean): IssueDescriptionPanelBase {
-        val issueType = if (issue.additionalData.isSecurityType) {
-            CODE_SECURITY_VULNERABILITY
-        } else {
-            CODE_QUALITY_ISSUE
-        }
-
         if (logEventNeeded) {
             getSnykAnalyticsService().logIssueInTreeIsClicked(
                 builder()
                     .ide(Ide.JETBRAINS)
-                    .issueType(issueType)
+                    .issueType(issue.type())
                     .issueId(issue.id)
                     .severity(
                         when (issue.severity.lowercase()) {
@@ -47,13 +39,13 @@ class SuggestionTreeNodeFromLS(
                     .build()
             )
         }
-        val snykCodeFileTreeNode = this.parent as? SnykFileTreeNodeFromLS
+        val snykFileTreeNode = this.parent as? FileTreeNodeFromLS
             ?: throw IllegalArgumentException(this.toString())
 
         @Suppress("UNCHECKED_CAST")
         val entry =
-            (snykCodeFileTreeNode.userObject as Pair<Map.Entry<SnykFile, List<ScanIssue>>, ProductType>).first
-        val snykCodeFile = entry.key
-        return SuggestionDescriptionPanelFromLS(snykCodeFile, issue)
+            (snykFileTreeNode.userObject as Pair<Map.Entry<SnykFile, List<ScanIssue>>, ProductType>).first
+        val snykFile = entry.key
+        return SuggestionDescriptionPanelFromLS(snykFile, issue)
     }
 }

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/nodes/secondlevel/FileTreeNodeFromLS.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/nodes/secondlevel/FileTreeNodeFromLS.kt
@@ -5,7 +5,7 @@ import snyk.common.ProductType
 import snyk.common.lsp.ScanIssue
 import javax.swing.tree.DefaultMutableTreeNode
 
-class SnykFileTreeNodeFromLS(
+class FileTreeNodeFromLS(
     file: Map.Entry<SnykFile, List<ScanIssue>>,
     productType: ProductType
 ) : DefaultMutableTreeNode(Pair(file, productType))

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/SnykCodeDataflowPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/SnykCodeDataflowPanel.kt
@@ -20,6 +20,7 @@ import kotlin.math.max
 
 class SnykCodeDataflowPanel(private val project: Project, codeIssueData: IssueData): JPanel() {
     init {
+        name = "dataFlowPanel"
         val dataFlow = codeIssueData.dataFlow
 
         this.layout = GridLayoutManager(1 + dataFlow.size, 1, JBUI.emptyInsets(), -1, 5)

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/SnykCodeExampleFixesPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/SnykCodeExampleFixesPanel.kt
@@ -19,6 +19,7 @@ import javax.swing.ScrollPaneConstants
 
 class SnykCodeExampleFixesPanel(codeIssueData: IssueData): JPanel() {
     init {
+        name = "fixExamplesPanel"
         val fixes = codeIssueData.exampleCommitFixes
         val examplesCount = fixes.size.coerceAtMost(3)
 

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/SnykCodeOverviewPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/SnykCodeOverviewPanel.kt
@@ -11,6 +11,7 @@ import javax.swing.JLabel
 
 class SnykCodeOverviewPanel(codeIssueData: IssueData) : JComponent() {
     init {
+        name = "overviewPanel"
         this.layout = GridLayoutManager(2, 1, JBUI.emptyInsets(), -1, -1)
         val label = JLabel("<html>" + codeIssueData.message + "</html>").apply {
             this.isOpaque = false

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/SuggestionDescriptionPanelFromLS.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/SuggestionDescriptionPanelFromLS.kt
@@ -90,7 +90,7 @@ class SuggestionDescriptionPanelFromLS(
         return when(issue.additionalData.getProductType()) {
             ProductType.OSS -> null
             ProductType.CODE_SECURITY, ProductType.CODE_QUALITY -> SnykCodeOverviewPanel(issue.additionalData)
-            else -> throw IllegalStateException("additionalData of this type has not been configured")
+            else -> throw IllegalStateException("product of this type has not been configured")
         }
     }
 
@@ -98,7 +98,7 @@ class SuggestionDescriptionPanelFromLS(
         return when(issue.additionalData.getProductType()) {
             ProductType.OSS -> null
             ProductType.CODE_SECURITY, ProductType.CODE_QUALITY -> SnykCodeDataflowPanel(project, issue.additionalData)
-            else -> throw IllegalStateException("additionalData of this type has not been configured")
+            else -> throw IllegalStateException("product of this type has not been configured")
         }
     }
 
@@ -106,7 +106,7 @@ class SuggestionDescriptionPanelFromLS(
         return when(issue.additionalData.getProductType()) {
             ProductType.OSS -> null
             ProductType.CODE_SECURITY, ProductType.CODE_QUALITY -> SnykCodeExampleFixesPanel(issue.additionalData)
-            else -> throw IllegalStateException("additionalData of this type has not been configured")
+            else -> throw IllegalStateException("product of this type has not been configured")
         }
     }
 }

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/SuggestionDescriptionPanelFromLS.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/SuggestionDescriptionPanelFromLS.kt
@@ -12,6 +12,7 @@ import io.snyk.plugin.ui.jcef.OpenFileLoadHandlerGenerator
 import io.snyk.plugin.ui.panelGridConstraints
 import io.snyk.plugin.ui.toolwindow.SnykToolWindowPanel
 import io.snyk.plugin.ui.wrapWithScrollPane
+import snyk.common.ProductType
 import snyk.common.lsp.ScanIssue
 import java.awt.BorderLayout
 import java.awt.Font
@@ -23,7 +24,7 @@ class SuggestionDescriptionPanelFromLS(
     snykFile: SnykFile,
     private val issue: ScanIssue
 ) : IssueDescriptionPanelBase(
-    title = getIssueTitle(issue),
+    title = issue.title(),
     severity = issue.getSeverityAsEnum()
 ) {
     val project = snykFile.project
@@ -31,9 +32,12 @@ class SuggestionDescriptionPanelFromLS(
         "Snyk encountered an issue while rendering the vulnerability description. Please try again, or contact support if the problem persists. We apologize for any inconvenience caused."
 
     init {
-        if (pluginSettings().isGlobalIgnoresFeatureEnabled && issue.additionalData.details != null) {
+        if (
+            pluginSettings().isGlobalIgnoresFeatureEnabled &&
+            issue.canLoadSuggestionPanelFromHTML()
+        ) {
             val openFileLoadHandlerGenerator = OpenFileLoadHandlerGenerator(snykFile)
-            val jbCefBrowserComponent = JCEFUtils.getJBCefBrowserComponentIfSupported(issue.additionalData.details) {
+            val jbCefBrowserComponent = JCEFUtils.getJBCefBrowserComponentIfSupported(issue.details()) {
                 openFileLoadHandlerGenerator.generate(it)
             }
             if (jbCefBrowserComponent == null) {
@@ -62,8 +66,12 @@ class SuggestionDescriptionPanelFromLS(
     }
 
     override fun secondRowTitlePanel(): DescriptionHeaderPanel = descriptionHeaderPanel(
-        issueNaming = if (issue.additionalData.isSecurityType) "Vulnerability" else "Quality Issue",
-        cwes = issue.additionalData.cwe ?: emptyList()
+        issueNaming = issue.issueNaming(),
+        cwes = issue.cwes(),
+        cvssScore = issue.cvssScore(),
+        cvssV3 = issue.cvssV3(),
+        cves = issue.cves(),
+        id = issue.id(),
     )
 
     override fun createMainBodyPanel(): Pair<JPanel, Int> {
@@ -79,24 +87,29 @@ class SuggestionDescriptionPanelFromLS(
     }
 
     private fun overviewPanel(): JComponent? {
-        return SnykCodeOverviewPanel(issue.additionalData)
+        return when(issue.additionalData.getProductType()) {
+            ProductType.OSS -> null
+            ProductType.CODE_SECURITY, ProductType.CODE_QUALITY -> SnykCodeOverviewPanel(issue.additionalData)
+            else -> throw IllegalStateException("additionalData of this type has not been configured")
+        }
     }
 
     private fun dataFlowPanel(): JPanel? {
-        return SnykCodeDataflowPanel(project, issue.additionalData)
+        return when(issue.additionalData.getProductType()) {
+            ProductType.OSS -> null
+            ProductType.CODE_SECURITY, ProductType.CODE_QUALITY -> SnykCodeDataflowPanel(project, issue.additionalData)
+            else -> throw IllegalStateException("additionalData of this type has not been configured")
+        }
     }
 
     private fun fixExamplesPanel(): JPanel? {
-        return SnykCodeExampleFixesPanel(issue.additionalData)
+        return when(issue.additionalData.getProductType()) {
+            ProductType.OSS -> null
+            ProductType.CODE_SECURITY, ProductType.CODE_QUALITY -> SnykCodeExampleFixesPanel(issue.additionalData)
+            else -> throw IllegalStateException("additionalData of this type has not been configured")
+        }
     }
 }
-
-private fun getIssueTitle(issue: ScanIssue) =
-    if (issue.additionalData.isSecurityType) {
-        issue.title.split(":").firstOrNull() ?: "Unknown issue"
-    } else {
-        issue.additionalData.message.split(".").firstOrNull() ?: "Unknown issue"
-    }
 
 fun defaultFontLabel(labelText: String, bold: Boolean = false): JLabel {
     return JLabel().apply {

--- a/src/main/kotlin/snyk/code/annotator/SnykAnnotator.kt
+++ b/src/main/kotlin/snyk/code/annotator/SnykAnnotator.kt
@@ -1,0 +1,133 @@
+package snyk.code.annotator
+
+import com.intellij.lang.annotation.AnnotationHolder
+import com.intellij.lang.annotation.ExternalAnnotator
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiFile
+import io.snyk.plugin.getSnykCachedResults
+import io.snyk.plugin.getSnykCachedResultsForProduct
+import io.snyk.plugin.isSnykCodeLSEnabled
+import io.snyk.plugin.isSnykCodeRunning
+import io.snyk.plugin.toLanguageServerURL
+import org.eclipse.lsp4j.CodeActionContext
+import org.eclipse.lsp4j.CodeActionParams
+import org.eclipse.lsp4j.Range
+import org.eclipse.lsp4j.TextDocumentIdentifier
+import snyk.common.AnnotatorCommon
+import snyk.common.ProductType
+import snyk.common.lsp.LanguageServerWrapper
+import snyk.common.lsp.ScanIssue
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+private const val CODEACTION_TIMEOUT = 2L
+
+abstract class SnykAnnotator(private val product: ProductType): ExternalAnnotator<PsiFile, Unit>() {
+    val logger = logger<SnykAnnotator>()
+
+    // overrides needed for the Annotator to invoke apply(). We don't do anything here
+    override fun collectInformation(file: PsiFile): PsiFile {
+        return file
+    }
+
+    override fun doAnnotate(psiFile: PsiFile?) {
+        AnnotatorCommon.prepareAnnotate(psiFile)
+    }
+
+    override fun apply(psiFile: PsiFile, annotationResult: Unit, holder: AnnotationHolder) {
+        if (!LanguageServerWrapper.getInstance().ensureLanguageServerInitialized()) return
+
+        getIssuesForFile(psiFile)
+            .filter { AnnotatorCommon.isSeverityToShow(it.getSeverityAsEnum()) }
+            .distinctBy { it.id }
+            .sortedBy { it.title }
+            .forEach { issue ->
+                val highlightSeverity = issue.getSeverityAsEnum().getHighlightSeverity()
+                val textRange = textRange(psiFile, issue.range)
+                if (textRange == null) {
+                    logger.warn("Invalid range for issue: $issue")
+                    return@forEach
+                }
+                if (!textRange.isEmpty) {
+                    val annotationMessage = "${issue.annotationMessage()} (Snyk)"
+                    holder.newAnnotation(highlightSeverity, annotationMessage)
+                        .range(textRange)
+                        .withFix(ShowDetailsIntentionAction(annotationMessage, issue))
+                        .create()
+
+                    val params = CodeActionParams(
+                        TextDocumentIdentifier(psiFile.virtualFile.toLanguageServerURL()),
+                        issue.range,
+                        CodeActionContext(emptyList())
+                    )
+                    val languageServer = LanguageServerWrapper.getInstance().languageServer
+                    val codeActions = try {
+                        languageServer.textDocumentService
+                            .codeAction(params).get(CODEACTION_TIMEOUT, TimeUnit.SECONDS) ?: emptyList()
+                    } catch (ignored: TimeoutException) {
+                        logger.info("Timeout fetching code actions for issue: $issue")
+                        emptyList()
+                    }
+
+                    codeActions
+                        .filter { a ->
+                            val diagnosticCode = a.right.diagnostics?.get(0)?.code?.left
+                            val ruleId = issue.ruleId()
+                            diagnosticCode == ruleId
+                        }
+                        .sortedBy { it.right.title }.forEach { action ->
+                            val codeAction = action.right
+                            val title = codeAction.title
+                            holder.newAnnotation(highlightSeverity, title)
+                                .range(textRange)
+                                .withFix(CodeActionIntention(issue, codeAction, ProductType.CODE_SECURITY))
+                                .create()
+                        }
+                }
+            }
+    }
+
+    private fun getIssuesForFile(psiFile: PsiFile): Set<ScanIssue> =
+        getSnykCachedResultsForProduct(psiFile.project, product)
+            ?.filter { it.key.virtualFile == psiFile.virtualFile }
+            ?.map { it.value }
+            ?.flatten()
+            ?.toSet()
+            ?: emptySet()
+
+    /** Public for Tests only */
+    @Suppress("DuplicatedCode")
+    fun textRange(psiFile: PsiFile, range: Range): TextRange? {
+        try {
+            val document =
+                psiFile.viewProvider.document ?: throw IllegalArgumentException("No document found for $psiFile")
+            val startRow = range.start.line
+            val endRow = range.end.line
+            val startCol = range.start.character
+            val endCol = range.end.character
+
+            if (startRow < 0 || startRow > document.lineCount - 1) {
+                return null
+            }
+            if (endRow < 0 || endRow > document.lineCount - 1 || endRow < startRow) {
+                return null
+            }
+
+            val lineOffSet = document.getLineStartOffset(startRow) + startCol
+            val lineOffSetEnd = document.getLineStartOffset(endRow) + endCol
+
+            if (lineOffSet < 0 || lineOffSet > document.textLength - 1) {
+                return null
+            }
+            if (lineOffSetEnd < 0 || lineOffSetEnd < lineOffSet || lineOffSetEnd > document.textLength - 1) {
+                return null
+            }
+
+            return TextRange.create(lineOffSet, lineOffSetEnd)
+        } catch (e: IllegalArgumentException) {
+            logger.warn(e)
+            return TextRange.EMPTY_RANGE
+        }
+    }
+}

--- a/src/main/kotlin/snyk/code/annotator/SnykCodeAnnotatorLS.kt
+++ b/src/main/kotlin/snyk/code/annotator/SnykCodeAnnotatorLS.kt
@@ -1,134 +1,17 @@
 package snyk.code.annotator
 
 import com.intellij.lang.annotation.AnnotationHolder
-import com.intellij.lang.annotation.ExternalAnnotator
-import com.intellij.openapi.diagnostic.logger
-import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiFile
-import io.snyk.plugin.getSnykCachedResults
 import io.snyk.plugin.isSnykCodeLSEnabled
 import io.snyk.plugin.isSnykCodeRunning
-import io.snyk.plugin.toLanguageServerURL
-import org.eclipse.lsp4j.CodeActionContext
-import org.eclipse.lsp4j.CodeActionParams
-import org.eclipse.lsp4j.Range
-import org.eclipse.lsp4j.TextDocumentIdentifier
-import snyk.common.AnnotatorCommon
 import snyk.common.ProductType
-import snyk.common.lsp.LanguageServerWrapper
-import snyk.common.lsp.ScanIssue
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.TimeoutException
 
-private const val CODEACTION_TIMEOUT = 2L
-
-class SnykCodeAnnotatorLS : ExternalAnnotator<PsiFile, Unit>() {
-    val logger = logger<SnykCodeAnnotatorLS>()
-
-    // overrides needed for the Annotator to invoke apply(). We don't do anything here
-    override fun collectInformation(file: PsiFile): PsiFile {
-        return file
-    }
-
-    override fun doAnnotate(psiFile: PsiFile?) {
-        AnnotatorCommon.prepareAnnotate(psiFile)
-    }
+class SnykCodeAnnotatorLS : SnykAnnotator(product = ProductType.CODE_SECURITY) {
 
     override fun apply(psiFile: PsiFile, annotationResult: Unit, holder: AnnotationHolder) {
         if (!isSnykCodeLSEnabled()) return
-        if (!LanguageServerWrapper.getInstance().ensureLanguageServerInitialized()) return
         if (isSnykCodeRunning(psiFile.project)) return
 
-        getIssuesForFile(psiFile)
-            .filter { AnnotatorCommon.isSeverityToShow(it.getSeverityAsEnum()) }
-            .distinctBy { it.id }
-            .sortedBy { it.title }
-            .forEach { issue ->
-                val highlightSeverity = issue.getSeverityAsEnum().getHighlightSeverity()
-                val textRange = textRange(psiFile, issue.range)
-                if (textRange == null) {
-                    logger.warn("Invalid range for issue: $issue")
-                    return@forEach
-                }
-                if (!textRange.isEmpty) {
-                    val annotationMessage = "${issue.annotationMessage()} (Snyk)"
-                    holder.newAnnotation(highlightSeverity, annotationMessage)
-                        .range(textRange)
-                        .withFix(ShowDetailsIntentionAction(annotationMessage, issue))
-                        .create()
-
-                    val params = CodeActionParams(
-                        TextDocumentIdentifier(psiFile.virtualFile.toLanguageServerURL()),
-                        issue.range,
-                        CodeActionContext(emptyList())
-                    )
-                    val languageServer = LanguageServerWrapper.getInstance().languageServer
-                    val codeActions = try {
-                        languageServer.textDocumentService
-                            .codeAction(params).get(CODEACTION_TIMEOUT, TimeUnit.SECONDS) ?: emptyList()
-                    } catch (ignored: TimeoutException) {
-                        logger.info("Timeout fetching code actions for issue: $issue")
-                        emptyList()
-                    }
-
-                    codeActions
-                        .filter { a ->
-                            val diagnosticCode = a.right.diagnostics?.get(0)?.code?.left
-                            val ruleId = issue.ruleId()
-                            diagnosticCode == ruleId
-                        }
-                        .sortedBy { it.right.title }.forEach { action ->
-                            val codeAction = action.right
-                            val title = codeAction.title
-                            holder.newAnnotation(highlightSeverity, title)
-                                .range(textRange)
-                                .withFix(CodeActionIntention(issue, codeAction, ProductType.CODE_SECURITY))
-                                .create()
-                        }
-                }
-            }
-    }
-
-    private fun getIssuesForFile(psiFile: PsiFile): Set<ScanIssue> =
-        getSnykCachedResults(psiFile.project)?.currentSnykCodeResultsLS
-            ?.filter { it.key.virtualFile == psiFile.virtualFile }
-            ?.map { it.value }
-            ?.flatten()
-            ?.toSet()
-            ?: emptySet()
-
-    /** Public for Tests only */
-    @Suppress("DuplicatedCode")
-    fun textRange(psiFile: PsiFile, range: Range): TextRange? {
-        try {
-            val document =
-                psiFile.viewProvider.document ?: throw IllegalArgumentException("No document found for $psiFile")
-            val startRow = range.start.line
-            val endRow = range.end.line
-            val startCol = range.start.character
-            val endCol = range.end.character
-
-            if (startRow < 0 || startRow > document.lineCount - 1) {
-                return null
-            }
-            if (endRow < 0 || endRow > document.lineCount - 1 || endRow < startRow) {
-                return null
-            }
-
-            val lineOffSet = document.getLineStartOffset(startRow) + startCol
-            val lineOffSetEnd = document.getLineStartOffset(endRow) + endCol
-
-            if (lineOffSet < 0 || lineOffSet > document.textLength - 1) {
-                return null
-            }
-            if (lineOffSetEnd < 0 || lineOffSetEnd < lineOffSet || lineOffSetEnd > document.textLength - 1) {
-                return null
-            }
-
-            return TextRange.create(lineOffSet, lineOffSetEnd)
-        } catch (e: IllegalArgumentException) {
-            logger.warn(e)
-            return TextRange.EMPTY_RANGE
-        }
+        super.apply(psiFile, annotationResult, holder)
     }
 }

--- a/src/main/kotlin/snyk/code/annotator/SnykOSSAnnotatorLS.kt
+++ b/src/main/kotlin/snyk/code/annotator/SnykOSSAnnotatorLS.kt
@@ -1,128 +1,16 @@
 package snyk.code.annotator
 
 import com.intellij.lang.annotation.AnnotationHolder
-import com.intellij.lang.annotation.ExternalAnnotator
-import com.intellij.openapi.diagnostic.logger
-import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiFile
 import io.snyk.plugin.*
-import org.eclipse.lsp4j.*
-import snyk.common.AnnotatorCommon
 import snyk.common.ProductType
-import snyk.common.lsp.LanguageServerWrapper
-import snyk.common.lsp.ScanIssue
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.TimeoutException
 
-private const val CODEACTION_TIMEOUT = 2L
-
-class SnykOSSAnnotatorLS : ExternalAnnotator<PsiFile, Unit>() {
-    val logger = logger<SnykOSSAnnotatorLS>()
-
-    // overrides needed for the Annotator to invoke apply(). We don't do anything here
-    override fun collectInformation(file: PsiFile): PsiFile {
-        return file
-    }
-
-    override fun doAnnotate(psiFile: PsiFile?) {
-        AnnotatorCommon.prepareAnnotate(psiFile)
-    }
+class SnykOSSAnnotatorLS : SnykAnnotator(product = ProductType.OSS) {
 
     override fun apply(psiFile: PsiFile, annotationResult: Unit, holder: AnnotationHolder) {
         if (!isSnykOSSLSEnabled()) return
-        if (!LanguageServerWrapper.getInstance().ensureLanguageServerInitialized()) return
         if (isOssRunning(psiFile.project)) return
 
-        getIssuesForFile(psiFile)
-            .filter { AnnotatorCommon.isSeverityToShow(it.getSeverityAsEnum()) }
-            .distinctBy { it.id }
-            .sortedBy { it.title }
-            .forEach { issue ->
-                val highlightSeverity = issue.getSeverityAsEnum().getHighlightSeverity()
-                val textRange = textRange(psiFile, issue.range)
-                if (textRange == null) {
-                    logger.warn("Invalid range for issue: $issue")
-                    return@forEach
-                }
-                if (!textRange.isEmpty) {
-                    val annotationMessage = "${issue.annotationMessage()} (Snyk)"
-                    holder.newAnnotation(highlightSeverity, annotationMessage)
-                        .range(textRange)
-                        .withFix(ShowDetailsIntentionAction(annotationMessage, issue))
-                        .create()
-
-                    val params = CodeActionParams(
-                        TextDocumentIdentifier(psiFile.virtualFile.toLanguageServerURL()),
-                        issue.range,
-                        CodeActionContext(emptyList())
-                    )
-                    val languageServer = LanguageServerWrapper.getInstance().languageServer
-                    val codeActions = try {
-                        languageServer.textDocumentService
-                            .codeAction(params).get(CODEACTION_TIMEOUT, TimeUnit.SECONDS) ?: emptyList()
-                    } catch (ignored: TimeoutException) {
-                        logger.info("Timeout fetching code actions for issue: $issue")
-                        emptyList()
-                    }
-
-                    codeActions
-                        .filter { a ->
-                            val diagnosticCode = a.right.diagnostics?.get(0)?.code?.left
-                            val ruleId = issue.ruleId()
-                            diagnosticCode == ruleId
-                        }
-                        .sortedBy { it.right.title }.forEach { action ->
-                            val codeAction = action.right
-                            val title = codeAction.title
-                            holder.newAnnotation(highlightSeverity, title)
-                                .range(textRange)
-                                .withFix(CodeActionIntention(issue, codeAction, ProductType.OSS))
-                                .create()
-                        }
-                }
-            }
-    }
-
-    private fun getIssuesForFile(psiFile: PsiFile): Set<ScanIssue> =
-        getSnykCachedResults(psiFile.project)?.currentOSSResultsLS
-            ?.filter { it.key.virtualFile == psiFile.virtualFile }
-            ?.map { it.value }
-            ?.flatten()
-            ?.toSet()
-            ?: emptySet()
-
-    /** Public for Tests only */
-    @Suppress("DuplicatedCode")
-    fun textRange(psiFile: PsiFile, range: Range): TextRange? {
-        try {
-            val document =
-                psiFile.viewProvider.document ?: throw IllegalArgumentException("No document found for $psiFile")
-            val startRow = range.start.line
-            val endRow = range.end.line
-            val startCol = range.start.character
-            val endCol = range.end.character
-
-            if (startRow < 0 || startRow > document.lineCount - 1) {
-                return null
-            }
-            if (endRow < 0 || endRow > document.lineCount - 1 || endRow < startRow) {
-                return null
-            }
-
-            val lineOffSet = document.getLineStartOffset(startRow) + startCol
-            val lineOffSetEnd = document.getLineStartOffset(endRow) + endCol
-
-            if (lineOffSet < 0 || lineOffSet > document.textLength - 1) {
-                return null
-            }
-            if (lineOffSetEnd < 0 || lineOffSetEnd < lineOffSet || lineOffSetEnd > document.textLength - 1) {
-                return null
-            }
-
-            return TextRange.create(lineOffSet, lineOffSetEnd)
-        } catch (e: IllegalArgumentException) {
-            logger.warn(e)
-            return TextRange.EMPTY_RANGE
-        }
+        super.apply(psiFile, annotationResult, holder)
     }
 }

--- a/src/main/kotlin/snyk/common/SnykCachedResults.kt
+++ b/src/main/kotlin/snyk/common/SnykCachedResults.kt
@@ -25,11 +25,17 @@ class SnykCachedResults(val project: Project) {
 
     var currentSnykCodeResults: SnykResults? = null
 
+    val currentOSSResultsLS: MutableMap<SnykFile, List<ScanIssue>> = mutableMapOf()
+
     var currentOssResults: OssResult? = null
         get() = if (field?.isExpired() == false) field else null
 
+    val currentContainerResultsLS: MutableMap<SnykFile, List<ScanIssue>> = mutableMapOf()
+
     var currentContainerResult: ContainerResult? = null
         get() = if (field?.isExpired() == false) field else null
+
+    val currentIacResultsLS: MutableMap<SnykFile, List<ScanIssue>> = mutableMapOf()
 
     var currentIacResult: IacResult? = null
         get() = if (field?.isExpired() == false) field else null
@@ -43,6 +49,7 @@ class SnykCachedResults(val project: Project) {
     var currentSnykCodeError: SnykError? = null
 
     fun cleanCaches() {
+        currentOSSResultsLS.clear()
         currentOssResults = null
         currentContainerResult = null
         currentIacResult = null
@@ -134,7 +141,13 @@ class SnykCachedResults(val project: Project) {
                     logger.info("scanning finished for project ${project.name}, assigning cache.")
                 }
 
-                override fun scanningSnykCodeError(snykScan: SnykScanParams) {
+                override fun scanningOssFinished(snykResults: Map<SnykFile, List<ScanIssue>>) {
+                    currentOSSResultsLS.clear()
+                    currentOSSResultsLS.putAll(snykResults)
+                    logger.info("scanning finished for project ${project.name}, assigning cache.")
+                }
+
+                override fun scanningError(snykScan: SnykScanParams) {
                     SnykBalloonNotificationHelper
                         .showError(
                             "scanning error for project ${project.name}, emptying cache.Data: $snykScan",

--- a/src/main/kotlin/snyk/common/lsp/Types.kt
+++ b/src/main/kotlin/snyk/common/lsp/Types.kt
@@ -491,7 +491,7 @@ data class IssueData(
     override fun hashCode(): Int {
         if (this.getProductType() == ProductType.OSS) {
             var result = ruleId.hashCode()
-            result = 31 + description.hashCode()
+            result = 31 * result + description.hashCode()
             result = 31 * result + (license?.hashCode() ?: 0)
             result = 31 * result + (identifiers?.hashCode() ?: 0)
             result = 31 * result + language.hashCode()

--- a/src/main/kotlin/snyk/common/lsp/Types.kt
+++ b/src/main/kotlin/snyk/common/lsp/Types.kt
@@ -8,9 +8,15 @@ import com.intellij.openapi.util.TextRange
 import com.intellij.openapi.vfs.VirtualFile
 import io.snyk.plugin.Severity
 import io.snyk.plugin.getDocument
+import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.toVirtualFile
 import org.eclipse.lsp4j.Range
+import snyk.analytics.IssueInTreeIsClicked.IssueType
+import snyk.common.ProductType
 import java.util.Date
+import io.snyk.plugin.ui.PackageManagerIconProvider.Companion.getIcon
+import javax.swing.Icon
+import java.util.Locale
 
 // Define the SnykScanParams data class
 data class SnykScanParams(
@@ -77,6 +83,185 @@ data class ScanIssue(
         document = virtualFile?.getDocument()
         startOffset = document?.getLineStartOffset(range.start.line)?.plus(range.start.character)
         endOffset = document?.getLineStartOffset(range.end.line)?.plus(range.end.character)
+    }
+
+    fun type(): IssueType {
+        return when (this.additionalData.getProductType()) {
+            ProductType.OSS -> {
+                if (this.additionalData.license != null) {
+                    IssueType.LICENCE_ISSUE
+                } else {
+                    IssueType.OPEN_SOURCE_VULNERABILITY
+                }
+            }
+            ProductType.IAC -> IssueType.INFRASTRUCTURE_AS_CODE_ISSUE
+            ProductType.CONTAINER -> IssueType.CONTAINER_VULNERABILITY
+            ProductType.CODE_SECURITY -> IssueType.CODE_SECURITY_VULNERABILITY
+            ProductType.CODE_QUALITY -> IssueType.CODE_QUALITY_ISSUE
+            ProductType.ADVISOR -> IssueType.ADVISOR
+        }
+    }
+
+    fun title(): String {
+        return when (this.additionalData.getProductType()) {
+            ProductType.OSS -> this.title
+            ProductType.CODE_QUALITY -> {
+                this.additionalData.message.split('.').firstOrNull() ?: "Unknown issue"
+            }
+            ProductType.CODE_SECURITY -> {
+                this.title.split(":").firstOrNull() ?: "Unknown issue"
+            }
+            else -> TODO()
+        }
+    }
+
+    fun longTitle(): String {
+        return when (this.additionalData.getProductType()) {
+            ProductType.OSS -> {
+                "${this.additionalData.packageName}@${this.additionalData.version}: ${this.title()}"
+            }
+            ProductType.CODE_QUALITY, ProductType.CODE_SECURITY -> {
+                return "${this.title()} [${this.range.start.line + 1},${this.range.start.character}]"
+            }
+            else -> TODO()
+        }
+    }
+
+    fun priority(): Int {
+        return when (this.additionalData.getProductType()) {
+            ProductType.OSS -> {
+                return when(this.getSeverityAsEnum()) {
+                    Severity.CRITICAL -> 4
+                    Severity.HIGH -> 3
+                    Severity.MEDIUM -> 2
+                    Severity.LOW -> 1
+                    Severity.UNKNOWN -> 0
+                }
+            }
+            ProductType.CODE_SECURITY, ProductType.CODE_QUALITY -> this.additionalData.priorityScore
+            else -> TODO()
+        }
+    }
+    fun issueNaming(): String {
+        return when (this.additionalData.getProductType()) {
+            ProductType.OSS -> {
+                if (this.additionalData.license != null) {
+                    "License"
+                } else {
+                    "Vulnerability"
+                }
+            }
+            ProductType.CODE_SECURITY -> "Vulnerability"
+            ProductType.CODE_QUALITY -> "Quality Issue"
+            else -> TODO()
+        }
+    }
+
+
+    fun cwes(): List<String> {
+        return when (this.additionalData.getProductType()) {
+            ProductType.OSS -> {
+                this.additionalData.identifiers?.CWE ?: emptyList()
+            }
+            ProductType.CODE_SECURITY, ProductType.CODE_QUALITY -> {
+                this.additionalData.cwe ?: emptyList()
+            }
+            else -> TODO()
+        }
+    }
+
+    fun cves(): List<String> {
+        return when (this.additionalData.getProductType()) {
+            ProductType.OSS -> {
+                    this.additionalData.identifiers?.CVE ?: emptyList()
+            }
+            ProductType.CODE_SECURITY, ProductType.CODE_QUALITY -> emptyList()
+            else -> TODO()
+        }
+    }
+
+    fun cvssScore(): String? {
+        return when (this.additionalData.getProductType()) {
+            ProductType.OSS -> this.additionalData.cvssScore
+            ProductType.CODE_SECURITY, ProductType.CODE_QUALITY -> null
+            else -> TODO()
+        }
+    }
+
+    fun cvssV3(): String? {
+        return when (this.additionalData.getProductType()) {
+            ProductType.OSS -> this.additionalData.CVSSv3
+            ProductType.CODE_SECURITY, ProductType.CODE_QUALITY -> null
+            else -> TODO()
+        }
+    }
+
+    fun id(): String? {
+        return when (this.additionalData.getProductType()) {
+            ProductType.OSS -> this.additionalData.ruleId
+            ProductType.CODE_SECURITY, ProductType.CODE_QUALITY -> null
+            else -> TODO()
+        }
+    }
+
+    fun ruleId(): String? {
+        return when (this.additionalData.getProductType()) {
+            ProductType.OSS, ProductType.CODE_SECURITY, ProductType.CODE_QUALITY -> this.additionalData.ruleId
+            else -> TODO()
+        }
+    }
+
+    fun icon(): Icon? {
+        return when (this.additionalData.getProductType()) {
+            ProductType.OSS -> getIcon(this.additionalData.packageManager.lowercase(Locale.getDefault()))
+            ProductType.CODE_SECURITY, ProductType.CODE_QUALITY -> null
+            else -> TODO()
+        }
+    }
+
+    fun details(): String {
+        return when (this.additionalData.getProductType()) {
+            ProductType.OSS -> this.additionalData.details ?: ""
+            ProductType.CODE_SECURITY, ProductType.CODE_QUALITY -> this.additionalData.details ?: ""
+            else -> TODO()
+        }
+    }
+
+    fun annotationMessage(): String {
+        return when (this.additionalData.getProductType()) {
+            ProductType.OSS -> this.title
+            ProductType.CODE_SECURITY, ProductType.CODE_QUALITY -> this.title.ifBlank {
+                this.additionalData.message.let {
+                    if (it.length < 70) it else "${it.take(70)}..."
+                }
+            }
+            else -> TODO()
+        }
+    }
+
+    fun canLoadSuggestionPanelFromHTML(): Boolean {
+        return when (this.additionalData.getProductType()) {
+            ProductType.OSS -> false
+            ProductType.CODE_SECURITY, ProductType.CODE_QUALITY -> this.additionalData.details != null
+            else -> TODO()
+        }
+    }
+
+    fun hasAIFix(): Boolean {
+        return when (this.additionalData.getProductType()) {
+            ProductType.OSS -> false
+            ProductType.CODE_SECURITY, ProductType.CODE_QUALITY -> {
+                if (this.isIgnored()) {
+                    return false
+                }
+                return this.additionalData.hasAIFix
+            }
+            else -> TODO()
+        }
+    }
+
+    fun isIgnored(): Boolean {
+        return pluginSettings().isGlobalIgnoresFeatureEnabled && this.isIgnored == true
     }
 
     fun getSeverityAsEnum(): Severity {
@@ -186,10 +371,10 @@ data class DataFlow(
 )
 
 data class IssueData(
+    // Code
     @SerializedName("message") val message: String,
     @SerializedName("leadURL") val leadURL: String?,
     @SerializedName("rule") val rule: String,
-    @SerializedName("ruleId") val ruleId: String,
     @SerializedName("repoDatasetSize") val repoDatasetSize: Int,
     @SerializedName("exampleCommitFixes") val exampleCommitFixes: List<ExampleCommitFix>,
     @SerializedName("cwe") val cwe: List<String>?,
@@ -201,13 +386,81 @@ data class IssueData(
     @SerializedName("priorityScore") val priorityScore: Int,
     @SerializedName("hasAIFix") val hasAIFix: Boolean,
     @SerializedName("dataFlow") val dataFlow: List<DataFlow>,
+
+    // OSS
+    @SerializedName("license") val license: String?,
+    @SerializedName("identifiers") val identifiers: OssIdentifiers?,
+    @SerializedName("description") val description: String,
+    @SerializedName("language") val language: String,
+    @SerializedName("packageManager") val packageManager: String,
+    @SerializedName("packageName") val packageName: String,
+    @SerializedName("name") val name: String,
+    @SerializedName("version") val version: String,
+    @SerializedName("exploit") val exploit: String?,
+    @SerializedName("CVSSv3") val CVSSv3: String?,
+    @SerializedName("cvssScore") val cvssScore: String?,
+    @SerializedName("fixedIn") val fixedIn: List<String>?,
+    @SerializedName("from") val from: List<String>,
+    @SerializedName("upgradePath") val upgradePath: List<Any>,
+    @SerializedName("isPatchable") val isPatchable: Boolean,
+    @SerializedName("isUpgradable") val isUpgradable: Boolean?,
+    @SerializedName("projectName") val projectName: String,
+    @SerializedName("displayTargetFile") val displayTargetFile: String?,
+    @SerializedName("matchingIssues") val matchingIssues: List<IssueData>?,
+    @SerializedName("lesson") val lesson: String?,
+
+    // Code and OSS
+    @SerializedName("ruleId") val ruleId: String,
     @SerializedName("details") val details: String?,
-    ) {
+) {
+
+    fun getProductType(): ProductType {
+        // TODO: how else to differentiate?
+        if (this.packageManager != null) {
+            return ProductType.OSS
+        }
+        if (this.message != null) {
+            if (this.isSecurityType) {
+                return ProductType.CODE_SECURITY
+            } else {
+                return ProductType.CODE_QUALITY
+            }
+        }
+        throw IllegalStateException("Not defined type of IssueData")
+    }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
 
         other as IssueData
+
+        if (this.getProductType() == ProductType.OSS) {
+            if (ruleId != other.ruleId) return false
+            if (license != other.license) return false
+            if (identifiers != other.identifiers) return false
+            if (description != other.description) return false
+            if (language != other.language) return false
+            if (packageManager != other.packageManager) return false
+            if (packageName != other.packageName) return false
+            if (name != other.name) return false
+            if (version != other.version) return false
+            if (exploit != other.exploit) return false
+            if (CVSSv3 != other.CVSSv3) return false
+            if (cvssScore != other.cvssScore) return false
+            if (fixedIn != other.fixedIn) return false
+            if (from != other.from) return false
+            if (upgradePath != other.upgradePath) return false
+            if (isPatchable != other.isPatchable) return false
+            if (isUpgradable != other.isUpgradable) return false
+            if (projectName != other.projectName) return false
+            if (displayTargetFile != other.displayTargetFile) return false
+            if (matchingIssues != other.matchingIssues) return false
+            if (lesson != other.lesson) return false
+            if (details != other.details) return false
+
+            return true
+        }
 
         if (message != other.message) return false
         if (leadURL != other.leadURL) return false
@@ -236,6 +489,31 @@ data class IssueData(
     }
 
     override fun hashCode(): Int {
+        if (this.getProductType() == ProductType.OSS) {
+            var result = ruleId.hashCode()
+            result = 31 + description.hashCode()
+            result = 31 * result + (license?.hashCode() ?: 0)
+            result = 31 * result + (identifiers?.hashCode() ?: 0)
+            result = 31 * result + language.hashCode()
+            result = 31 * result + packageManager.hashCode()
+            result = 31 * result + packageName.hashCode()
+            result = 31 * result + name.hashCode()
+            result = 31 * result + version.hashCode()
+            result = 31 * result + (exploit?.hashCode() ?: 0)
+            result = 31 * result + (CVSSv3?.hashCode() ?: 0)
+            result = 31 * result + (cvssScore?.hashCode() ?: 0)
+            result = 31 * result + (fixedIn?.hashCode() ?: 0)
+            result = 31 * result + from.hashCode()
+            result = 31 * result + upgradePath.hashCode()
+            result = 31 * result + isPatchable.hashCode()
+            result = 31 * result + (isUpgradable?.hashCode() ?: 0)
+            result = 31 * result + displayTargetFile.hashCode()
+            result = 31 * result + (details?.hashCode() ?: 0)
+            result = 31 * result +( matchingIssues?.hashCode() ?: 0)
+            result = 31 * result + (lesson?.hashCode() ?: 0)
+            return result
+        }
+
         var result = message.hashCode()
         result = 31 * result + (leadURL?.hashCode() ?: 0)
         result = 31 * result + rule.hashCode()
@@ -267,3 +545,27 @@ data class IgnoreDetails(
     @SerializedName("ignoredOn") val ignoredOn: Date,
     @SerializedName("ignoredBy") val ignoredBy: String,
 )
+
+data class OssIdentifiers(
+    @SerializedName("CWE") val CWE: List<String>?,
+    @SerializedName("CVE") val CVE: List<String>?,
+){
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as OssIdentifiers
+
+        if (CWE != other.CWE) return false
+        if (CVE != other.CVE) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = (CWE.hashCode() ?: 0)
+        result = 31 * result + (CVE?.hashCode() ?: 0)
+        return result
+    }
+}

--- a/src/main/kotlin/snyk/oss/OssBulkFileListener.kt
+++ b/src/main/kotlin/snyk/oss/OssBulkFileListener.kt
@@ -1,22 +1,67 @@
 package snyk.oss
 
+import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
+import com.intellij.ide.impl.ProjectUtil
 import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.openapi.vfs.newvfs.events.VFileEvent
+import com.intellij.openapi.vfs.readText
 import io.snyk.plugin.SnykBulkFileListener
+import io.snyk.plugin.SnykFile
 import io.snyk.plugin.getSnykCachedResults
+import io.snyk.plugin.isSnykOSSLSEnabled
+import io.snyk.plugin.toLanguageServerURL
+import io.snyk.plugin.toSnykFileSet
+import org.eclipse.lsp4j.DidSaveTextDocumentParams
+import org.eclipse.lsp4j.TextDocumentIdentifier
+import snyk.common.lsp.LanguageServerWrapper
 
 class OssBulkFileListener : SnykBulkFileListener() {
 
     private val log = logger<OssBulkFileListener>()
 
     override fun before(project: Project, virtualFilesAffected: Set<VirtualFile>) {
+        if (isSnykOSSLSEnabled()) {
+            return
+        }
         dropOssCacheIfNeeded(project, virtualFilesAffected)
     }
 
     override fun after(project: Project, virtualFilesAffected: Set<VirtualFile>) {
+        if (isSnykOSSLSEnabled()) {
+            val filesAffected = toSnykFileSet(project, virtualFilesAffected)
+            updateCacheAndUI(filesAffected, project)
+        }
         dropOssCacheIfNeeded(project, virtualFilesAffected)
+    }
+
+    override fun forwardEvents(events: MutableList<out VFileEvent>) {
+        val languageServerWrapper = LanguageServerWrapper.getInstance()
+
+        if (!isSnykOSSLSEnabled()) return
+        if (!languageServerWrapper.isInitialized) return
+
+        val languageServer = languageServerWrapper.languageServer
+        for (event in events) {
+            if (event.file == null || !event.isFromSave) continue
+            val file = event.file!!
+            val activeProject = ProjectUtil.getActiveProject()
+            ProgressManager.getInstance().run(object : Task.Backgroundable(
+                activeProject,
+                "Snyk: forwarding save event to Language Server"
+            ) {
+                override fun run(indicator: ProgressIndicator) {
+                    val param = DidSaveTextDocumentParams(TextDocumentIdentifier(file.toLanguageServerURL()), file.readText())
+                    languageServer.textDocumentService.didSave(param)
+                }
+            })
+        }
     }
 
     private fun dropOssCacheIfNeeded(project: Project, virtualFilesAffected: Set<VirtualFile>) {
@@ -30,6 +75,15 @@ class OssBulkFileListener : SnykBulkFileListener() {
                 log.debug("OSS cached results dropped due to changes in: $buildFileChanged")
             }
         }
+    }
+
+    private fun updateCacheAndUI(filesAffected: Set<SnykFile>, project: Project) {
+        val cache = getSnykCachedResults(project)?.currentSnykCodeResultsLS ?: return
+        filesAffected.forEach {
+            cache.remove(it)
+        }
+        VirtualFileManager.getInstance().asyncRefresh()
+        DaemonCodeAnalyzer.getInstance(project).restart()
     }
 
     companion object {

--- a/src/main/kotlin/snyk/oss/annotator/OSSBaseAnnotator.kt
+++ b/src/main/kotlin/snyk/oss/annotator/OSSBaseAnnotator.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiFile
 import io.snyk.plugin.Severity
 import io.snyk.plugin.getSnykCachedResults
+import io.snyk.plugin.isSnykOSSLSEnabled
 import io.snyk.plugin.ui.toolwindow.SnykToolWindowPanel
 import snyk.common.AnnotatorCommon
 import snyk.common.intentionactions.AlwaysAvailableReplacementIntentionAction
@@ -28,6 +29,8 @@ abstract class OSSBaseAnnotator : ExternalAnnotator<PsiFile, Unit>() {
     }
 
     override fun apply(psiFile: PsiFile, annotationResult: Unit, holder: AnnotationHolder) {
+        if (isSnykOSSLSEnabled()) return
+
         val issues = getIssuesForFile(psiFile) ?: return
 
         val filteredVulns = issues.vulnerabilities

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -57,6 +57,7 @@
 
     <externalAnnotator language="" implementationClass="snyk.code.annotator.SnykCodeAnnotatorLS"/>
     <externalAnnotator language="" implementationClass="snyk.code.annotator.SnykCodeAnnotator"/>
+    <externalAnnotator language="" implementationClass="snyk.code.annotator.SnykOSSAnnotatorLS"/>
   </extensions>
 
   <actions>

--- a/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SuggestionDescriptionPanelFromLSOSSTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SuggestionDescriptionPanelFromLSOSSTest.kt
@@ -1,0 +1,96 @@
+@file:Suppress("FunctionName")
+package io.snyk.plugin.ui.toolwindow
+
+import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiFile
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.snyk.plugin.Severity
+import io.snyk.plugin.pluginSettings
+import io.snyk.plugin.resetSettings
+import io.snyk.plugin.SnykFile
+import io.snyk.plugin.ui.jcef.JCEFUtils
+import io.snyk.plugin.ui.toolwindow.panels.SuggestionDescriptionPanelFromLS
+import org.eclipse.lsp4j.Position
+import org.eclipse.lsp4j.Range
+import org.junit.Before
+import org.junit.Test
+import snyk.UIComponentFinder.getActionLinkByText
+import snyk.UIComponentFinder.getJBCEFBrowser
+import snyk.UIComponentFinder.getJButtonByText
+import snyk.UIComponentFinder.getJLabelByText
+import snyk.UIComponentFinder.getJPanelByName
+import snyk.code.annotator.SnykCodeAnnotator
+import snyk.common.ProductType
+import snyk.common.lsp.CommitChangeLine
+import snyk.common.lsp.DataFlow
+import snyk.common.lsp.ExampleCommitFix
+import snyk.common.lsp.ScanIssue
+import java.nio.file.Paths
+import javax.swing.JLabel
+
+class SuggestionDescriptionPanelFromLSOSSTest : BasePlatformTestCase() {
+    private lateinit var cut: SuggestionDescriptionPanelFromLS
+    private val fileName = "app.js"
+    private lateinit var snykFile: SnykFile
+    private lateinit var issue: ScanIssue
+
+    private lateinit var file: VirtualFile
+    private lateinit var psiFile: PsiFile
+
+    override fun getTestDataPath(): String {
+        val resource = SnykCodeAnnotator::class.java.getResource("/test-fixtures/code/annotator")
+        requireNotNull(resource) { "Make sure that the resource $resource exists!" }
+        return Paths.get(resource.toURI()).toString()
+    }
+
+    @Before
+    override fun setUp() {
+        super.setUp()
+        unmockkAll()
+        resetSettings(project)
+
+        file = myFixture.copyFileToProject(fileName)
+        psiFile = WriteAction.computeAndWait<PsiFile, Throwable> { psiManager.findFile(file)!! }
+        snykFile = SnykFile(psiFile.project, psiFile.virtualFile)
+
+        issue = mockk<ScanIssue>()
+        every { issue.getSeverityAsEnum() } returns Severity.CRITICAL
+        every { issue.title() } returns "title"
+        every { issue.issueNaming() } returns "issueNaming"
+        every { issue.cwes() } returns emptyList()
+        every { issue.cves() } returns emptyList()
+        every { issue.cvssV3() } returns "cvssScore"
+        every { issue.cvssScore() } returns "cvssScore"
+        every { issue.id() } returns "id"
+        every { issue.ruleId() } returns "ruleId"
+        every { issue.additionalData.getProductType() } returns ProductType.OSS
+    }
+
+    @Test
+    fun `test createUI should build the right panels for Snyk OSS`() {
+        cut = SuggestionDescriptionPanelFromLS(snykFile, issue)
+
+        val issueNaming = getJLabelByText(cut, issue.issueNaming())
+        assertNotNull(issueNaming)
+
+        val cvssScore = getActionLinkByText(cut, "CVSS cvssScore")
+        assertNotNull(cvssScore)
+
+        val ruleId = getActionLinkByText(cut, "ID")
+        assertNotNull(ruleId)
+
+        val overviewPanel = getJLabelByText(cut, "<html>Test message</html>")
+        assertNull(overviewPanel)
+
+        val dataFlowPanel = getJPanelByName(cut, "dataFlowPanel")
+        assertNull(dataFlowPanel)
+
+        val fixExamplesPanel = getJPanelByName(cut, "fixExamplesPanel")
+        assertNull(fixExamplesPanel)
+    }
+}

--- a/src/test/kotlin/snyk/UIComponentFinder.kt
+++ b/src/test/kotlin/snyk/UIComponentFinder.kt
@@ -1,5 +1,6 @@
 package snyk
 
+import com.intellij.ui.components.ActionLink
 import com.intellij.ui.jcef.JBCefBrowser
 import java.awt.Container
 import javax.swing.JButton
@@ -70,4 +71,20 @@ object UIComponentFinder {
         }
         return found
     }
+    fun getActionLinkByText(parent: Container, text: String): JButton? {
+        val components = parent.components
+        var found: JButton? = null
+        for (component in components) {
+            if (component is ActionLink && text == component.text) {
+                found = component
+            } else if (component is Container) {
+                found = getActionLinkByText(component, text)
+            }
+            if (found != null) {
+                break
+            }
+        }
+        return found
+    }
+
 }


### PR DESCRIPTION
### Description

This PR loads the Tree Nodes for OSS from LS. It also renders a simple Suggestion Panel with a title and subtitle, but the follow-up UI elements will be added in a separate PR.

It has been written so that all the product lines loaded via the LS are rendered the same way. So the `ScanIssue` type now exposes functions that are meant to be used in the UI elements to render information about the issue, depending on what product-line it is.

It requires the changes in https://github.com/snyk/snyk-ls/releases/tag/v20240513.094925 to work, so update the CLI locally for now and run `make build`, then change the path to the CLI in the Snyk Settings. Also make sure to enable the `snyk.preview.snyk.oss.ls.enabled` registry flag in IntelliJ.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

Without feature flag:
![Screenshot 2024-05-09 at 15 56 25](https://github.com/snyk/snyk-intellij-plugin/assets/81559517/1ab665ff-cc21-49f1-af6f-ef914ee423df)
![Screenshot 2024-05-09 at 15 56 19](https://github.com/snyk/snyk-intellij-plugin/assets/81559517/1174e50e-ce40-4e31-839e-d51b4f8e827a)
![Screenshot 2024-05-10 at 15 50 38](https://github.com/snyk/snyk-intellij-plugin/assets/81559517/ffb5b83d-fe10-4522-98b6-47a854e8080e)

With feature flag:
![Screenshot 2024-05-10 at 16 08 18](https://github.com/snyk/snyk-intellij-plugin/assets/81559517/c9be866f-89a5-4d8c-854f-13d1aa802587)
![Screenshot 2024-05-10 at 16 08 07](https://github.com/snyk/snyk-intellij-plugin/assets/81559517/ca17051d-8d08-4320-afa1-303555909d4c)
![Screenshot 2024-05-10 at 16 08 11](https://github.com/snyk/snyk-intellij-plugin/assets/81559517/3f2ee542-5229-43c6-8f2f-3bf59b9e6bfa)