### PR TITLE
refactor: rename common classes from SnykCode prefix [IDE-283]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Snyk Security Changelog
 
+## [2.7.19]
+### Added
+- Refactors some files so they can be used by more than just Snyk Code
+
 ## [2.7.18]
 ### Added
 - Improved theming in the Code Issue Panel by applying IntelliJ theme colors dynamically to JCEF components. This ensures consistency of UI elements with the rest of the IDE.

--- a/src/main/java/ai/deepcode/javaclient/core/HashContentUtilsBase.java
+++ b/src/main/java/ai/deepcode/javaclient/core/HashContentUtilsBase.java
@@ -1,6 +1,6 @@
 package ai.deepcode.javaclient.core;
 
-import io.snyk.plugin.snykcode.core.SnykCodeFile;
+import io.snyk.plugin.SnykFile;
 import org.jetbrains.annotations.NotNull;
 
 import java.nio.charset.StandardCharsets;
@@ -26,8 +26,8 @@ public abstract class HashContentUtilsBase {
   }
 
   void removeProjectHashContent(@NotNull Object project) {
-    mapFile2Hash.keySet().removeIf(f -> f instanceof SnykCodeFile && platformDependentUtils.getProject(f) == project);
-    mapFile2Content.keySet().removeIf(f -> f instanceof SnykCodeFile && platformDependentUtils.getProject(f) == project);
+    mapFile2Hash.keySet().removeIf(f -> f instanceof SnykFile && platformDependentUtils.getProject(f) == project);
+    mapFile2Content.keySet().removeIf(f -> f instanceof SnykFile && platformDependentUtils.getProject(f) == project);
   }
 
   // ?? com.intellij.openapi.util.text.StringUtil.toHexString

--- a/src/main/kotlin/io/snyk/plugin/SnykFile.kt
+++ b/src/main/kotlin/io/snyk/plugin/SnykFile.kt
@@ -1,4 +1,4 @@
-package io.snyk.plugin.snykcode.core
+package io.snyk.plugin
 
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
@@ -8,7 +8,7 @@ import io.snyk.plugin.getPsiFile
 import snyk.common.RelativePathHelper
 import javax.swing.Icon
 
