### PR TITLE
fix: Update Integration Environment and Version

### DIFF
--- a/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
@@ -10,7 +10,6 @@ import com.intellij.openapi.vfs.VirtualFile
 import io.snyk.plugin.getCliFile
 import io.snyk.plugin.getContentRootVirtualFiles
 import io.snyk.plugin.getSnykTaskQueueService
-import io.snyk.plugin.getUserAgentString
 import io.snyk.plugin.isCliInstalled
 import io.snyk.plugin.isSnykIaCLSEnabled
 import io.snyk.plugin.isSnykOSSLSEnabled
@@ -187,8 +186,7 @@ class LanguageServerWrapper(
 
         val params = InitializeParams()
         params.processId = ProcessHandle.current().pid().toInt()
-        val clientInfo = getUserAgentString()
-        params.clientInfo = ClientInfo(clientInfo, "lsp4j")
+        params.clientInfo = ClientInfo(pluginInfo.integrationEnvironment, pluginInfo.integrationEnvironmentVersion)
         params.initializationOptions = getSettings()
         params.workspaceFolders = workspaceFolders
         params.capabilities = getCapabilities()


### PR DESCRIPTION
### Description

Environment Name/Version set by the IntelliJ Plugin. I couldn’t find the problem and it was not always reproducible but it showed like the below:

`"environment": {"name":"GOLAND/2023.3.4 (Mac OS X;aarch64) JETBRAINS_IDE/2.8.1 (GOLAND/2023.3.4)","version":"lsp4j"}`

The name should just be GOLAND and the version should be 2023.3.4  not lsp4j.

### Checklist

- [x] Tests added and all succeed
- [x] Linted


### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
