### PR TITLE
fix: append v1 suffix conditionally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Snyk Security Changelog
 
+## [2.7.21]
+
+### Fixed
+- Append /v1 to the endpoint when necessary
+
 ## [2.7.20]
 ### Added
 - (LS OSS) Starts rendering the Tree Nodes for OSS via the LS

--- a/src/main/kotlin/io/snyk/plugin/SnykPostStartupActivity.kt
+++ b/src/main/kotlin/io/snyk/plugin/SnykPostStartupActivity.kt
@@ -115,7 +115,7 @@ class SnykPostStartupActivity : ProjectActivity {
             getKubernetesImageCache(project)?.cacheKubernetesFileFromProject()
         }
 
-        if (settings.scanOnSave && (isSnykCodeLSEnabled() || isSnykOSSLSEnabled() || isSnykIaCLSEnabled())) {
+        if (!settings.token.isNullOrBlank() && settings.scanOnSave && (isSnykCodeLSEnabled() || isSnykOSSLSEnabled() || isSnykIaCLSEnabled())) {
             getSnykTaskQueueService(project)?.scan(true)
         }
 

--- a/src/main/kotlin/snyk/common/CustomEndpoints.kt
+++ b/src/main/kotlin/snyk/common/CustomEndpoints.kt
@@ -73,7 +73,8 @@ fun getEndpointUrl(): String {
         ""
     }
     val customEndpointUrl = resolveCustomEndpoint(endpointUrl)
-    return customEndpointUrl.removeTrailingSlashesIfPresent()
+    // we need to set v1 here, to make the sast-enabled calls work in LS
+    return customEndpointUrl.removeTrailingSlashesIfPresent().suffixIfNot("/v1")
 }
 
 fun isSnykCodeAvailable(endpointUrl: String?): Boolean {

--- a/src/main/kotlin/snyk/common/CustomEndpoints.kt
+++ b/src/main/kotlin/snyk/common/CustomEndpoints.kt
@@ -21,12 +21,14 @@ fun toSnykCodeApiUrl(endpointUrl: String?): String {
         uri.isDev() ->
             endpoint
                 .replace("api.", "")
+                .replace("/v1", "")
                 .replace("https://dev.", "https://$codeSubdomain.dev.")
                 .suffixIfNot("/")
 
         uri.isSnykTenant() ->
             endpoint
                 .replace("https://api.", "https://")
+                .replace("/v1", "")
                 .replace("https://", "https://$codeSubdomain.")
                 .suffixIfNot("/")
 

--- a/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
@@ -271,7 +271,7 @@ class LanguageServerWrapper(
     }
 
     private fun getFeatureFlagStatusInternal(featureFlag: String): Boolean {
-        if (!isSnykCodeLSEnabled()) {
+        if (!(isSnykCodeLSEnabled() || isSnykOSSLSEnabled() || isSnykIaCLSEnabled()) || pluginSettings().token.isNullOrBlank()) {
             return false
         }
 

--- a/src/test/kotlin/snyk/common/CustomEndpointsTest.kt
+++ b/src/test/kotlin/snyk/common/CustomEndpointsTest.kt
@@ -107,9 +107,11 @@ class CustomEndpointsTest {
     fun `toSnykCodeApiUrl returns correct deeproxy url for SaaS deployments using api url`() {
         val apiUrlForProduction = toSnykCodeApiUrl("https://api.eu.snyk.io")
         val apiUrlForDevelopment = toSnykCodeApiUrl("https://dev.api.eu.snyk.io")
+        val apiUrlForWithV1 = toSnykCodeApiUrl("https://api.eu.snyk.io/v1")
 
         assertEquals("https://deeproxy.eu.snyk.io/", apiUrlForProduction)
         assertEquals("https://deeproxy.dev.eu.snyk.io/", apiUrlForDevelopment)
+        assertEquals("https://deeproxy.eu.snyk.io/", apiUrlForWithV1)
     }
 
     @Test


### PR DESCRIPTION
### Description

Currently when using the `stable` CLI version in IntelliJ (with or without the "Code in LS" registry flag enabled) we end up failing to run Snyk Code scans because the call to retrieve the SAST settings requires a `/v1` in the path. This has started since https://github.com/snyk/snyk-intellij-plugin/pull/515. 

In https://github.com/snyk/snyk-intellij-plugin/pull/523 we removed this from being added to all API calls because of some bugs we noticed at the time. The bug at the time was that when `snykCodeConsistentIgnores` is enabled, we make some calls to the new Snyk REST API so we should not add this `/v1` to all calls. In https://github.com/snyk/snyk-ls/pull/498 (requirement for PR#523), we made sure to only add `/v1` to the required calls but this missed the cutoff for the first `stable` release and so is not released to `stable` yet.

Instead of making a hotfix in the CLI, which is expensive, we decided to undo the change in https://github.com/snyk/snyk-intellij-plugin/pull/523. Upon testing though, we noticed a new bug similar to the one when `snykCodeConsistentIgnores` is enabled. When the "Code in LS" registry flag was not enabled (which is what all our customers have now and Casey had actually noticed [here](https://snyk.slack.com/archives/C06B1U3RKG8/p1714665917838529?thread_ts=1714646918.499379&cid=C06B1U3RKG8)) the calls to `deeproxy` were getting the `/v1` appended to them and failing. So this PR also adds a fix for that.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

In `master` with `stable`
- with "Code in LS" and without "Code in LS"
<img width="1399" alt="Screenshot 2024-05-22 at 15 10 09" src="https://github.com/snyk/snyk-intellij-plugin/assets/81559517/a169c2b6-184b-4ccb-bf89-66ac6725bcd3">

In `master` with `preview`
- with "Code in LS" and without "Code in LS"
<img width="1705" alt="Screenshot 2024-05-22 at 15 11 14" src="https://github.com/snyk/snyk-intellij-plugin/assets/81559517/1614acf0-f926-479a-91c6-5d771e2ac309">

In PR with `stable`
- with "Code in LS"
<img width="1673" alt="Screenshot 2024-05-22 at 16 00 58" src="https://github.com/snyk/snyk-intellij-plugin/assets/81559517/f943bf22-c3ef-44be-8ed9-34f1b5236a2c">

- without "Code in LS"
![Uploading Screenshot 2024-05-22 at 16.06.47.png…]()


In PR with `preview`
- with "Code in LS"
<img width="1683" alt="Screenshot 2024-05-22 at 16 02 51" src="https://github.com/snyk/snyk-intellij-plugin/assets/81559517/0f936025-83b4-451e-8a4a-551b84b5edd4">

- without "Code in LS"
<img width="1683" alt="Screenshot 2024-05-22 at 16 05 35" src="https://github.com/snyk/snyk-intellij-plugin/assets/81559517/f0c75759-bca2-4d5e-b921-d699e1a9df14">