-data class SnykCodeFile(val project: Project, val virtualFile: VirtualFile) {
+data class SnykFile(val project: Project, val virtualFile: VirtualFile) {
     var icon: Icon? = null
     val relativePath = RelativePathHelper().getRelativePath(virtualFile, project)
     init {

--- a/src/main/kotlin/io/snyk/plugin/analytics/AnalyticsScanListener.kt
+++ b/src/main/kotlin/io/snyk/plugin/analytics/AnalyticsScanListener.kt
@@ -3,7 +3,7 @@ package io.snyk.plugin.analytics
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.project.Project
 import io.snyk.plugin.events.SnykScanListener
-import io.snyk.plugin.snykcode.SnykCodeResults
+import io.snyk.plugin.SnykResults
 import snyk.common.SnykError
 import snyk.common.lsp.LanguageServerWrapper
 import snyk.common.lsp.commands.ScanDoneEvent
@@ -56,16 +56,16 @@ class AnalyticsScanListener(val project: Project) {
             LanguageServerWrapper.getInstance().sendReportAnalyticsCommand(scanDoneEvent)
         }
 
-        override fun scanningSnykCodeFinished(snykCodeResults: SnykCodeResults?) {
+        override fun scanningSnykCodeFinished(snykResults: SnykResults?) {
             val duration = System.currentTimeMillis() - start
             val product = "Snyk Code"
             val scanDoneEvent = getScanDoneEvent(
                 duration,
                 product,
-                snykCodeResults?.totalCriticalCount ?: 0,
-                snykCodeResults?.totalErrorsCount ?: 0,
-                snykCodeResults?.totalWarnsCount ?: 0,
-                snykCodeResults?.totalInfosCount ?: 0,
+                snykResults?.totalCriticalCount ?: 0,
+                snykResults?.totalErrorsCount ?: 0,
+                snykResults?.totalWarnsCount ?: 0,
+                snykResults?.totalInfosCount ?: 0,
             )
             LanguageServerWrapper.getInstance().sendReportAnalyticsCommand(scanDoneEvent)
         }

--- a/src/main/kotlin/io/snyk/plugin/analytics/ItlyHelper.kt
+++ b/src/main/kotlin/io/snyk/plugin/analytics/ItlyHelper.kt
@@ -3,7 +3,7 @@ package io.snyk.plugin.analytics
 import ai.deepcode.javaclient.core.SuggestionForFile
 import io.snyk.plugin.Severity
 import io.snyk.plugin.services.SnykApplicationSettingsStateService
-import io.snyk.plugin.snykcode.getSeverityAsEnum
+import io.snyk.plugin.getSeverityAsEnum
 import snyk.ItlyOverrideHelper
 import snyk.advisor.AdvisorPackageManager
 import snyk.analytics.AnalysisIsReady.AnalysisType

--- a/src/main/kotlin/io/snyk/plugin/events/SnykScanListener.kt
+++ b/src/main/kotlin/io/snyk/plugin/events/SnykScanListener.kt
@@ -1,7 +1,7 @@
 package io.snyk.plugin.events
 
 import com.intellij.util.messages.Topic
-import io.snyk.plugin.snykcode.SnykCodeResults
+import io.snyk.plugin.SnykResults
 import snyk.common.SnykError
 import snyk.container.ContainerResult
 import snyk.iac.IacResult
@@ -17,7 +17,7 @@ interface SnykScanListener {
 
     fun scanningOssFinished(ossResult: OssResult)
 
-    fun scanningSnykCodeFinished(snykCodeResults: SnykCodeResults?)
+    fun scanningSnykCodeFinished(snykResults: SnykResults?)
 
     fun scanningIacFinished(iacResult: IacResult)
 

--- a/src/main/kotlin/io/snyk/plugin/events/SnykScanListenerLS.kt
+++ b/src/main/kotlin/io/snyk/plugin/events/SnykScanListenerLS.kt
@@ -1,19 +1,19 @@
 package io.snyk.plugin.events
 
 import com.intellij.util.messages.Topic
-import io.snyk.plugin.snykcode.core.SnykCodeFile
+import io.snyk.plugin.SnykFile
 import snyk.common.lsp.ScanIssue
 import snyk.common.lsp.SnykScanParams
 
-interface SnykCodeScanListenerLS {
+interface SnykScanListenerLS {
     companion object {
         val SNYK_SCAN_TOPIC =
-            Topic.create("Snyk scan LS", SnykCodeScanListenerLS::class.java)
+            Topic.create("Snyk scan LS", SnykScanListenerLS::class.java)
     }
 
     fun scanningStarted(snykScan: SnykScanParams) {}
 
-    fun scanningSnykCodeFinished(snykCodeResults: Map<SnykCodeFile, List<ScanIssue>>)
+    fun scanningSnykCodeFinished(snykResults: Map<SnykFile, List<ScanIssue>>)
 
     fun scanningSnykCodeError(snykScan: SnykScanParams)
 }

--- a/src/main/kotlin/io/snyk/plugin/services/SnykAnalyticsService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykAnalyticsService.kt
@@ -9,7 +9,7 @@ import io.snyk.plugin.analytics.Iteratively
 import io.snyk.plugin.events.SnykScanListener
 import io.snyk.plugin.getSnykApiService
 import io.snyk.plugin.pluginSettings
-import io.snyk.plugin.snykcode.SnykCodeResults
+import io.snyk.plugin.SnykResults
 import snyk.analytics.AnalysisIsReady
 import snyk.analytics.AnalysisIsTriggered
 import snyk.analytics.AuthenticateButtonIsClicked
@@ -57,7 +57,7 @@ class SnykAnalyticsService : Disposable {
                 )
             }
 
-            override fun scanningSnykCodeFinished(snykCodeResults: SnykCodeResults?) {
+            override fun scanningSnykCodeFinished(snykResults: SnykResults?) {
                 logSnykCodeAnalysisIsReady(AnalysisIsReady.Result.SUCCESS)
             }
 

--- a/src/main/kotlin/io/snyk/plugin/snykcode/SnykCodeBulkFileListener.kt
+++ b/src/main/kotlin/io/snyk/plugin/snykcode/SnykCodeBulkFileListener.kt
@@ -17,7 +17,7 @@ import io.snyk.plugin.isSnykCodeLSEnabled
 import io.snyk.plugin.snykcode.core.AnalysisData
 import io.snyk.plugin.snykcode.core.PDU
 import io.snyk.plugin.snykcode.core.RunUtils
-import io.snyk.plugin.snykcode.core.SnykCodeFile
+import io.snyk.plugin.SnykFile
 import io.snyk.plugin.snykcode.core.SnykCodeIgnoreInfoHolder
 import io.snyk.plugin.snykcode.core.SnykCodeUtils
 import io.snyk.plugin.toLanguageServerURL
@@ -27,7 +27,7 @@ import snyk.common.lsp.LanguageServerWrapper
 
 class SnykCodeBulkFileListener : SnykBulkFileListener() {
     override fun before(project: Project, virtualFilesAffected: Set<VirtualFile>) {
-        val filesAffected = toSnykCodeFileSet(
+        val filesAffected = toSnykFileSet(
             project,
             virtualFilesAffected
         )
@@ -69,7 +69,7 @@ class SnykCodeBulkFileListener : SnykBulkFileListener() {
     }
 
     override fun after(project: Project, virtualFilesAffected: Set<VirtualFile>) {
-        val filesAffected = toSnykCodeFileSet(project, virtualFilesAffected)
+        val filesAffected = toSnykFileSet(project, virtualFilesAffected)
 
         if (isSnykCodeLSEnabled()) {
             updateCacheAndUI(filesAffected, project)
@@ -102,7 +102,7 @@ class SnykCodeBulkFileListener : SnykBulkFileListener() {
         }
     }
 
-    private fun updateCacheAndUI(filesAffected: Set<SnykCodeFile>, project: Project) {
+    private fun updateCacheAndUI(filesAffected: Set<SnykFile>, project: Project) {
         val cache = getSnykCachedResults(project)?.currentSnykCodeResultsLS ?: return
         filesAffected.forEach {
             cache.remove(it)
@@ -111,6 +111,6 @@ class SnykCodeBulkFileListener : SnykBulkFileListener() {
         DaemonCodeAnalyzer.getInstance(project).restart()
     }
 
-    private fun toSnykCodeFileSet(project: Project, virtualFiles: Set<VirtualFile>) =
-        virtualFiles.map { SnykCodeFile(project, it) }.toSet()
+    private fun toSnykFileSet(project: Project, virtualFiles: Set<VirtualFile>) =
+        virtualFiles.map { SnykFile(project, it) }.toSet()
 }

--- a/src/main/kotlin/io/snyk/plugin/snykcode/core/HashContentUtils.kt
+++ b/src/main/kotlin/io/snyk/plugin/snykcode/core/HashContentUtils.kt
@@ -2,12 +2,13 @@ package io.snyk.plugin.snykcode.core
 
 import ai.deepcode.javaclient.core.HashContentUtilsBase
 import com.intellij.openapi.util.Computable
+import io.snyk.plugin.SnykFile
 
 class HashContentUtils private constructor() : HashContentUtilsBase(
     PDU.instance
 ) {
     override fun doGetFileContent(file: Any): String {
-        require(file is SnykCodeFile) { "File $file must be of type SnykCodeFile but is ${file.javaClass.name}" }
+        require(file is SnykFile) { "File $file must be of type SnykCodeFile but is ${file.javaClass.name}" }
         return RunUtils.computeInReadActionInSmartMode(
             file.project,
             Computable {

--- a/src/main/kotlin/io/snyk/plugin/snykcode/core/PDU.kt
+++ b/src/main/kotlin/io/snyk/plugin/snykcode/core/PDU.kt
@@ -14,6 +14,7 @@ import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
+import io.snyk.plugin.SnykFile
 import io.snyk.plugin.events.SnykScanListener
 import io.snyk.plugin.getSnykToolWindowPanel
 import io.snyk.plugin.getSyncPublisher
@@ -61,7 +62,7 @@ class PDU private constructor() : PlatformDependentUtilsBase() {
             SCLogger.instance.logWarn("VirtualFile not found for: $absolutePath or $path")
             return null
         }
-        return SnykCodeFile(prj, virtualFile)
+        return SnykFile(prj, virtualFile)
     }
 
     override fun getOpenProjects(): Array<Any> = ProjectManager.getInstance().openProjects.toList().toTypedArray()
@@ -198,8 +199,8 @@ class PDU private constructor() : PlatformDependentUtilsBase() {
 
         fun toVirtualFile(file: Any): VirtualFile = toSnykCodeFile(file).virtualFile
 
-        fun toSnykCodeFile(file: Any): SnykCodeFile {
-            require(file is SnykCodeFile) { "File $file must be of type SnykCodeFile but is ${file.javaClass.name}" }
+        fun toSnykCodeFile(file: Any): SnykFile {
+            require(file is SnykFile) { "File $file must be of type SnykCodeFile but is ${file.javaClass.name}" }
             return file
         }
 

--- a/src/main/kotlin/io/snyk/plugin/snykcode/core/RunUtils.kt
+++ b/src/main/kotlin/io/snyk/plugin/snykcode/core/RunUtils.kt
@@ -10,7 +10,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Computable
 import io.snyk.plugin.events.SnykScanListener
 import io.snyk.plugin.getSyncPublisher
-import io.snyk.plugin.snykcode.SnykCodeResults
+import io.snyk.plugin.SnykResults
 import java.util.function.Consumer
 
 class RunUtils private constructor() : RunUtilsBase(
@@ -57,10 +57,10 @@ class RunUtils private constructor() : RunUtilsBase(
     override fun updateAnalysisResultsUIPresentation(projectAsAny: Any, files: Collection<Any>) {
         val project = PDU.toProject(projectAsAny)
         if (project.isDisposed) return
-        val scanResults: SnykCodeResults? = when {
+        val scanResults: SnykResults? = when {
             ProgressManager.getInstance().progressIndicator?.isCanceled == true -> null
-            files.isEmpty() -> SnykCodeResults()
-            else -> SnykCodeResults(
+            files.isEmpty() -> SnykResults()
+            else -> SnykResults(
                 AnalysisData.instance.getAnalysis(files).mapKeys { PDU.toSnykCodeFile(it.key) }
             )
         }

--- a/src/main/kotlin/io/snyk/plugin/snykcode/core/SnykCodeIgnoreInfoHolder.kt
+++ b/src/main/kotlin/io/snyk/plugin/snykcode/core/SnykCodeIgnoreInfoHolder.kt
@@ -2,6 +2,7 @@ package io.snyk.plugin.snykcode.core
 
 import ai.deepcode.javaclient.core.DeepCodeIgnoreInfoHolderBase
 import com.intellij.openapi.project.Project
+import io.snyk.plugin.SnykFile
 import io.snyk.plugin.getSnykTaskQueueService
 import io.snyk.plugin.ui.SnykBalloonNotificationHelper
 import java.io.File
@@ -12,7 +13,7 @@ class SnykCodeIgnoreInfoHolder private constructor() : DeepCodeIgnoreInfoHolderB
     SCLogger.instance
 ) {
 
-    fun cleanIgnoreFileCachesIfAffected(filesToCheck: Collection<SnykCodeFile>) {
+    fun cleanIgnoreFileCachesIfAffected(filesToCheck: Collection<SnykFile>) {
         val ignoreFilesChanged = getIgnoreFiles(filesToCheck)
         for (ignoreFile in ignoreFilesChanged) {
             remove_ignoreFileContent(ignoreFile)
@@ -20,7 +21,7 @@ class SnykCodeIgnoreInfoHolder private constructor() : DeepCodeIgnoreInfoHolderB
         }
     }
 
-    fun updateIgnoreFileCachesIfAffected(filesToCheck: Collection<SnykCodeFile>) {
+    fun updateIgnoreFileCachesIfAffected(filesToCheck: Collection<SnykFile>) {
         val ignoreFilesChanged = getIgnoreFiles(filesToCheck)
         for (ignoreFile in ignoreFilesChanged) {
             getSnykTaskQueueService(ignoreFile.project)
@@ -53,7 +54,7 @@ class SnykCodeIgnoreInfoHolder private constructor() : DeepCodeIgnoreInfoHolderB
         }
     }
 
-    private fun getIgnoreFiles(filesToCheck: Collection<SnykCodeFile>) =
+    private fun getIgnoreFiles(filesToCheck: Collection<SnykFile>) =
         filesToCheck
             .filter { it.virtualFile.name == ".dcignore" || it.virtualFile.name == ".gitignore" }
             .filter { it.virtualFile.isValid }

--- a/src/main/kotlin/io/snyk/plugin/snykcode/core/SnykCodeUtils.kt
+++ b/src/main/kotlin/io/snyk/plugin/snykcode/core/SnykCodeUtils.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.vcs.changes.ChangeListManager
+import io.snyk.plugin.SnykFile
 import io.snyk.plugin.snykcode.newCodeRestApi
 
 class SnykCodeUtils private constructor() : DeepCodeUtilsBase(
@@ -23,11 +24,11 @@ class SnykCodeUtils private constructor() : DeepCodeUtilsBase(
         scLogger.logInfo("allProjectFiles requested")
         val project = PDU.toProject(projectO)
         val progressIndicator = ProgressManager.getInstance().progressIndicator ?: null
-        val files = mutableSetOf<SnykCodeFile>()
+        val files = mutableSetOf<SnykFile>()
 
         val cancelled = !ProjectRootManager.getInstance(project).fileIndex.iterateContent {
             if (!it.isDirectory) {
-                files.add(SnykCodeFile(project, it))
+                files.add(SnykFile(project, it))
             }
             return@iterateContent progressIndicator?.isCanceled != true
         }

--- a/src/main/kotlin/io/snyk/plugin/ui/jcef/OpenFileLoadHandlerGenerator.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/jcef/OpenFileLoadHandlerGenerator.kt
@@ -9,15 +9,15 @@ import com.intellij.ui.jcef.JBCefJSQuery
 import com.intellij.util.ui.UIUtil
 import io.snyk.plugin.getDocument
 import io.snyk.plugin.navigateToSource
-import io.snyk.plugin.snykcode.core.SnykCodeFile
+import io.snyk.plugin.SnykFile
 import org.cef.browser.CefBrowser
 import org.cef.browser.CefFrame
 import org.cef.handler.CefLoadHandlerAdapter
 import java.awt.Color
 
-class OpenFileLoadHandlerGenerator(snykCodeFile: SnykCodeFile) {
-    private val project = snykCodeFile.project
-    private val virtualFile = snykCodeFile.virtualFile
+class OpenFileLoadHandlerGenerator(snykFile: SnykFile) {
+    private val project = snykFile.project
+    private val virtualFile = snykFile.virtualFile
 
     fun openFile(value: String): JBCefJSQuery.Response {
         val values = value.replace("\n", "").split(":")

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindow.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindow.kt
@@ -16,7 +16,7 @@ import com.intellij.ui.PopupHandler
 import io.snyk.plugin.events.SnykScanListener
 import io.snyk.plugin.events.SnykTaskQueueListener
 import io.snyk.plugin.getSnykToolWindowPanel
-import io.snyk.plugin.snykcode.SnykCodeResults
+import io.snyk.plugin.SnykResults
 import io.snyk.plugin.ui.expandTreeNodeRecursively
 import snyk.common.SnykError
 import snyk.container.ContainerResult
@@ -72,7 +72,7 @@ class SnykToolWindow(private val project: Project) : SimpleToolWindowPanel(false
 
                 override fun scanningOssFinished(ossResult: OssResult) = updateActionsPresentation()
 
-                override fun scanningSnykCodeFinished(snykCodeResults: SnykCodeResults?) = updateActionsPresentation()
+                override fun scanningSnykCodeFinished(snykResults: SnykResults?) = updateActionsPresentation()
 
                 override fun scanningIacFinished(iacResult: IacResult) = updateActionsPresentation()
 

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykTreeCellRenderer.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykTreeCellRenderer.kt
@@ -9,8 +9,8 @@ import icons.SnykIcons
 import io.snyk.plugin.getSnykCachedResults
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.snykcode.core.AnalysisData
-import io.snyk.plugin.snykcode.core.SnykCodeFile
-import io.snyk.plugin.snykcode.getSeverityAsEnum
+import io.snyk.plugin.SnykFile
+import io.snyk.plugin.getSeverityAsEnum
 import io.snyk.plugin.ui.PackageManagerIconProvider.Companion.getIcon
 import io.snyk.plugin.ui.getDisabledIcon
 import io.snyk.plugin.ui.snykCodeAvailabilityPostfix
@@ -25,7 +25,7 @@ import io.snyk.plugin.ui.toolwindow.nodes.root.RootSecurityIssuesTreeNode
 import io.snyk.plugin.ui.toolwindow.nodes.secondlevel.ErrorTreeNode
 import io.snyk.plugin.ui.toolwindow.nodes.secondlevel.FileTreeNode
 import io.snyk.plugin.ui.toolwindow.nodes.secondlevel.SnykCodeFileTreeNode
-import io.snyk.plugin.ui.toolwindow.nodes.secondlevel.SnykCodeFileTreeNodeFromLS
+import io.snyk.plugin.ui.toolwindow.nodes.secondlevel.SnykFileTreeNodeFromLS
 import snyk.common.ProductType
 import snyk.common.SnykError
 import snyk.common.lsp.ScanIssue
@@ -100,7 +100,7 @@ class SnykTreeCellRenderer : ColoredTreeCellRenderer() {
                     if (suggestion.title.isNullOrEmpty()) suggestion.message else suggestion.title
                 }"
                 val parentFileNode = value.parent as SnykCodeFileTreeNode
-                val file = (parentFileNode.userObject as Pair<SnykCodeFile, ProductType>).first
+                val file = (parentFileNode.userObject as Pair<SnykFile, ProductType>).first
                 if (!AnalysisData.instance.isFileInCache(file)) {
                     attributes = SimpleTextAttributes.GRAYED_ATTRIBUTES
                     nodeIcon = getDisabledIcon(nodeIcon)
@@ -125,9 +125,9 @@ class SnykTreeCellRenderer : ColoredTreeCellRenderer() {
                         issue.additionalData.message.split('.')[0]
                     }
                 } [${range.start.line + 1},${range.start.character}]"
-                val parentFileNode = value.parent as SnykCodeFileTreeNodeFromLS
+                val parentFileNode = value.parent as SnykFileTreeNodeFromLS
                 val entry =
-                    (parentFileNode.userObject as Pair<Map.Entry<SnykCodeFile, List<ScanIssue>>, ProductType>).first
+                    (parentFileNode.userObject as Pair<Map.Entry<SnykFile, List<ScanIssue>>, ProductType>).first
                 val cachedIssues = getSnykCachedResults(entry.key.project)?.currentSnykCodeResultsLS
                 if (cachedIssues?.values?.flatten()?.contains(issue) == false) {
                     attributes = SimpleTextAttributes.GRAYED_ATTRIBUTES
@@ -135,9 +135,9 @@ class SnykTreeCellRenderer : ColoredTreeCellRenderer() {
                 }
             }
 
-            is SnykCodeFileTreeNodeFromLS -> {
+            is SnykFileTreeNodeFromLS -> {
                 val (entry, productType) =
-                    value.userObject as Pair<Map.Entry<SnykCodeFile, List<ScanIssue>>, ProductType>
+                    value.userObject as Pair<Map.Entry<SnykFile, List<ScanIssue>>, ProductType>
                 val file = entry.key
 
                 val pair = updateTextTooltipAndIcon(file, productType, value)
@@ -152,7 +152,7 @@ class SnykTreeCellRenderer : ColoredTreeCellRenderer() {
             }
 
             is SnykCodeFileTreeNode -> {
-                val (file, productType) = value.userObject as Pair<SnykCodeFile, ProductType>
+                val (file, productType) = value.userObject as Pair<SnykFile, ProductType>
                 val (icon, nodeText) = updateTextTooltipAndIcon(file, productType, value)
                 nodeIcon = icon
                 text = nodeText
@@ -329,7 +329,7 @@ class SnykTreeCellRenderer : ColoredTreeCellRenderer() {
     }
 
     private fun updateTextTooltipAndIcon(
-        file: SnykCodeFile,
+        file: SnykFile,
         productType: ProductType,
         value: DefaultMutableTreeNode
     ): Pair<Icon?, String?> {

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/nodes/leaf/SuggestionTreeNode.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/nodes/leaf/SuggestionTreeNode.kt
@@ -4,7 +4,7 @@ import ai.deepcode.javaclient.core.SuggestionForFile
 import io.snyk.plugin.analytics.getIssueSeverityOrNull
 import io.snyk.plugin.analytics.getIssueType
 import io.snyk.plugin.getSnykAnalyticsService
-import io.snyk.plugin.snykcode.core.SnykCodeFile
+import io.snyk.plugin.SnykFile
 import io.snyk.plugin.ui.toolwindow.nodes.DescriptionHolderTreeNode
 import io.snyk.plugin.ui.toolwindow.nodes.NavigatableToSourceTreeNode
 import io.snyk.plugin.ui.toolwindow.nodes.secondlevel.SnykCodeFileTreeNode
@@ -32,7 +32,7 @@ class SuggestionTreeNode(
         )
         val snykCodeFileTreeNode = this.parent as? SnykCodeFileTreeNode
             ?: throw IllegalArgumentException(this.toString())
-        val snykCodeFile = (snykCodeFileTreeNode.userObject as Pair<SnykCodeFile, ProductType>).first
-        return SuggestionDescriptionPanel(snykCodeFile, suggestion, rangeIndex)
+        val snykFile = (snykCodeFileTreeNode.userObject as Pair<SnykFile, ProductType>).first
+        return SuggestionDescriptionPanel(snykFile, suggestion, rangeIndex)
     }
 }

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/nodes/leaf/SuggestionTreeNodeFromLS.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/nodes/leaf/SuggestionTreeNodeFromLS.kt
@@ -1,10 +1,10 @@
 package io.snyk.plugin.ui.toolwindow.nodes.leaf
 
 import io.snyk.plugin.getSnykAnalyticsService
-import io.snyk.plugin.snykcode.core.SnykCodeFile
+import io.snyk.plugin.SnykFile
 import io.snyk.plugin.ui.toolwindow.nodes.DescriptionHolderTreeNode
 import io.snyk.plugin.ui.toolwindow.nodes.NavigatableToSourceTreeNode
-import io.snyk.plugin.ui.toolwindow.nodes.secondlevel.SnykCodeFileTreeNodeFromLS
+import io.snyk.plugin.ui.toolwindow.nodes.secondlevel.SnykFileTreeNodeFromLS
 import io.snyk.plugin.ui.toolwindow.panels.IssueDescriptionPanelBase
 import io.snyk.plugin.ui.toolwindow.panels.SuggestionDescriptionPanelFromLS
 import snyk.analytics.IssueInTreeIsClicked.Ide
@@ -47,12 +47,12 @@ class SuggestionTreeNodeFromLS(
                     .build()
             )
         }
-        val snykCodeFileTreeNode = this.parent as? SnykCodeFileTreeNodeFromLS
+        val snykCodeFileTreeNode = this.parent as? SnykFileTreeNodeFromLS
             ?: throw IllegalArgumentException(this.toString())
 
         @Suppress("UNCHECKED_CAST")
         val entry =
-            (snykCodeFileTreeNode.userObject as Pair<Map.Entry<SnykCodeFile, List<ScanIssue>>, ProductType>).first
+            (snykCodeFileTreeNode.userObject as Pair<Map.Entry<SnykFile, List<ScanIssue>>, ProductType>).first
         val snykCodeFile = entry.key
         return SuggestionDescriptionPanelFromLS(snykCodeFile, issue)
     }

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/nodes/secondlevel/SnykCodeFileTreeNode.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/nodes/secondlevel/SnykCodeFileTreeNode.kt
@@ -1,10 +1,10 @@
 package io.snyk.plugin.ui.toolwindow.nodes.secondlevel
 
-import io.snyk.plugin.snykcode.core.SnykCodeFile
+import io.snyk.plugin.SnykFile
 import snyk.common.ProductType
 import javax.swing.tree.DefaultMutableTreeNode
 
 class SnykCodeFileTreeNode(
-    file: SnykCodeFile,
+    file: SnykFile,
     productType: ProductType
 ) : DefaultMutableTreeNode(Pair(file, productType))

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/nodes/secondlevel/SnykFileTreeNodeFromLS.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/nodes/secondlevel/SnykFileTreeNodeFromLS.kt
@@ -1,11 +1,11 @@
 package io.snyk.plugin.ui.toolwindow.nodes.secondlevel
 
-import io.snyk.plugin.snykcode.core.SnykCodeFile
+import io.snyk.plugin.SnykFile
 import snyk.common.ProductType
 import snyk.common.lsp.ScanIssue
 import javax.swing.tree.DefaultMutableTreeNode
 
-class SnykCodeFileTreeNodeFromLS(
-    file: Map.Entry<SnykCodeFile, List<ScanIssue>>,
+class SnykFileTreeNodeFromLS(
+    file: Map.Entry<SnykFile, List<ScanIssue>>,
     productType: ProductType
 ) : DefaultMutableTreeNode(Pair(file, productType))

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/SuggestionDescriptionPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/SuggestionDescriptionPanel.kt
@@ -14,8 +14,8 @@ import com.intellij.util.ui.JBInsets
 import com.intellij.util.ui.UIUtil
 import io.snyk.plugin.navigateToSource
 import io.snyk.plugin.snykcode.core.PDU
-import io.snyk.plugin.snykcode.core.SnykCodeFile
-import io.snyk.plugin.snykcode.getSeverityAsEnum
+import io.snyk.plugin.SnykFile
+import io.snyk.plugin.getSeverityAsEnum
 import io.snyk.plugin.ui.DescriptionHeaderPanel
 import io.snyk.plugin.ui.baseGridConstraintsAnchorWest
 import io.snyk.plugin.ui.descriptionHeaderPanel
@@ -34,14 +34,14 @@ import kotlin.math.max
 import kotlin.math.min
 
 class SuggestionDescriptionPanel(
-    private val snykCodeFile: SnykCodeFile,
+    private val snykFile: SnykFile,
     private val suggestion: SuggestionForFile,
     private val suggestionIndex: Int
 ) : IssueDescriptionPanelBase(
     title = suggestion.title,
     severity = suggestion.getSeverityAsEnum()
 ) {
-    val project = snykCodeFile.project
+    val project = snykFile.project
 
     private val suggestionRange: MyTextRange? = suggestion.ranges?.getOrNull(suggestionIndex)
 
@@ -82,7 +82,7 @@ class SuggestionDescriptionPanel(
         return panel
     }
 
-    private fun codeLine(range: MyTextRange, file: SnykCodeFile?): JTextArea {
+    private fun codeLine(range: MyTextRange, file: SnykFile?): JTextArea {
         val component = JTextArea(getLineOfCode(range, file))
         component.font = io.snyk.plugin.ui.getFont(-1, 14, component.font)
         component.isEditable = false
@@ -116,7 +116,7 @@ class SuggestionDescriptionPanel(
         }
     }
 
-    private fun getLineOfCode(range: MyTextRange, file: SnykCodeFile?): String {
+    private fun getLineOfCode(range: MyTextRange, file: SnykFile?): String {
         if (file == null) return "<File Not Found>"
         val document = PDU.toPsiFile(file)?.let { PsiDocumentManager.getInstance(file.project).getDocument(it) }
             ?: return "<No Document Found>"
@@ -180,7 +180,7 @@ class SuggestionDescriptionPanel(
             val stepPanel = stepPanel(
                 index = index,
                 markerRange = markerRange,
-                maxFilenameLength = max(snykCodeFile.virtualFile.name.length, maxFilenameLength),
+                maxFilenameLength = max(snykFile.virtualFile.name.length, maxFilenameLength),
                 allStepPanels = allStepPanels
             )
 
@@ -210,7 +210,7 @@ class SuggestionDescriptionPanel(
 
         val paddedStepNumber = (index + 1).toString().padStart(2, ' ')
 
-        val fileName = snykCodeFile.virtualFile.name
+        val fileName = snykFile.virtualFile.name
 
         val positionLinkText = "$fileName:${markerRange.startRow}".padEnd(maxFilenameLength + 5, ' ')
 
@@ -221,9 +221,9 @@ class SuggestionDescriptionPanel(
             toolTipText = "Click to show in the Editor",
             customFont = JTextArea().font
         ) {
-            if (!snykCodeFile.virtualFile.isValid) return@linkLabel
+            if (!snykFile.virtualFile.isValid) return@linkLabel
 
-            navigateToSource(project, snykCodeFile.virtualFile, markerRange.start, markerRange.end)
+            navigateToSource(project, snykFile.virtualFile, markerRange.start, markerRange.end)
 
             allStepPanels.forEach {
                 it.background = UIUtil.getTextFieldBackground()
@@ -232,7 +232,7 @@ class SuggestionDescriptionPanel(
         }
         stepPanel.add(positionLabel, baseGridConstraintsAnchorWest(0, indent = 1))
 
-        val codeLine = codeLine(markerRange, snykCodeFile)
+        val codeLine = codeLine(markerRange, snykFile)
         codeLine.isOpaque = false
         stepPanel.add(
             codeLine,

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/SuggestionDescriptionPanelFromLS.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/SuggestionDescriptionPanelFromLS.kt
@@ -12,7 +12,7 @@ import com.intellij.util.ui.UIUtil
 import io.snyk.plugin.getDocument
 import io.snyk.plugin.navigateToSource
 import io.snyk.plugin.pluginSettings
-import io.snyk.plugin.snykcode.core.SnykCodeFile
+import io.snyk.plugin.SnykFile
 import io.snyk.plugin.toVirtualFile
 import io.snyk.plugin.ui.DescriptionHeaderPanel
 import io.snyk.plugin.ui.SnykBalloonNotificationHelper
@@ -38,19 +38,19 @@ import javax.swing.event.HyperlinkEvent
 import kotlin.math.max
 
 class SuggestionDescriptionPanelFromLS(
-    snykCodeFile: SnykCodeFile,
+    snykFile: SnykFile,
     private val issue: ScanIssue
 ) : IssueDescriptionPanelBase(
     title = getIssueTitle(issue),
     severity = issue.getSeverityAsEnum()
 ) {
-    val project = snykCodeFile.project
+    val project = snykFile.project
     private val unexpectedErrorMessage =
         "Snyk encountered an issue while rendering the vulnerability description. Please try again, or contact support if the problem persists. We apologize for any inconvenience caused."
 
     init {
         if (pluginSettings().isGlobalIgnoresFeatureEnabled && issue.additionalData.details != null) {
-            val openFileLoadHandlerGenerator = OpenFileLoadHandlerGenerator(snykCodeFile)
+            val openFileLoadHandlerGenerator = OpenFileLoadHandlerGenerator(snykFile)
             val jbCefBrowserComponent = JCEFUtils.getJBCefBrowserComponentIfSupported(issue.additionalData.details) {
                 openFileLoadHandlerGenerator.generate(it)
             }

--- a/src/main/kotlin/snyk/code/annotator/SnykCodeAnnotator.kt
+++ b/src/main/kotlin/snyk/code/annotator/SnykCodeAnnotator.kt
@@ -10,8 +10,8 @@ import com.intellij.psi.PsiFile
 import io.snyk.plugin.Severity
 import io.snyk.plugin.isSnykCodeLSEnabled
 import io.snyk.plugin.snykcode.core.AnalysisData
-import io.snyk.plugin.snykcode.core.SnykCodeFile
-import io.snyk.plugin.snykcode.getSeverityAsEnum
+import io.snyk.plugin.SnykFile
+import io.snyk.plugin.getSeverityAsEnum
 import io.snyk.plugin.ui.toolwindow.SnykToolWindowPanel
 import snyk.common.AnnotatorCommon
 import snyk.common.intentionactions.ShowDetailsIntentionActionBase
@@ -46,7 +46,7 @@ class SnykCodeAnnotator : ExternalAnnotator<PsiFile, Unit>() {
     }
 
     private fun getIssuesForFile(psiFile: PsiFile): List<SuggestionForFile> =
-        AnalysisData.instance.getAnalysis(SnykCodeFile(psiFile.project, psiFile.virtualFile))
+        AnalysisData.instance.getAnalysis(SnykFile(psiFile.project, psiFile.virtualFile))
 
     /** Public for Tests only */
     fun annotationMessage(suggestion: SuggestionForFile): String =

--- a/src/test/kotlin/io/snyk/plugin/core/IgnoreInfoHolderPlatformTestCase.kt
+++ b/src/test/kotlin/io/snyk/plugin/core/IgnoreInfoHolderPlatformTestCase.kt
@@ -11,7 +11,7 @@ import com.intellij.testFramework.HeavyPlatformTestCase
 import com.intellij.testFramework.PlatformTestUtil
 import io.snyk.plugin.getSnykCode
 import io.snyk.plugin.resetSettings
-import io.snyk.plugin.snykcode.core.SnykCodeFile
+import io.snyk.plugin.SnykFile
 import io.snyk.plugin.snykcode.core.SnykCodeIgnoreInfoHolder
 import io.snyk.plugin.snykcode.core.SnykCodeUtils
 import org.awaitility.Awaitility.await
@@ -114,7 +114,7 @@ class IgnoreInfoHolderPlatformTestCase : HeavyPlatformTestCase() {
         )
     }
 
-    private fun setUpTest(): SnykCodeFile {
+    private fun setUpTest(): SnykFile {
         val filePathToCheck = project.basePath + "/node_modules/1.js"
         File(filePathToCheck).parentFile.mkdirs() &&
             File(filePathToCheck).createNewFile() ||
@@ -125,8 +125,8 @@ class IgnoreInfoHolderPlatformTestCase : HeavyPlatformTestCase() {
         return fileToCheck
     }
 
-    private fun findFile(project: Project, path: String): SnykCodeFile {
+    private fun findFile(project: Project, path: String): SnykFile {
         val file = StandardFileSystems.local().refreshAndFindFileByPath(path) ?: throw FileNotFoundException(path)
-        return SnykCodeFile(project, file)
+        return SnykFile(project, file)
     }
 }

--- a/src/test/kotlin/io/snyk/plugin/core/PDUTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/core/PDUTest.kt
@@ -5,7 +5,7 @@ import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.testFramework.LightPlatformTestCase
 import com.intellij.testFramework.PlatformTestUtil
 import io.snyk.plugin.snykcode.core.PDU
-import io.snyk.plugin.snykcode.core.SnykCodeFile
+import io.snyk.plugin.SnykFile
 import java.io.File
 
 @Suppress("FunctionName")
@@ -17,14 +17,14 @@ class PDUTest : LightPlatformTestCase() {
         try {
             val virtualFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(testFilePath)
                 ?: throw IllegalStateException("Didn't find virtualfile for $testFilePath")
-            val snykCodeFile = SnykCodeFile(project, virtualFile)
+            val snykFile = SnykFile(project, virtualFile)
 
             val expected = testFilePath.removePrefix("/")
-            val actual = PDU.instance.getDeepCodedFilePath(snykCodeFile).removePrefix("/")
+            val actual = PDU.instance.getDeepCodedFilePath(snykFile).removePrefix("/")
             assertEquals(expected, actual)
 
             assertEquals(
-                snykCodeFile, PDU.instance.getFileByDeepcodedPath(testFilePath, project)
+                snykFile, PDU.instance.getFileByDeepcodedPath(testFilePath, project)
             )
         } finally {
             testFile.delete()

--- a/src/test/kotlin/io/snyk/plugin/ui/jcef/OpenFileLoadHandlerGeneratorTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/jcef/OpenFileLoadHandlerGeneratorTest.kt
@@ -6,7 +6,7 @@ import com.intellij.psi.PsiFile
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import io.mockk.unmockkAll
 import io.snyk.plugin.resetSettings
-import io.snyk.plugin.snykcode.core.SnykCodeFile
+import io.snyk.plugin.SnykFile
 import org.junit.Test
 import snyk.code.annotator.SnykCodeAnnotator
 import java.nio.file.Paths
@@ -16,7 +16,7 @@ class OpenFileLoadHandlerGeneratorTest : BasePlatformTestCase(){
     private val fileName = "app.js"
     private lateinit var file: VirtualFile
     private lateinit var psiFile: PsiFile
-    private lateinit var snykCodeFile: SnykCodeFile
+    private lateinit var snykFile: SnykFile
 
     override fun getTestDataPath(): String {
         val resource = SnykCodeAnnotator::class.java.getResource("/test-fixtures/code/annotator")
@@ -31,9 +31,9 @@ class OpenFileLoadHandlerGeneratorTest : BasePlatformTestCase(){
 
         file = myFixture.copyFileToProject(fileName)
         psiFile = WriteAction.computeAndWait<PsiFile, Throwable> { psiManager.findFile(file)!! }
-        snykCodeFile = SnykCodeFile(psiFile.project, psiFile.virtualFile)
+        snykFile = SnykFile(psiFile.project, psiFile.virtualFile)
 
-        generator = OpenFileLoadHandlerGenerator(snykCodeFile)
+        generator = OpenFileLoadHandlerGenerator(snykFile)
     }
 
     @Test

--- a/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanelIntegTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanelIntegTest.kt
@@ -34,8 +34,8 @@ import io.snyk.plugin.removeDummyCliFile
 import io.snyk.plugin.resetSettings
 import io.snyk.plugin.services.SnykTaskQueueService
 import io.snyk.plugin.setupDummyCliFile
-import io.snyk.plugin.snykcode.SnykCodeResults
-import io.snyk.plugin.snykcode.core.SnykCodeFile
+import io.snyk.plugin.SnykResults
+import io.snyk.plugin.SnykFile
 import io.snyk.plugin.ui.SnykBalloonNotificationHelper
 import io.snyk.plugin.ui.actions.SnykTreeMediumSeverityFilterAction
 import io.snyk.plugin.ui.toolwindow.nodes.leaf.SuggestionTreeNode
@@ -183,10 +183,10 @@ class SnykToolWindowPanelIntegTest : HeavyPlatformTestCase() {
 
     private fun prepareTreeWithFakeCodeResults() {
         val virtualFile = super.createTempVirtualFile("test.js", null, "test", Charset.defaultCharset())
-        val codeResults = SnykCodeResults(
+        val codeResults = SnykResults(
             mapOf(
                 Pair(
-                    SnykCodeFile(project, virtualFile),
+                    SnykFile(project, virtualFile),
                     listOf(fakeSuggestionForFile)
                 )
             )

--- a/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SuggestionDescriptionPanelFromLSTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SuggestionDescriptionPanelFromLSTest.kt
@@ -12,7 +12,7 @@ import io.mockk.unmockkAll
 import io.snyk.plugin.Severity
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.resetSettings
-import io.snyk.plugin.snykcode.core.SnykCodeFile
+import io.snyk.plugin.SnykFile
 import io.snyk.plugin.ui.jcef.JCEFUtils
 import io.snyk.plugin.ui.toolwindow.panels.SuggestionDescriptionPanelFromLS
 import org.eclipse.lsp4j.Position
@@ -32,7 +32,7 @@ import javax.swing.JLabel
 class SuggestionDescriptionPanelFromLSTest : BasePlatformTestCase() {
     private lateinit var cut: SuggestionDescriptionPanelFromLS
     private val fileName = "app.js"
-    private lateinit var snykCodeFile: SnykCodeFile
+    private lateinit var snykFile: SnykFile
     private lateinit var issue: ScanIssue
 
     private lateinit var file: VirtualFile
@@ -52,7 +52,7 @@ class SuggestionDescriptionPanelFromLSTest : BasePlatformTestCase() {
 
         file = myFixture.copyFileToProject(fileName)
         psiFile = WriteAction.computeAndWait<PsiFile, Throwable> { psiManager.findFile(file)!! }
-        snykCodeFile = SnykCodeFile(psiFile.project, psiFile.virtualFile)
+        snykFile = SnykFile(psiFile.project, psiFile.virtualFile)
 
         issue = mockk<ScanIssue>()
         every { issue.additionalData.message } returns "Test message"
@@ -71,7 +71,7 @@ class SuggestionDescriptionPanelFromLSTest : BasePlatformTestCase() {
     fun `test createUI should build panel with issue message as overview label if the feature flag is not enabled`() {
         every { issue.additionalData.details } returns "<html>HTML message</html>"
         every { issue.additionalData.details } returns null
-        cut = SuggestionDescriptionPanelFromLS(snykCodeFile, issue)
+        cut = SuggestionDescriptionPanelFromLS(snykFile, issue)
 
         val actual = getJLabelByText(cut, "<html>Test message</html>")
         assertNotNull(actual)
@@ -85,7 +85,7 @@ class SuggestionDescriptionPanelFromLSTest : BasePlatformTestCase() {
         pluginSettings().isGlobalIgnoresFeatureEnabled = true
 
         every { issue.additionalData.details } returns null
-        cut = SuggestionDescriptionPanelFromLS(snykCodeFile, issue)
+        cut = SuggestionDescriptionPanelFromLS(snykFile, issue)
 
         val actual = getJLabelByText(cut, "<html>Test message</html>")
         assertNotNull(actual)
@@ -102,7 +102,7 @@ class SuggestionDescriptionPanelFromLSTest : BasePlatformTestCase() {
         every { JCEFUtils.getJBCefBrowserComponentIfSupported(eq("<html>HTML message</html>"), any()) } returns null
 
         every { issue.additionalData.details } returns "<html>HTML message</html>"
-        cut = SuggestionDescriptionPanelFromLS(snykCodeFile, issue)
+        cut = SuggestionDescriptionPanelFromLS(snykFile, issue)
 
         val actual = getJLabelByText(cut, "<html>Test message</html>")
         assertNull(actual)
@@ -120,7 +120,7 @@ class SuggestionDescriptionPanelFromLSTest : BasePlatformTestCase() {
         every { JCEFUtils.getJBCefBrowserComponentIfSupported(eq("<html>HTML message</html>"), any()) } returns mockJBCefBrowserComponent
 
         every { issue.additionalData.details } returns "<html>HTML message</html>"
-        cut = SuggestionDescriptionPanelFromLS(snykCodeFile, issue)
+        cut = SuggestionDescriptionPanelFromLS(snykFile, issue)
 
         val actual = getJLabelByText(cut, "<html>Test message</html>")
         assertNull(actual)

--- a/src/test/kotlin/snyk/code/annotator/SnykCodeAnnotatorTest.kt
+++ b/src/test/kotlin/snyk/code/annotator/SnykCodeAnnotatorTest.kt
@@ -17,7 +17,7 @@ import io.mockk.verify
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.resetSettings
 import io.snyk.plugin.snykcode.core.AnalysisData
-import io.snyk.plugin.snykcode.core.SnykCodeFile
+import io.snyk.plugin.SnykFile
 import org.junit.Before
 import org.junit.Test
 import java.nio.file.Paths
@@ -106,7 +106,7 @@ class SnykCodeAnnotatorTest : BasePlatformTestCase() {
     @Test
     fun `test apply should trigger newAnnotation call`() {
         mockkObject(AnalysisData)
-        every { AnalysisData.instance.getAnalysis(SnykCodeFile(psiFile.project, psiFile.virtualFile)) } returns
+        every { AnalysisData.instance.getAnalysis(SnykFile(psiFile.project, psiFile.virtualFile)) } returns
             createSnykCodeResultWithIssues()
 
         cut.apply(psiFile, Unit, annotationHolderMock)
@@ -117,7 +117,7 @@ class SnykCodeAnnotatorTest : BasePlatformTestCase() {
     @Test
     fun `test apply for disabled Severity should not trigger newAnnotation call`() {
         mockkObject(AnalysisData)
-        every { AnalysisData.instance.getAnalysis(SnykCodeFile(psiFile.project, psiFile.virtualFile)) } returns
+        every { AnalysisData.instance.getAnalysis(SnykFile(psiFile.project, psiFile.virtualFile)) } returns
             createSnykCodeResultWithIssues()
         pluginSettings().highSeverityEnabled = false
 


### PR DESCRIPTION
### Description

Renames and moves common "LS in IntelliJ" files that were used when integrating Snyk Code via LS, so that we can use them when we integrated Snyk OSS via LS.

There is not actual change but I have tested it in IntelliJ by running the IDE, just to sanity check that Snyk Code scanning still works.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots

![Screenshot 2024-05-09 at 14 09 49](https://github.com/snyk/snyk-intellij-plugin/assets/81559517/2b7803c4-5630-4a7d-afee-2ee5cf78fc7a)

