### PR TITLE
feat: add oss ls registry flag [IDE-283]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Snyk Security Changelog
 
 ## [2.7.19]
-### Added
 - Refactors some files so they can be used by more than just Snyk Code
+- Registry flag for integrating Snyk OSS scans in JetBrains via the LS
 
 ## [2.7.18]
 ### Added

--- a/src/main/kotlin/io/snyk/plugin/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/Utils.kt
@@ -258,7 +258,7 @@ fun isFileListenerEnabled(): Boolean = pluginSettings().fileListenerEnabled
 
 fun isSnykCodeLSEnabled(): Boolean = Registry.`is`("snyk.preview.snyk.code.ls.enabled", true)
 
-fun isSnykOSSLSEnabled(): Boolean = false
+fun isSnykOSSLSEnabled(): Boolean = Registry.`is`("snyk.preview.snyk.oss.ls.enabled", false)
 
 fun isSnykIaCLSEnabled(): Boolean = false
 

--- a/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
@@ -313,7 +313,7 @@ class LanguageServerWrapper(
     fun getSettings(): LanguageServerSettings {
         val ps = pluginSettings()
         return LanguageServerSettings(
-            activateSnykOpenSource = isSnykOSSLSEnabled().toString(),
+            activateSnykOpenSource = (isSnykOSSLSEnabled() && ps.ossScanEnable).toString(),
             activateSnykCodeSecurity = (isSnykCodeLSEnabled() && ps.snykCodeSecurityIssuesScanEnable).toString(),
             activateSnykCodeQuality = (isSnykCodeLSEnabled() && ps.snykCodeQualityIssuesScanEnable).toString(),
             activateSnykIac = isSnykIaCLSEnabled().toString(),

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -46,6 +46,11 @@
                  description="Preview: Use language server as source for Snyk Code findings."
                  restartRequired="true"/>
 
+    <registryKey key="snyk.preview.snyk.oss.ls.enabled"
+                 defaultValue="false"
+                 description="Preview: Use language server as source for Snyk OSS findings."
+                 restartRequired="true"/>
+
     <notificationGroup id="Snyk" displayType="BALLOON" toolWindowId="Snyk"/>
 
     <codeInsight.codeVisionProvider implementation="snyk.common.lsp.LSCodeVisionProvider"/>


### PR DESCRIPTION
### Description

Adds the registry flag to be used while integrating OSS into IntelliJ via LS. Also adds a small "fix" which means once we enable the LS we also check that OSS is enabled from the settings, like we do for Code too.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing
