### PR TITLE
feat: show count of ignored and non-ignored issues [IDE-332]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Snyk Security Changelog
 
-## [2.9.0]
+## [2.8.2]
 
 ### Added
 - Inserts the IDE specific scripting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 - Inserts the IDE specific scripting.
-- Add information about the number of ignores issues for consistent ignores.
+- Add information about the number of ignored and non-ignored vulnerabilities for consistent ignores.
 
 ## [2.8.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Snyk Security Changelog
 
-
 ## [2.9.0]
 
 ### Added
 - Inserts the IDE specific scripting.
+- Add information about the number of ignores issues for consistent ignores.
 
 ## [2.8.1]
+
 ### Added
 - Injects custom styling for the HTML panel used by Snyk Code for consistent ignores.
 

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLS.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLS.kt
@@ -137,7 +137,7 @@ class SnykToolWindowSnykScanListenerLS(
         var rootNodePostFix = ""
 
         if (enabledInSettings) {
-            rootNodePostFix = buildSeveritiesPostfixForFileNode(snykResults)
+            rootNodePostFix = buildIssueViewOptionsPostfixForFileNode(snykResults) + buildSeveritiesPostfixForFileNode(snykResults)
 
             if (filterTree) {
                 val resultsToDisplay = snykResults.map { entry ->
@@ -197,6 +197,14 @@ class SnykToolWindowSnykScanListenerLS(
                         )
                     }
             }
+    }
+
+    private fun buildIssueViewOptionsPostfixForFileNode(results: Map<SnykFile, List<ScanIssue>>): String {
+        if (!pluginSettings().isGlobalIgnoresFeatureEnabled) {
+            return ""
+        }
+        val ignored = results.values.flatten().count { it.isIgnored() }
+        return " ($ignored ignored)"
     }
 
     private fun buildSeveritiesPostfixForFileNode(results: Map<SnykFile, List<ScanIssue>>): String {

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLS.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLS.kt
@@ -172,7 +172,8 @@ class SnykToolWindowSnykScanListenerLS(
         )
     }
 
-    private fun addInfoTreeNodes(
+    @Suppress("RedundantVisibilityModifierRule")
+    fun addInfoTreeNodes(
         rootNode: DefaultMutableTreeNode,
         issues: List<ScanIssue>,
         securityIssuesCount: Int? = null,

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLS.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLS.kt
@@ -81,7 +81,7 @@ class SnykToolWindowSnykScanListenerLS(
             snykResults = securityIssues,
             rootNode = this.rootSecurityIssuesTreeNode,
             securityIssuesCount = securityIssues.values.flatten().distinct().size,
-            fixableIssuesCount = securityIssues.values.flatten().distinct().count { it.hasAIFix() },
+            fixableIssuesCount = securityIssues.values.flatten().distinct().count { it.hasAIFix() }
         )
 
         // display Quality (non Security) issues
@@ -96,6 +96,7 @@ class SnykToolWindowSnykScanListenerLS(
             snykResults = qualityIssues,
             rootNode = this.rootQualityIssuesTreeNode,
             qualityIssuesCount = qualityIssues.values.flatten().distinct().size,
+            fixableIssuesCount = qualityIssues.values.flatten().distinct().count { it.hasAIFix() }
         )
     }
 
@@ -162,7 +163,7 @@ class SnykToolWindowSnykScanListenerLS(
             ossResultsCount = ossResultsCount,
             iacResultsCount = iacResultsCount,
             containerResultsCount = containerResultsCount,
-            addHMLPostfix = rootNodePostFix,
+            addHMLPostfix = rootNodePostFix
         )
 
         snykToolWindowPanel.smartReloadRootNode(
@@ -212,7 +213,7 @@ class SnykToolWindowSnykScanListenerLS(
             if (fixableIssuesCount > 0) {
                 rootNode.add(
                     InfoTreeNode(
-                        "⚡\uFE0F $fixableIssuesCount vulnerabilities can be fixed by Snyk DeepCode AI",
+                        "⚡ $fixableIssuesCount vulnerabilities can be fixed by Snyk DeepCode AI",
                         project,
                     ),
                 )
@@ -226,7 +227,7 @@ class SnykToolWindowSnykScanListenerLS(
 
     private fun displayResultsForRootTreeNode(
         rootNode: DefaultMutableTreeNode,
-        issues: Map<SnykFile, List<ScanIssue>>,
+        issues: Map<SnykFile, List<ScanIssue>>
     ) {
         fun navigateToSource(
             virtualFile: VirtualFile,
@@ -256,8 +257,8 @@ class SnykToolWindowSnykScanListenerLS(
                         fileTreeNode.add(
                             SuggestionTreeNode(
                                 issue,
-                                navigateToSource(entry.key.virtualFile, issue.textRange ?: TextRange(0, 0)),
-                            ),
+                                navigateToSource(entry.key.virtualFile, issue.textRange ?: TextRange(0, 0))
+                            )
                         )
                     }
             }

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykTreeCellRenderer.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykTreeCellRenderer.kt
@@ -21,6 +21,7 @@ import io.snyk.plugin.ui.toolwindow.nodes.root.RootQualityIssuesTreeNode
 import io.snyk.plugin.ui.toolwindow.nodes.root.RootSecurityIssuesTreeNode
 import io.snyk.plugin.ui.toolwindow.nodes.secondlevel.ErrorTreeNode
 import io.snyk.plugin.ui.toolwindow.nodes.secondlevel.FileTreeNode
+import io.snyk.plugin.ui.toolwindow.nodes.secondlevel.InfoTreeNode
 import io.snyk.plugin.ui.toolwindow.nodes.secondlevel.SnykCodeFileTreeNode
 import snyk.common.ProductType
 import snyk.common.SnykError
@@ -45,7 +46,13 @@ private const val MAX_FILE_TREE_NODE_LENGTH = 60
 class SnykTreeCellRenderer : ColoredTreeCellRenderer() {
     @Suppress("UNCHECKED_CAST")
     override fun customizeCellRenderer(
-        tree: JTree, value: Any, selected: Boolean, expanded: Boolean, leaf: Boolean, row: Int, hasFocus: Boolean
+        tree: JTree,
+        value: Any,
+        selected: Boolean,
+        expanded: Boolean,
+        leaf: Boolean,
+        row: Int,
+        hasFocus: Boolean,
     ) {
         var nodeIcon: Icon? = null
         var text: String? = null
@@ -72,13 +79,16 @@ class SnykTreeCellRenderer : ColoredTreeCellRenderer() {
                         append(fileVulns.sanitizedTargetFile)
                         append(ProductType.OSS.getCountText(value.childCount))
                     }
-                text = toolTipText.apply {
-                    if (toolTipText.length > MAX_FILE_TREE_NODE_LENGTH) {
-                        "..." + this.substring(
-                            this.length - MAX_FILE_TREE_NODE_LENGTH, this.length
-                        )
+                text =
+                    toolTipText.apply {
+                        if (toolTipText.length > MAX_FILE_TREE_NODE_LENGTH) {
+                            "..." +
+                                this.substring(
+                                    this.length - MAX_FILE_TREE_NODE_LENGTH,
+                                    this.length,
+                                )
+                        }
                     }
-                }
 
                 val snykCachedResults = getSnykCachedResults(value.project)
                 if (snykCachedResults?.currentOssResults == null) {
@@ -112,8 +122,9 @@ class SnykTreeCellRenderer : ColoredTreeCellRenderer() {
                 val pair = updateTextTooltipAndIcon(file, productType, value, entry.value.first())
                 nodeIcon = pair.first
                 text = pair.second
-                val cachedIssues = getSnykCachedResultsForProduct(entry.key.project, productType)
-                    ?.filter { it.key.virtualFile == file.virtualFile } ?: emptyMap()
+                val cachedIssues =
+                    getSnykCachedResultsForProduct(entry.key.project, productType)
+                        ?.filter { it.key.virtualFile == file.virtualFile } ?: emptyMap()
                 if (cachedIssues.isEmpty()) {
                     attributes = SimpleTextAttributes.GRAYED_ATTRIBUTES
                     nodeIcon = getDisabledIcon(nodeIcon)
@@ -122,23 +133,28 @@ class SnykTreeCellRenderer : ColoredTreeCellRenderer() {
 
             is IacFileTreeNode -> {
                 val iacVulnerabilitiesForFile = value.userObject as IacIssuesForFile
-                nodeIcon = getIcon(
-                    iacVulnerabilitiesForFile.packageManager.lowercase(Locale.getDefault())
-                )
+                nodeIcon =
+                    getIcon(
+                        iacVulnerabilitiesForFile.packageManager.lowercase(Locale.getDefault()),
+                    )
                 val relativePath =
                     iacVulnerabilitiesForFile.relativePath ?: iacVulnerabilitiesForFile.targetFilePath
-                toolTipText = buildString {
-                    append(relativePath)
-                    append(ProductType.IAC.getCountText(value.childCount))
-                }
-
-                text = toolTipText.apply {
-                    if (toolTipText.length > MAX_FILE_TREE_NODE_LENGTH) {
-                        "..." + this.substring(
-                            this.length - MAX_FILE_TREE_NODE_LENGTH, this.length
-                        )
+                toolTipText =
+                    buildString {
+                        append(relativePath)
+                        append(ProductType.IAC.getCountText(value.childCount))
                     }
-                }
+
+                text =
+                    toolTipText.apply {
+                        if (toolTipText.length > MAX_FILE_TREE_NODE_LENGTH) {
+                            "..." +
+                                this.substring(
+                                    this.length - MAX_FILE_TREE_NODE_LENGTH,
+                                    this.length,
+                                )
+                        }
+                    }
 
                 val snykCachedResults = getSnykCachedResults(value.project)
                 if (snykCachedResults?.currentIacResult == null || iacVulnerabilitiesForFile.obsolete) {
@@ -167,16 +183,22 @@ class SnykTreeCellRenderer : ColoredTreeCellRenderer() {
                 nodeIcon = AllIcons.General.Error
             }
 
+            is InfoTreeNode -> {
+                val info = value.userObject as String
+                text = info
+            }
+
             is IacIssueTreeNode -> {
                 val issue = (value.userObject as IacIssue)
                 val snykCachedResults = getSnykCachedResults(value.project)
                 nodeIcon = SnykIcons.getSeverityIcon(issue.getSeverity())
                 val prefix = if (issue.lineNumber > 0) "line ${issue.lineNumber}: " else ""
-                text = prefix + issue.title + when {
-                    issue.ignored -> IGNORED_SUFFIX
-                    snykCachedResults?.currentIacResult == null || issue.obsolete -> OBSOLETE_SUFFIX
-                    else -> ""
-                }
+                text = prefix + issue.title +
+                    when {
+                        issue.ignored -> IGNORED_SUFFIX
+                        snykCachedResults?.currentIacResult == null || issue.obsolete -> OBSOLETE_SUFFIX
+                        else -> ""
+                    }
                 if (snykCachedResults?.currentIacResult == null || issue.ignored || issue.obsolete) {
                     attributes = SimpleTextAttributes.GRAYED_ATTRIBUTES
                     nodeIcon = getDisabledIcon(nodeIcon)
@@ -187,11 +209,12 @@ class SnykTreeCellRenderer : ColoredTreeCellRenderer() {
                 val issue = value.userObject as ContainerIssue
                 val snykCachedResults = getSnykCachedResults(value.project)
                 nodeIcon = SnykIcons.getSeverityIcon(issue.getSeverity())
-                text = issue.title + when {
-                    issue.ignored -> IGNORED_SUFFIX
-                    snykCachedResults?.currentContainerResult == null || issue.obsolete -> OBSOLETE_SUFFIX
-                    else -> ""
-                }
+                text = issue.title +
+                    when {
+                        issue.ignored -> IGNORED_SUFFIX
+                        snykCachedResults?.currentContainerResult == null || issue.obsolete -> OBSOLETE_SUFFIX
+                        else -> ""
+                    }
                 if (snykCachedResults?.currentContainerResult == null || issue.ignored || issue.obsolete) {
                     attributes = SimpleTextAttributes.GRAYED_ATTRIBUTES
                     nodeIcon = getDisabledIcon(nodeIcon)
@@ -207,11 +230,12 @@ class SnykTreeCellRenderer : ColoredTreeCellRenderer() {
                     nodeIcon = SnykIcons.OPEN_SOURCE_SECURITY_DISABLED
                     attributes = SimpleTextAttributes.GRAYED_ATTRIBUTES
                 }
-                text = if (settings.ossScanEnable) {
-                    value.userObject.toString()
-                } else {
-                    SnykToolWindowPanel.OSS_ROOT_TEXT + DISABLED_SUFFIX
-                }
+                text =
+                    if (settings.ossScanEnable) {
+                        value.userObject.toString()
+                    } else {
+                        SnykToolWindowPanel.OSS_ROOT_TEXT + DISABLED_SUFFIX
+                    }
             }
 
             is RootSecurityIssuesTreeNode -> {
@@ -223,12 +247,14 @@ class SnykTreeCellRenderer : ColoredTreeCellRenderer() {
                     nodeIcon = SnykIcons.SNYK_CODE_DISABLED
                     attributes = SimpleTextAttributes.GRAYED_ATTRIBUTES
                 }
-                text = if (settings.snykCodeSecurityIssuesScanEnable) {
-                    value.userObject.toString()
-                } else {
-                    SnykToolWindowPanel.CODE_SECURITY_ROOT_TEXT + snykCodeAvailabilityPostfix()
-                        .ifEmpty { DISABLED_SUFFIX }
-                }
+                text =
+                    if (settings.snykCodeSecurityIssuesScanEnable) {
+                        value.userObject.toString()
+                    } else {
+                        SnykToolWindowPanel.CODE_SECURITY_ROOT_TEXT +
+                            snykCodeAvailabilityPostfix()
+                                .ifEmpty { DISABLED_SUFFIX }
+                    }
             }
 
             is RootQualityIssuesTreeNode -> {
@@ -240,12 +266,14 @@ class SnykTreeCellRenderer : ColoredTreeCellRenderer() {
                     nodeIcon = SnykIcons.SNYK_CODE_DISABLED
                     attributes = SimpleTextAttributes.GRAYED_ATTRIBUTES
                 }
-                text = if (settings.snykCodeQualityIssuesScanEnable) {
-                    value.userObject.toString()
-                } else {
-                    SnykToolWindowPanel.CODE_QUALITY_ROOT_TEXT + snykCodeAvailabilityPostfix()
-                        .ifEmpty { DISABLED_SUFFIX }
-                }
+                text =
+                    if (settings.snykCodeQualityIssuesScanEnable) {
+                        value.userObject.toString()
+                    } else {
+                        SnykToolWindowPanel.CODE_QUALITY_ROOT_TEXT +
+                            snykCodeAvailabilityPostfix()
+                                .ifEmpty { DISABLED_SUFFIX }
+                    }
             }
 
             is RootIacIssuesTreeNode -> {
@@ -257,11 +285,12 @@ class SnykTreeCellRenderer : ColoredTreeCellRenderer() {
                     nodeIcon = SnykIcons.IAC_DISABLED
                     attributes = SimpleTextAttributes.GRAYED_ATTRIBUTES
                 }
-                text = if (settings.iacScanEnabled) {
-                    value.userObject.toString()
-                } else {
-                    SnykToolWindowPanel.IAC_ROOT_TEXT + DISABLED_SUFFIX
-                }
+                text =
+                    if (settings.iacScanEnabled) {
+                        value.userObject.toString()
+                    } else {
+                        SnykToolWindowPanel.IAC_ROOT_TEXT + DISABLED_SUFFIX
+                    }
             }
 
             is RootContainerIssuesTreeNode -> {
@@ -273,11 +302,12 @@ class SnykTreeCellRenderer : ColoredTreeCellRenderer() {
                     nodeIcon = SnykIcons.CONTAINER_DISABLED
                     attributes = SimpleTextAttributes.GRAYED_ATTRIBUTES
                 }
-                text = if (settings.containerScanEnabled) {
-                    value.userObject.toString()
-                } else {
-                    SnykToolWindowPanel.CONTAINER_ROOT_TEXT + DISABLED_SUFFIX
-                }
+                text =
+                    if (settings.containerScanEnabled) {
+                        value.userObject.toString()
+                    } else {
+                        SnykToolWindowPanel.CONTAINER_ROOT_TEXT + DISABLED_SUFFIX
+                    }
             }
         }
         icon = nodeIcon
@@ -289,7 +319,7 @@ class SnykTreeCellRenderer : ColoredTreeCellRenderer() {
         file: SnykFile,
         productType: ProductType,
         value: DefaultMutableTreeNode,
-        firstIssue: ScanIssue?
+        firstIssue: ScanIssue?,
     ): Pair<Icon?, String?> {
         val relativePath = file.relativePath
         toolTipText =
@@ -298,14 +328,16 @@ class SnykTreeCellRenderer : ColoredTreeCellRenderer() {
                 append(productType.getCountText(value.childCount))
             }
 
-        val text = toolTipText.apply {
-            if (toolTipText.length > MAX_FILE_TREE_NODE_LENGTH) {
-                "..." + this.substring(
-                    this.length - MAX_FILE_TREE_NODE_LENGTH, this.length
-                )
+        val text =
+            toolTipText.apply {
+                if (toolTipText.length > MAX_FILE_TREE_NODE_LENGTH) {
+                    "..." +
+                        this.substring(
+                            this.length - MAX_FILE_TREE_NODE_LENGTH,
+                            this.length,
+                        )
+                }
             }
-        }
-
 
         val nodeIcon = firstIssue?.icon() ?: file.icon
         return Pair(nodeIcon, text)

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/nodes/secondlevel/InfoTreeNode.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/nodes/secondlevel/InfoTreeNode.kt
@@ -1,0 +1,9 @@
+package io.snyk.plugin.ui.toolwindow.nodes.secondlevel
+
+import com.intellij.openapi.project.Project
+import javax.swing.tree.DefaultMutableTreeNode
+
+class InfoTreeNode(
+    private val info: String,
+    val project: Project,
+) : DefaultMutableTreeNode(info)

--- a/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
@@ -90,12 +90,13 @@ class LanguageServerWrapper(
             .newReentrantLock("initializeLock")
 
     internal val isInitialized: Boolean
-        get() = ::languageClient.isInitialized &&
-            ::languageServer.isInitialized &&
-            ::process.isInitialized &&
-            process.info().startInstant().isPresent &&
-            process.isAlive &&
-            !isInitializing.isLocked
+        get() =
+            ::languageClient.isInitialized &&
+                ::languageServer.isInitialized &&
+                ::process.isInitialized &&
+                process.info().startInstant().isPresent &&
+                process.isAlive &&
+                !isInitializing.isLocked
 
     @OptIn(DelicateCoroutinesApi::class)
     private fun initialize() {
@@ -107,7 +108,7 @@ class LanguageServerWrapper(
         try {
             val snykLanguageClient = SnykLanguageClient()
             languageClient = snykLanguageClient
-            val logLevel = if (snykLanguageClient.logger.isDebugEnabled) "trace" else "trace"
+            val logLevel = if (snykLanguageClient.logger.isDebugEnabled) "debug" else "trace"
             val cmd = listOf(lsPath, "language-server", "-l", logLevel)
 
             val processBuilder = ProcessBuilder(cmd)
@@ -198,29 +199,34 @@ class LanguageServerWrapper(
 
     private fun getCapabilities(): ClientCapabilities =
         ClientCapabilities().let { clientCapabilities ->
-            clientCapabilities.workspace = WorkspaceClientCapabilities().let { workspaceClientCapabilities ->
-                workspaceClientCapabilities.workspaceFolders = true
-                workspaceClientCapabilities.workspaceEdit =
-                    WorkspaceEditCapabilities().let { workspaceEditCapabilities ->
-                        workspaceEditCapabilities.documentChanges = true
-                        workspaceEditCapabilities
-                    }
-                workspaceClientCapabilities.codeLens = CodeLensWorkspaceCapabilities(true)
-                workspaceClientCapabilities.inlineValue = InlineValueWorkspaceCapabilities(true)
-                workspaceClientCapabilities.applyEdit = true
-                workspaceClientCapabilities
-            }
-            clientCapabilities.textDocument = TextDocumentClientCapabilities().let {
-                it.codeLens = CodeLensCapabilities(true)
-                it.codeAction = CodeActionCapabilities(true)
-                it.diagnostic = DiagnosticCapabilities(true)
+            clientCapabilities.workspace =
+                WorkspaceClientCapabilities().let { workspaceClientCapabilities ->
+                    workspaceClientCapabilities.workspaceFolders = true
+                    workspaceClientCapabilities.workspaceEdit =
+                        WorkspaceEditCapabilities().let { workspaceEditCapabilities ->
+                            workspaceEditCapabilities.documentChanges = true
+                            workspaceEditCapabilities
+                        }
+                    workspaceClientCapabilities.codeLens = CodeLensWorkspaceCapabilities(true)
+                    workspaceClientCapabilities.inlineValue = InlineValueWorkspaceCapabilities(true)
+                    workspaceClientCapabilities.applyEdit = true
+                    workspaceClientCapabilities
+                }
+            clientCapabilities.textDocument =
+                TextDocumentClientCapabilities().let {
+                    it.codeLens = CodeLensCapabilities(true)
+                    it.codeAction = CodeActionCapabilities(true)
+                    it.diagnostic = DiagnosticCapabilities(true)
 
-                it
-            }
+                    it
+                }
             return clientCapabilities
         }
 
-    fun updateWorkspaceFolders(added: Set<WorkspaceFolder>, removed: Set<WorkspaceFolder>) {
+    fun updateWorkspaceFolders(
+        added: Set<WorkspaceFolder>,
+        removed: Set<WorkspaceFolder>,
+    ) {
         try {
             if (!ensureLanguageServerInitialized()) return
             val params = DidChangeWorkspaceFoldersParams()
@@ -291,7 +297,6 @@ class LanguageServerWrapper(
                 logger.info("Feature flag $featureFlag is disabled. Message: $userMessage")
                 return false
             }
-
         } catch (e: Exception) {
             logger.warn("Error while checking feature flag: ${e.message}", e)
             return false
@@ -321,12 +326,13 @@ class LanguageServerWrapper(
             endpoint = getEndpointUrl(),
             cliPath = getCliFile().absolutePath,
             token = ps.token,
-            filterSeverity = SeverityFilter(
-                critical = ps.criticalSeverityEnabled,
-                high = ps.highSeverityEnabled,
-                medium = ps.mediumSeverityEnabled,
-                low = ps.lowSeverityEnabled
-            ),
+            filterSeverity =
+                SeverityFilter(
+                    critical = ps.criticalSeverityEnabled,
+                    high = ps.highSeverityEnabled,
+                    medium = ps.mediumSeverityEnabled,
+                    low = ps.lowSeverityEnabled,
+                ),
             enableTrustedFoldersFeature = "false",
             scanningMode = if (!ps.scanOnSave) "manual" else "auto",
             integrationName = pluginInfo.integrationName,
@@ -360,15 +366,17 @@ class LanguageServerWrapper(
 
         getSnykTaskQueueService(project)?.waitUntilCliDownloadedIfNeeded()
         if (!isCliInstalled()) {
-            val message = "Snyk Language Server version $protocolVersion " +
-                "does not match the required version ${pluginSettings().requiredLsProtocolVersion}. " +
-                "Please update the Snyk CLI."
+            val message =
+                "Snyk Language Server version $protocolVersion " +
+                    "does not match the required version ${pluginSettings().requiredLsProtocolVersion}. " +
+                    "Please update the Snyk CLI."
             SnykBalloonNotificationHelper.showError(message, project)
         }
     }
 
     companion object {
         private var INSTANCE: LanguageServerWrapper? = null
+
         fun getInstance() = INSTANCE ?: LanguageServerWrapper().also { INSTANCE = it }
     }
 }

--- a/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
@@ -107,7 +107,7 @@ class LanguageServerWrapper(
         try {
             val snykLanguageClient = SnykLanguageClient()
             languageClient = snykLanguageClient
-            val logLevel = if (snykLanguageClient.logger.isDebugEnabled) "debug" else "info"
+            val logLevel = if (snykLanguageClient.logger.isDebugEnabled) "trace" else "trace"
             val cmd = listOf(lsPath, "language-server", "-l", logLevel)
 
             val processBuilder = ProcessBuilder(cmd)

--- a/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
@@ -108,7 +108,7 @@ class LanguageServerWrapper(
         try {
             val snykLanguageClient = SnykLanguageClient()
             languageClient = snykLanguageClient
-            val logLevel = if (snykLanguageClient.logger.isDebugEnabled) "debug" else "trace"
+            val logLevel = if (snykLanguageClient.logger.isDebugEnabled) "debug" else "info"
             val cmd = listOf(lsPath, "language-server", "-l", logLevel)
 
             val processBuilder = ProcessBuilder(cmd)

--- a/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLSlTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLSlTest.kt
@@ -1,0 +1,157 @@
+package io.snyk.plugin.ui.toolwindow
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.intellij.ui.treeStructure.Tree
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import io.snyk.plugin.Severity
+import io.snyk.plugin.pluginSettings
+import io.snyk.plugin.resetSettings
+import io.snyk.plugin.ui.toolwindow.nodes.root.RootOssTreeNode
+import io.snyk.plugin.ui.toolwindow.nodes.root.RootQualityIssuesTreeNode
+import io.snyk.plugin.ui.toolwindow.nodes.root.RootSecurityIssuesTreeNode
+import junit.framework.TestCase
+import org.eclipse.lsp4j.Position
+import org.eclipse.lsp4j.Range
+import snyk.common.ProductType
+import snyk.common.lsp.CommitChangeLine
+import snyk.common.lsp.DataFlow
+import snyk.common.lsp.ExampleCommitFix
+import snyk.common.lsp.ScanIssue
+import javax.swing.JTree
+import javax.swing.tree.DefaultMutableTreeNode
+
+class SnykToolWindowSnykScanListenerLSlTest : BasePlatformTestCase() {
+    private lateinit var cut: SnykToolWindowSnykScanListenerLS
+    private lateinit var snykToolWindowPanel: SnykToolWindowPanel
+    private lateinit var vulnerabilitiesTree: JTree
+    private lateinit var rootTreeNode: DefaultMutableTreeNode
+    private lateinit var rootOssIssuesTreeNode: DefaultMutableTreeNode
+    private lateinit var rootSecurityIssuesTreeNode: DefaultMutableTreeNode
+    private lateinit var rootQualityIssuesTreeNode: DefaultMutableTreeNode
+
+    override fun setUp() {
+        super.setUp()
+        unmockkAll()
+        resetSettings(project)
+
+        snykToolWindowPanel = SnykToolWindowPanel(project)
+        rootOssIssuesTreeNode = RootOssTreeNode(project)
+        rootSecurityIssuesTreeNode = RootSecurityIssuesTreeNode(project)
+        rootQualityIssuesTreeNode = RootQualityIssuesTreeNode(project)
+    }
+
+    private fun mockScanIssues(): List<ScanIssue> {
+        val issue = mockk<ScanIssue>(relaxed = true)
+        every { issue.getSeverityAsEnum() } returns Severity.CRITICAL
+        every { issue.title() } returns "title"
+        every { issue.issueNaming() } returns "issueNaming"
+        every { issue.isIgnored() } returns false
+        every { issue.cwes() } returns emptyList()
+        every { issue.cves() } returns emptyList()
+        every { issue.cvssV3() } returns null
+        every { issue.cvssScore() } returns null
+        every { issue.id() } returns "id"
+        every { issue.additionalData.getProductType() } returns ProductType.CODE_SECURITY
+        every { issue.additionalData.message } returns "Test message"
+        every { issue.additionalData.repoDatasetSize } returns 1
+        every { issue.additionalData.exampleCommitFixes } returns
+            listOf(
+                ExampleCommitFix(
+                    "https://commit-url",
+                    listOf(
+                        CommitChangeLine("1", 1, "lineChange"),
+                    ),
+                ),
+            )
+        every {
+            issue.additionalData.dataFlow
+        } returns listOf(DataFlow(0, getTestDataPath(), Range(Position(1, 1), Position(1, 1)), ""))
+        return listOf(issue)
+    }
+
+    fun `testAddInfoTreeNodes does not add new tree nodes for non-code security`() {
+        pluginSettings().isGlobalIgnoresFeatureEnabled = true
+
+        // setup the rootTreeNode from scratch
+        rootTreeNode = DefaultMutableTreeNode("")
+        rootTreeNode.add(rootOssIssuesTreeNode)
+        rootTreeNode.add(rootSecurityIssuesTreeNode)
+        rootTreeNode.add(rootQualityIssuesTreeNode)
+        vulnerabilitiesTree =
+            Tree(rootTreeNode).apply {
+                this.isRootVisible = false
+            }
+
+        cut =
+            SnykToolWindowSnykScanListenerLS(
+                project,
+                snykToolWindowPanel,
+                vulnerabilitiesTree,
+                rootSecurityIssuesTreeNode,
+                rootQualityIssuesTreeNode,
+                rootOssIssuesTreeNode,
+            )
+
+        TestCase.assertEquals(3, rootTreeNode.childCount)
+        cut.addInfoTreeNodes(rootTreeNode, mockScanIssues())
+        TestCase.assertEquals(3, rootTreeNode.childCount)
+    }
+
+    fun `testAddInfoTreeNodes does not add new tree nodes for code security if ignores are not enabled`() {
+        pluginSettings().isGlobalIgnoresFeatureEnabled = false
+
+        // setup the rootTreeNode from scratch
+        rootTreeNode = DefaultMutableTreeNode("")
+        rootTreeNode.add(rootOssIssuesTreeNode)
+        rootTreeNode.add(rootSecurityIssuesTreeNode)
+        rootTreeNode.add(rootQualityIssuesTreeNode)
+        vulnerabilitiesTree =
+            Tree(rootTreeNode).apply {
+                this.isRootVisible = false
+            }
+
+        cut =
+            SnykToolWindowSnykScanListenerLS(
+                project,
+                snykToolWindowPanel,
+                vulnerabilitiesTree,
+                rootSecurityIssuesTreeNode,
+                rootQualityIssuesTreeNode,
+                rootOssIssuesTreeNode,
+            )
+
+        TestCase.assertEquals(3, rootTreeNode.childCount)
+        cut.addInfoTreeNodes(rootTreeNode, mockScanIssues(), 1, 1)
+        TestCase.assertEquals(3, rootTreeNode.childCount)
+    }
+
+    fun `testAddInfoTreeNodes adds new tree nodes for code security if ignores are enabled`() {
+        pluginSettings().isGlobalIgnoresFeatureEnabled = true
+
+        // setup the rootTreeNode from scratch
+        rootTreeNode = DefaultMutableTreeNode("")
+        rootTreeNode.add(rootOssIssuesTreeNode)
+        rootTreeNode.add(rootSecurityIssuesTreeNode)
+        rootTreeNode.add(rootQualityIssuesTreeNode)
+        vulnerabilitiesTree =
+            Tree(rootTreeNode).apply {
+                this.isRootVisible = false
+            }
+
+        cut =
+            SnykToolWindowSnykScanListenerLS(
+                project,
+                snykToolWindowPanel,
+                vulnerabilitiesTree,
+                rootSecurityIssuesTreeNode,
+                rootQualityIssuesTreeNode,
+                rootOssIssuesTreeNode,
+            )
+
+        TestCase.assertEquals(3, rootTreeNode.childCount)
+        cut.addInfoTreeNodes(rootTreeNode, mockScanIssues(), 1, 1)
+        TestCase.assertEquals(5, rootTreeNode.childCount)
+    }
+}


### PR DESCRIPTION
### Description

This adds some warning messages in the Tree View that are already in VSCode for the following cases:
- no vulns found
- the number of vulns found
- the number of vulns that can be fixed by DeepCode AI

It also adds info about the number of ignored issues, so they are made aware of that.

Compared to https://github.com/snyk/vscode-extension/pull/464, we won't show the warnings if all the issue view options are unselected. That is because we don't allow customers to unselect all of them.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs
<img width="547" alt="Screenshot 2024-05-31 at 18 52 18" src="https://github.com/snyk/snyk-intellij-plugin/assets/81559517/2dcde712-5250-4889-924a-2328f3bed037">

