### PR TITLE
fix: disable debug logging by default for ls

### DIFF
--- a/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
+++ b/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
@@ -60,7 +60,7 @@ class SnykLanguageClient() : LanguageClient {
     private val progressLock: ReentrantLock = ReentrantLock()
 
     // TODO FIX Log Level
-    val logger = Logger.getInstance("Snyk Language Server").also { it.setLevel(LogLevel.DEBUG) }
+    val logger = Logger.getInstance("Snyk Language Server")
 
     private val progresses: Cache<String, ProgressIndicator> =
         Caffeine.newBuilder()


### PR DESCRIPTION
### Description

Previously, LS was always logging in debug mode. Now it is respecting the logger settings.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
