### PR TITLE
feat: code action for OSS via LS in IntelliJ [IDE-284]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Snyk Security Changelog
 
 ## [2.8.8]
+### Added
+- renders code actions and code lenses for OpenSource scans via the LS
 
 ### Fixes
 - change some of the colours used in the HTML panel so it's consistent with designs

--- a/src/main/kotlin/snyk/code/annotator/CodeActionIntention.kt
+++ b/src/main/kotlin/snyk/code/annotator/CodeActionIntention.kt
@@ -71,7 +71,13 @@ class CodeActionIntention(
 
     override fun getIcon(p0: Int): Icon {
         return when (product) {
-            ProductType.OSS -> SnykIcons.OPEN_SOURCE_SECURITY
+            ProductType.OSS -> {
+                if (this.codeAction.title.startsWith("Upgrade to")) {
+                    SnykIcons.CHECKMARK_GREEN
+                } else {
+                    SnykIcons.OPEN_SOURCE_SECURITY
+                }
+            }
             ProductType.IAC -> SnykIcons.IAC
             ProductType.CONTAINER -> SnykIcons.CONTAINER
             ProductType.CODE_SECURITY -> SnykIcons.SNYK_CODE
@@ -84,6 +90,7 @@ class CodeActionIntention(
     override fun getPriority(): PriorityAction.Priority {
         return when {
             codeAction.title.contains("fix", ignoreCase = true) -> PriorityAction.Priority.TOP
+            codeAction.title.contains("Upgrade to", ignoreCase = true) -> PriorityAction.Priority.TOP
             else -> issue.getSeverityAsEnum().getQuickFixPriority()
         }
     }

--- a/src/main/kotlin/snyk/common/lsp/LanguageServerSettings.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerSettings.kt
@@ -39,6 +39,7 @@ data class LanguageServerSettings(
     @SerializedName("authenticationMethod") val authenticationMethod: AuthenticationMethod? = null,
     @SerializedName("snykCodeApi") val snykCodeApi: String? = null,
     @SerializedName("enableSnykLearnCodeActions") val enableSnykLearnCodeActions: String? = null,
+    @SerializedName("enableSnykOSSQuickFixCodeActions") val enableSnykOSSQuickFixCodeActions: String? = null,
     @SerializedName("requiredProtocolVersion") val requiredProtocolVersion: String =
         pluginSettings().requiredLsProtocolVersion.toString(),
 )
@@ -47,7 +48,7 @@ data class SeverityFilter(
     @SerializedName("critical") val critical: Boolean?,
     @SerializedName("high") val high: Boolean?,
     @SerializedName("medium") val medium: Boolean?,
-    @SerializedName("low") val low: Boolean?
+    @SerializedName("low") val low: Boolean?,
 )
 
 enum class AuthenticationMethod {
@@ -55,5 +56,5 @@ enum class AuthenticationMethod {
     TokenAuthentication,
 
     @SerializedName("oauth")
-    OAuthAuthentication
+    OAuthAuthentication,
 }

--- a/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
@@ -358,6 +358,7 @@ class LanguageServerWrapper(
             scanningMode = if (!ps.scanOnSave) "manual" else "auto",
             integrationName = pluginInfo.integrationName,
             integrationVersion = pluginInfo.integrationVersion,
+            enableSnykOSSQuickFixCodeActions = "true",
         )
     }
 

--- a/src/main/kotlin/snyk/common/lsp/Types.kt
+++ b/src/main/kotlin/snyk/common/lsp/Types.kt
@@ -247,12 +247,12 @@ data class ScanIssue(
 
     fun annotationMessage(): String {
         return when (this.additionalData.getProductType()) {
-            ProductType.OSS -> this.title
+            ProductType.OSS -> this.title + " in " + this.additionalData.packageName + " id: " + this.ruleId()
             ProductType.CODE_SECURITY, ProductType.CODE_QUALITY ->
                 this.title.ifBlank {
                     this.additionalData.message.let {
                         if (it.length < 70) it else "${it.take(70)}..."
-                    }
+                    } + " (Snyk)"
                 }
 
             else -> TODO()


### PR DESCRIPTION
### Description

This PR enhances the existing `codeActions` returned via the LS for OSS with quickfix actions that tell us what version to upgrade a package to. 

The only difference is that the new "OSS via LS" code actions have Snyk Learn actions too and we return quickfix code actions for all possible upgrade paths, rather than just the one.

To review, build https://github.com/snyk/snyk-ls/pull/511 and follow the review instructions there.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

🚨After having merged, please update the CLI go.mod to pull in latest language server.

### Screenshots / GIFs
This was tested by building `snyk-ls` from https://github.com/snyk/snyk-ls/pull/511 and then the CLI with a `snyk-ls` replace directive, then changing the IntelliJ sandbox generated from this branch to point at the local CLI. Make sure to enable the registry flag.

The tests were run on https://github.com/snyk-labs/snyk-chat-goof.

Before:
<img width="711" alt="Screenshot 2024-05-15 at 10 15 25" src="https://github.com/snyk/snyk-ls/assets/81559517/3624ea1c-c339-446b-bfd8-664bf4d37813">
<img width="692" alt="Screenshot 2024-05-15 at 10 15 34" src="https://github.com/snyk/snyk-ls/assets/81559517/50b83c84-5ab2-451c-b149-db2d307b4674">
<img width="782" alt="Screenshot 2024-05-15 at 10 15 39" src="https://github.com/snyk/snyk-ls/assets/81559517/ed4b1547-0b48-4a81-8230-2c51accf8e63">
<img width="889" alt="Screenshot 2024-05-15 at 10 15 43" src="https://github.com/snyk/snyk-ls/assets/81559517/259997d8-8495-435d-9383-b1bb8b203229">
<img width="888" alt="Screenshot 2024-05-15 at 10 15 48" src="https://github.com/snyk/snyk-ls/assets/81559517/d3b66f54-772d-477c-937c-9a3f383fee40">
<img width="894" alt="Screenshot 2024-05-15 at 10 15 51" src="https://github.com/snyk/snyk-ls/assets/81559517/8ff6d729-a946-4a72-b781-7c473f361871">

After:

<img width="814" alt="Screenshot 2024-05-16 at 16 56 59" src="https://github.com/snyk/snyk-ls/assets/81559517/2f49ed36-baac-4e84-8c9f-3c73fae6374f">
<img width="901" alt="Screenshot 2024-05-16 at 16 57 04" src="https://github.com/snyk/snyk-ls/assets/81559517/ab4cd690-4914-4946-8bd2-ebc466c6efe1">
<img width="931" alt="Screenshot 2024-05-16 at 16 57 09" src="https://github.com/snyk/snyk-ls/assets/81559517/1f67795e-b7b5-4ad2-929f-4b37f79822bd">
<img width="1000" alt="Screenshot 2024-05-16 at 16 57 15" src="https://github.com/snyk/snyk-ls/assets/81559517/4fc19e90-b473-47d0-a485-aed7a56c0165">
<img width="643" alt="Screenshot 2024-05-16 at 16 57 20" src="https://github.com/snyk/snyk-ls/assets/81559517/9ddefc77-f592-4154-aa0f-c264db60caa5">
<img width="1070" alt="Screenshot 2024-05-16 at 16 57 38" src="https://github.com/snyk/snyk-ls/assets/81559517/954e2545-be01-48c1-8336-964996feb9d2">
<img width="829" alt="Screenshot 2024-05-16 at 16 57 41" src="https://github.com/snyk/snyk-ls/assets/81559517/1927618f-8d92-47dc-a428-f6d0f44b7685">
