### PR TITLE
fix: tab font size for consistent ignores [IDE-382]

### DIFF
--- a/src/main/resources/stylesheets/snyk_code_suggestion.scss
+++ b/src/main/resources/stylesheets/snyk_code_suggestion.scss
@@ -44,18 +44,16 @@ a,
   font-size: 0.75rem;
 }
 
-
 .issue-overview-header,
 .ignore-details-header,
 .data-flow-header,
 .ai-fix-header,
 .example-fixes-header {
-  font-size: 0.75rem;
+  font-size: 0.85rem;
 }
 
 .severity-type-container {
   font-size: 0.85rem;
-
 }
 
 .data-flow-clickable-row {
@@ -71,7 +69,7 @@ a,
 }
 
 .tab-item{
-  font-size: 0.75rem;
+  font-size: 0.85rem;
 }
 
 .tab-item-icon path {


### PR DESCRIPTION
### Description

Increases the font size in the tabs so it matches the [designs](https://www.figma.com/design/hcI2QHUtHfcIjgrpYlMqff/Holistic-Ignores?node-id=2292-63654&t=iIxZM8o3pih8EY4M-0) more. 

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs
<img width="815" alt="Screenshot 2024-06-11 at 17 45 27" src="https://github.com/snyk/snyk-intellij-plugin/assets/81559517/ab5fae66-024c-4787-8950-a6345d7d2049">
