### PR TITLE
feat: load Snyk OSS issues in the suggestion panel via LS [IDE-238]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [2.7.20]
 ### Added
 - (LS OSS) Starts rendering the Tree Nodes for OSS via the LS
+- (LS OSS) Renders the Suggestion Panel for OSS via the LS
 
 ## [2.7.19]
 ### Added

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/SnykOSSDetailedPathsPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/SnykOSSDetailedPathsPanel.kt
@@ -3,20 +3,16 @@ package io.snyk.plugin.ui.toolwindow.panels
 import com.intellij.ui.components.ActionLink
 import com.intellij.uiDesigner.core.GridLayoutManager
 import com.intellij.util.ui.JBUI
-import com.intellij.util.ui.UIUtil
 import io.snyk.plugin.ui.baseGridConstraintsAnchorWest
 import io.snyk.plugin.ui.boldLabel
 import io.snyk.plugin.ui.insertTitleAndResizableTextIntoPanelColumns
 import io.snyk.plugin.ui.panelGridConstraints
 import snyk.common.lsp.IssueData
-import java.awt.Dimension
-import javax.swing.JComponent
-import javax.swing.JLabel
 import javax.swing.JPanel
 
-class SnykOSSDetailedPathsPanel(private val ossIssueData: IssueData) : JComponent() {
+class SnykOSSDetailedPathsPanel(private val ossIssueData: IssueData) : JPanel() {
     init {
-        name = "detailedPathspanel"
+        name = "detailedPathsPanel"
         this.layout = GridLayoutManager(2, 2, JBUI.emptyInsets(), -1, -1)
 
         this.add(

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/SnykOSSDetailedPathsPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/SnykOSSDetailedPathsPanel.kt
@@ -1,0 +1,93 @@
+package io.snyk.plugin.ui.toolwindow.panels
+
+import com.intellij.ui.components.ActionLink
+import com.intellij.uiDesigner.core.GridLayoutManager
+import com.intellij.util.ui.JBUI
+import com.intellij.util.ui.UIUtil
+import io.snyk.plugin.ui.baseGridConstraintsAnchorWest
+import io.snyk.plugin.ui.boldLabel
+import io.snyk.plugin.ui.insertTitleAndResizableTextIntoPanelColumns
+import io.snyk.plugin.ui.panelGridConstraints
+import snyk.common.lsp.IssueData
+import java.awt.Dimension
+import javax.swing.JComponent
+import javax.swing.JLabel
+import javax.swing.JPanel
+
+class SnykOSSDetailedPathsPanel(private val ossIssueData: IssueData) : JComponent() {
+    init {
+        name = "detailedPathspanel"
+        this.layout = GridLayoutManager(2, 2, JBUI.emptyInsets(), -1, -1)
+
+        this.add(
+            boldLabel("Detailed paths").apply {
+                font = font.deriveFont(14f)
+            },
+            baseGridConstraintsAnchorWest(
+                row = 0
+            )
+        )
+
+        this.add(
+            getInnerDetailedPathsPanel(3),
+            panelGridConstraints(
+                row = 1
+            )
+        )
+    }
+
+    private fun getInnerDetailedPathsPanel(itemsToShow: Int? = null): JPanel {
+        val detailsPanel = JPanel()
+        detailsPanel.layout = GridLayoutManager(ossIssueData.matchingIssues.size + 2, 2, JBUI.emptyInsets(), -1, -1)
+
+        ossIssueData.matchingIssues
+            .take(itemsToShow ?: ossIssueData.matchingIssues.size)
+            .forEachIndexed { index, vuln ->
+                val detailPanel = JPanel()
+                detailPanel.layout = GridLayoutManager(2, 2, JBUI.emptyInsets(), 30, 0)
+
+                insertTitleAndResizableTextIntoPanelColumns(
+                    panel = detailPanel,
+                    row = 0,
+                    title = "Introduced through:",
+                    htmlText = vuln.from.joinToString(separator = " > ")
+                )
+
+                val remediationText = when {
+                    vuln.upgradePath.isEmpty() || vuln.upgradePath.size < 2 -> "none"
+                    else -> "Upgrade to " + vuln.upgradePath.first()
+                }
+                insertTitleAndResizableTextIntoPanelColumns(
+                    panel = detailPanel,
+                    row = 1,
+                    title = "Fix:",
+                    htmlText = remediationText
+                )
+
+                detailsPanel.add(
+                    detailPanel,
+                    panelGridConstraints(
+                        row = index + 1
+                    )
+                )
+            }
+
+        if (itemsToShow != null && itemsToShow < ossIssueData.matchingIssues.size) {
+            val showMoreLabel = ActionLink("...and ${ossIssueData.matchingIssues.size - itemsToShow} more") {
+                detailsPanel.removeAll()
+                detailsPanel.add(
+                    getInnerDetailedPathsPanel(),
+                    panelGridConstraints(
+                        row = 0
+                    )
+                )
+            }
+            detailsPanel.add(
+                showMoreLabel,
+                baseGridConstraintsAnchorWest(ossIssueData.matchingIssues.size + 1)
+            )
+        }
+
+        return detailsPanel
+    }
+}

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/SnykOSSIntroducedThroughPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/SnykOSSIntroducedThroughPanel.kt
@@ -7,11 +7,10 @@ import io.snyk.plugin.ui.baseGridConstraintsAnchorWest
 import io.snyk.plugin.ui.boldLabel
 import snyk.common.lsp.IssueData
 import io.snyk.plugin.ui.toolwindow.LabelProvider
-import javax.swing.JComponent
 import javax.swing.JLabel
 import javax.swing.JPanel
 
-class SnykOSSIntroducedThroughPanel(private val ossIssueData: IssueData) : JComponent() {
+class SnykOSSIntroducedThroughPanel(private val ossIssueData: IssueData) : JPanel() {
     private val labelProvider: LabelProvider = LabelProvider()
 
     init {

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/SnykOSSIntroducedThroughPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/SnykOSSIntroducedThroughPanel.kt
@@ -1,0 +1,95 @@
+package io.snyk.plugin.ui.toolwindow.panels
+
+import com.intellij.uiDesigner.core.GridLayoutManager
+import com.intellij.util.ui.JBUI
+import io.snyk.plugin.ui.addRowOfItemsToPanel
+import io.snyk.plugin.ui.baseGridConstraintsAnchorWest
+import io.snyk.plugin.ui.boldLabel
+import snyk.common.lsp.IssueData
+import io.snyk.plugin.ui.toolwindow.LabelProvider
+import javax.swing.JComponent
+import javax.swing.JLabel
+import javax.swing.JPanel
+
+class SnykOSSIntroducedThroughPanel(private val ossIssueData: IssueData) : JComponent() {
+    private val labelProvider: LabelProvider = LabelProvider()
+
+    init {
+        name = "introducedThroughPanel"
+        this.layout = GridLayoutManager(11, 2, JBUI.insets(10, 0, 20, 0), 30, -1)
+
+        this.add(
+            boldLabel("Vulnerable module:"),
+            baseGridConstraintsAnchorWest(2, 0)
+        )
+        this.add(
+            JLabel(ossIssueData.name)/*.apply { this.horizontalAlignment = SwingConstants.LEFT }*/,
+            baseGridConstraintsAnchorWest(2, 1, indent = 0)
+        )
+
+        val introducedThroughListPanel = getIntroducedThroughListPanel()
+        if (introducedThroughListPanel != null) {
+            this.add(
+                boldLabel("Introduced through:"),
+                baseGridConstraintsAnchorWest(3, 0)
+            )
+            this.add(
+                introducedThroughListPanel,
+                baseGridConstraintsAnchorWest(3, 1, indent = 0)
+            )
+        }
+
+        val fixedInText = ossIssueData.fixedIn?.let {
+            if (it.isNotEmpty()) {
+                it.joinToString(prefix = "${ossIssueData.name}@", separator = ", @")
+            } else "Not fixed"
+        }
+        if (fixedInText != null) {
+            this.add(
+                boldLabel("Fixed in:"),
+                baseGridConstraintsAnchorWest(4, 0)
+            )
+            this.add(
+                JLabel(fixedInText),
+                baseGridConstraintsAnchorWest(4, 1, indent = 0)
+            )
+        }
+
+        val exploit = ossIssueData.exploit
+        if (exploit != null) {
+            this.add(
+                boldLabel("Exploit maturity:"),
+                baseGridConstraintsAnchorWest(5, 0)
+            )
+            this.add(
+                JLabel(exploit),
+                baseGridConstraintsAnchorWest(5, 1, indent = 0)
+            )
+        }
+    }
+
+    private fun getIntroducedThroughListPanel(): JPanel? {
+        val intros = ossIssueData.matchingIssues
+            .mapNotNull { vulnerability ->
+                vulnerability.from.let { if (it.size > 1) it[1] else null }
+            }
+            .distinct()
+
+        if (intros.isEmpty()) return null
+
+        val panel = JPanel()
+        val packageManager = ossIssueData.packageManager
+
+        panel.layout = GridLayoutManager(1, intros.size * 2, JBUI.emptyInsets(), 0, 0)
+
+        addRowOfItemsToPanel(
+            panel = panel,
+            startingColumn = 0,
+            items = intros.map { item -> labelProvider.getDependencyLabel(packageManager, item) },
+            separator = ", ",
+            firstSeparator = false,
+            opaqueSeparator = false
+        )
+        return panel
+    }
+}

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/SnykOSSOverviewPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/SnykOSSOverviewPanel.kt
@@ -1,0 +1,39 @@
+package io.snyk.plugin.ui.toolwindow.panels
+
+import com.intellij.uiDesigner.core.GridLayoutManager
+import com.intellij.util.ui.JBUI
+import com.intellij.util.ui.UIUtil
+import io.snyk.plugin.ui.getReadOnlyClickableHtmlJEditorPane
+import io.snyk.plugin.ui.panelGridConstraints
+import org.commonmark.parser.Parser
+import org.commonmark.renderer.html.HtmlRenderer
+import snyk.common.lsp.IssueData
+import java.awt.Dimension
+import javax.swing.JComponent
+import javax.swing.JLabel
+
+class SnykOSSOverviewPanel(private val ossIssueData: IssueData) : JComponent() {
+    init {
+        name = "overviewPanel"
+        this.layout = GridLayoutManager(2, 1, JBUI.insetsLeft(5), -1, 0)
+
+        val descriptionPane = getReadOnlyClickableHtmlJEditorPane(getDescriptionAsHtml())
+
+        this.add(
+            descriptionPane,
+            panelGridConstraints(1)
+        )
+    }
+
+    private fun getDescriptionAsHtml(): String {
+        val overviewMarkdownStr = ossIssueData.description
+
+        val parser = Parser.builder().build()
+        val document = parser.parse(overviewMarkdownStr)
+
+        val renderer = HtmlRenderer.builder().escapeHtml(true).build()
+
+        return renderer.render(document)
+    }
+
+}

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/SnykOSSOverviewPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/SnykOSSOverviewPanel.kt
@@ -2,17 +2,14 @@ package io.snyk.plugin.ui.toolwindow.panels
 
 import com.intellij.uiDesigner.core.GridLayoutManager
 import com.intellij.util.ui.JBUI
-import com.intellij.util.ui.UIUtil
 import io.snyk.plugin.ui.getReadOnlyClickableHtmlJEditorPane
 import io.snyk.plugin.ui.panelGridConstraints
 import org.commonmark.parser.Parser
 import org.commonmark.renderer.html.HtmlRenderer
 import snyk.common.lsp.IssueData
-import java.awt.Dimension
-import javax.swing.JComponent
-import javax.swing.JLabel
+import javax.swing.JPanel
 
-class SnykOSSOverviewPanel(private val ossIssueData: IssueData) : JComponent() {
+class SnykOSSOverviewPanel(private val ossIssueData: IssueData) : JPanel() {
     init {
         name = "overviewPanel"
         this.layout = GridLayoutManager(2, 1, JBUI.insetsLeft(5), -1, 0)

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/SuggestionDescriptionPanelFromLS.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/SuggestionDescriptionPanelFromLS.kt
@@ -6,6 +6,7 @@ import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.SnykFile
 import io.snyk.plugin.ui.DescriptionHeaderPanel
 import io.snyk.plugin.ui.SnykBalloonNotificationHelper
+import io.snyk.plugin.ui.baseGridConstraintsAnchorWest
 import io.snyk.plugin.ui.descriptionHeaderPanel
 import io.snyk.plugin.ui.jcef.JCEFUtils
 import io.snyk.plugin.ui.jcef.OpenFileLoadHandlerGenerator
@@ -16,7 +17,6 @@ import snyk.common.ProductType
 import snyk.common.lsp.ScanIssue
 import java.awt.BorderLayout
 import java.awt.Font
-import javax.swing.JComponent
 import javax.swing.JLabel
 import javax.swing.JPanel
 
@@ -79,35 +79,37 @@ class SuggestionDescriptionPanelFromLS(
         val panel = JPanel(
             GridLayoutManager(lastRowToAddSpacer + 1, 1, JBUI.insets(0, 10, 20, 10), -1, 20)
         ).apply {
-            overviewPanel()?.let { this.add(it, panelGridConstraints(2)) }
-            dataFlowPanel()?.let { this.add(it, panelGridConstraints(3)) }
-            fixExamplesPanel()?.let { this.add(it, panelGridConstraints(4)) }
+            if (issue.additionalData.getProductType() == ProductType.CODE_SECURITY || issue.additionalData.getProductType() == ProductType.CODE_QUALITY) {
+                this.add(
+                    SnykCodeOverviewPanel(issue.additionalData),
+                    panelGridConstraints(2)
+                )
+                this.add(
+                    SnykCodeDataflowPanel(project, issue.additionalData),
+                    panelGridConstraints(3)
+                )
+                this.add(
+                    SnykCodeExampleFixesPanel(issue.additionalData),
+                    panelGridConstraints(4)
+                )
+            } else if (issue.additionalData.getProductType() == ProductType.OSS) {
+                this.add(
+                    SnykOSSIntroducedThroughPanel(issue.additionalData),
+                    baseGridConstraintsAnchorWest(1, indent = 0)
+                )
+                this.add(
+                   SnykOSSDetailedPathsPanel(issue.additionalData),
+                    panelGridConstraints(2)
+                )
+                this.add(
+                    SnykOSSOverviewPanel(issue.additionalData),
+                    panelGridConstraints(3)
+                )
+            } else {
+                TODO()
+            }
         }
         return Pair(panel, lastRowToAddSpacer)
-    }
-
-    private fun overviewPanel(): JComponent? {
-        return when(issue.additionalData.getProductType()) {
-            ProductType.OSS -> null
-            ProductType.CODE_SECURITY, ProductType.CODE_QUALITY -> SnykCodeOverviewPanel(issue.additionalData)
-            else -> throw IllegalStateException("product of this type has not been configured")
-        }
-    }
-
-    private fun dataFlowPanel(): JPanel? {
-        return when(issue.additionalData.getProductType()) {
-            ProductType.OSS -> null
-            ProductType.CODE_SECURITY, ProductType.CODE_QUALITY -> SnykCodeDataflowPanel(project, issue.additionalData)
-            else -> throw IllegalStateException("product of this type has not been configured")
-        }
-    }
-
-    private fun fixExamplesPanel(): JPanel? {
-        return when(issue.additionalData.getProductType()) {
-            ProductType.OSS -> null
-            ProductType.CODE_SECURITY, ProductType.CODE_QUALITY -> SnykCodeExampleFixesPanel(issue.additionalData)
-            else -> throw IllegalStateException("product of this type has not been configured")
-        }
     }
 }
 

--- a/src/main/kotlin/snyk/common/lsp/Types.kt
+++ b/src/main/kotlin/snyk/common/lsp/Types.kt
@@ -389,7 +389,7 @@ data class IssueData(
 
     // OSS
     @SerializedName("license") val license: String?,
-    @SerializedName("identifiers") val identifiers: OssIdentifiers?,
+    @SerializedName("identifiers") val identifiers: OssIdentifiers,
     @SerializedName("description") val description: String,
     @SerializedName("language") val language: String,
     @SerializedName("packageManager") val packageManager: String,
@@ -406,7 +406,7 @@ data class IssueData(
     @SerializedName("isUpgradable") val isUpgradable: Boolean?,
     @SerializedName("projectName") val projectName: String,
     @SerializedName("displayTargetFile") val displayTargetFile: String?,
-    @SerializedName("matchingIssues") val matchingIssues: List<IssueData>?,
+    @SerializedName("matchingIssues") val matchingIssues: List<IssueData>,
     @SerializedName("lesson") val lesson: String?,
 
     // Code and OSS
@@ -569,3 +569,4 @@ data class OssIdentifiers(
         return result
     }
 }
+

--- a/src/main/kotlin/snyk/common/lsp/Types.kt
+++ b/src/main/kotlin/snyk/common/lsp/Types.kt
@@ -389,7 +389,7 @@ data class IssueData(
 
     // OSS
     @SerializedName("license") val license: String?,
-    @SerializedName("identifiers") val identifiers: OssIdentifiers,
+    @SerializedName("identifiers") val identifiers: OssIdentifiers?,
     @SerializedName("description") val description: String,
     @SerializedName("language") val language: String,
     @SerializedName("packageManager") val packageManager: String,

--- a/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SuggestionDescriptionPanelFromLSCodeTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SuggestionDescriptionPanelFromLSCodeTest.kt
@@ -89,6 +89,15 @@ class SuggestionDescriptionPanelFromLSCodeTest : BasePlatformTestCase() {
 
         val fixExamplesPanel = getJPanelByName(cut, "fixExamplesPanel")
         assertNotNull(fixExamplesPanel)
+
+        val introducedThroughPanel = getJPanelByName(cut, "introducedThroughPanel")
+        assertNull(introducedThroughPanel)
+
+        val detailedPathsPanel = getJPanelByName(cut, "detailedPathsPanel")
+        assertNull(detailedPathsPanel)
+
+        val ossOverviewPanel = getJPanelByName(cut, "overviewPanel")
+        assertNull(ossOverviewPanel)
     }
 
     @Test

--- a/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SuggestionDescriptionPanelFromLSOSSTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SuggestionDescriptionPanelFromLSOSSTest.kt
@@ -29,6 +29,7 @@ import snyk.common.ProductType
 import snyk.common.lsp.CommitChangeLine
 import snyk.common.lsp.DataFlow
 import snyk.common.lsp.ExampleCommitFix
+import snyk.common.lsp.IssueData
 import snyk.common.lsp.ScanIssue
 import java.nio.file.Paths
 import javax.swing.JLabel
@@ -58,6 +59,14 @@ class SuggestionDescriptionPanelFromLSOSSTest : BasePlatformTestCase() {
         psiFile = WriteAction.computeAndWait<PsiFile, Throwable> { psiManager.findFile(file)!! }
         snykFile = SnykFile(psiFile.project, psiFile.virtualFile)
 
+        val matchingIssue = mockk<IssueData>()
+        every { matchingIssue.getProductType() } returns ProductType.OSS
+        every { matchingIssue.name } returns "Another test name"
+        every { matchingIssue.from } returns listOf("from")
+        every { matchingIssue.upgradePath } returns listOf("upgradePath")
+
+        val matchingIssues = listOf(matchingIssue)
+
         issue = mockk<ScanIssue>()
         every { issue.getSeverityAsEnum() } returns Severity.CRITICAL
         every { issue.title() } returns "title"
@@ -69,6 +78,11 @@ class SuggestionDescriptionPanelFromLSOSSTest : BasePlatformTestCase() {
         every { issue.id() } returns "id"
         every { issue.ruleId() } returns "ruleId"
         every { issue.additionalData.getProductType() } returns ProductType.OSS
+        every { issue.additionalData.name } returns "Test name"
+        every { issue.additionalData.matchingIssues } returns matchingIssues
+        every { issue.additionalData.fixedIn } returns listOf("fixedIn")
+        every { issue.additionalData.exploit } returns "exploit"
+        every { issue.additionalData.description } returns "description"
     }
 
     @Test
@@ -92,5 +106,14 @@ class SuggestionDescriptionPanelFromLSOSSTest : BasePlatformTestCase() {
 
         val fixExamplesPanel = getJPanelByName(cut, "fixExamplesPanel")
         assertNull(fixExamplesPanel)
+
+        val introducedThroughPanel = getJPanelByName(cut, "introducedThroughPanel")
+        assertNotNull(introducedThroughPanel)
+
+        val detailedPathsPanel = getJPanelByName(cut, "detailedPathsPanel")
+        assertNotNull(detailedPathsPanel)
+
+        val ossOverviewPanel = getJPanelByName(cut, "overviewPanel")
+        assertNotNull(ossOverviewPanel)
     }
 }


### PR DESCRIPTION
### Description

This PR is a continuation of https://github.com/snyk/snyk-intellij-plugin/pull/525 and loads the full OSS content inside the Suggestion Panel. The components were taken from https://github.com/snyk/snyk-intellij-plugin/blob/fa6d6e06028ebf45c3b056fb67b3fbf26b630e41/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/VulnerabilityDescriptionPanel.kt. I could have de-duplicated them but we want to remove this file anyway soon and it would require retro-fitting the data types into the `IssueData` type for the LS so a bit more effort than worth it.

It requires the changes in https://github.com/snyk/snyk-ls/releases/tag/v20240513.094925 to work, so update the CLI locally for now and run `make build`, then change the path to the CLI in the Snyk Settings. Also make sure to enable the `snyk.preview.snyk.oss.ls.enabled` registry flag in IntelliJ.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs
Before:
<img width="1712" alt="Screenshot 2024-05-13 at 11 08 26" src="https://github.com/snyk/snyk-intellij-plugin/assets/81559517/8bc193b7-91dc-47a0-acf8-0009ddc46179">
<img width="1709" alt="Screenshot 2024-05-13 at 11 08 17" src="https://github.com/snyk/snyk-intellij-plugin/assets/81559517/5b476976-ec5c-4167-811c-62d7146e74ae">

After:
<img width="1706" alt="Screenshot 2024-05-13 at 10 27 03" src="https://github.com/snyk/snyk-intellij-plugin/assets/81559517/96ac775b-72f4-4985-8025-9083ba4d95d5">
<img width="1703" alt="Screenshot 2024-05-13 at 10 26 48" src="https://github.com/snyk/snyk-intellij-plugin/assets/81559517/f7653a7f-7469-46ba-a3b1-c8b0098c15e3">
![Screenshot 2024-05-10 at 16 08 18](https://github.com/snyk/snyk-intellij-plugin/assets/81559517/208352a5-3a7e-4708-a4c0-5c0935046cf6)
![OSS IN LS](https://github.com/snyk/snyk-intellij-plugin/assets/81559517/5b168d4b-219b-47b9-9245-b52dcf80ddc5)
