### PR TITLE
fix: don't display IaC ignored errors in balloon notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [2.8.5]
 ### Fixed
-- don't display balloon warnings if IaC error is ignored (e.g. no IaC files found) 
+- don't display balloon warnings if IaC error is ignored (e.g. no IaC files found)
+- don't output amplitude errors as warning, only debug
 
 ## [2.8.4]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Snyk Security Changelog
 
+## [2.8.5]
+### Fixed
+- don't display balloon warnings if IaC error is ignored (e.g. no IaC files found) 
+
 ## [2.8.4]
 ### Fixed
-- dont use kotlin specific convenience function that may cause errors on non kotlin IDEs
+- don't use kotlin specific convenience function that may cause errors on non kotlin IDEs
 
 ## [2.8.3]
 

--- a/src/main/kotlin/io/snyk/plugin/SnykBulkFileListener.kt
+++ b/src/main/kotlin/io/snyk/plugin/SnykBulkFileListener.kt
@@ -3,6 +3,7 @@ package io.snyk.plugin
 import com.intellij.ide.impl.ProjectUtil
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.isFile
 import com.intellij.openapi.vfs.newvfs.BulkFileListener
 import com.intellij.openapi.vfs.newvfs.events.VFileContentChangeEvent
 import com.intellij.openapi.vfs.newvfs.events.VFileCopyEvent
@@ -121,6 +122,7 @@ abstract class SnykBulkFileListener : BulkFileListener {
             .filter { eventsFilter.invoke(it) }
             .mapNotNull(eventToVirtualFileTransformer)
             .filter(VirtualFile::isValid)
+            .filter(VirtualFile::isFile)
             .toSet()
     }
 

--- a/src/main/kotlin/io/snyk/plugin/SnykProjectManagerListener.kt
+++ b/src/main/kotlin/io/snyk/plugin/SnykProjectManagerListener.kt
@@ -19,7 +19,7 @@ class SnykProjectManagerListener : ProjectManagerListener {
     override fun projectClosing(project: Project) {
         val closingTask = object : Backgroundable(project, "Project closing ${project.name}") {
             override fun run(indicator: ProgressIndicator) {
-                // limit clean up to 5s
+                // limit clean up to TIMEOUT
                 try {
                     threadPool.submit {
                         // lets all running ProgressIndicators release MUTEX first

--- a/src/main/kotlin/io/snyk/plugin/SnykProjectManagerListener.kt
+++ b/src/main/kotlin/io/snyk/plugin/SnykProjectManagerListener.kt
@@ -7,18 +7,21 @@ import com.intellij.openapi.progress.Task.Backgroundable
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManagerListener
 import snyk.common.lsp.LanguageServerWrapper
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
 private const val TIMEOUT = 1L
 
 class SnykProjectManagerListener : ProjectManagerListener {
+    val threadPool: ExecutorService = Executors.newWorkStealingPool()
+
     override fun projectClosing(project: Project) {
         val closingTask = object : Backgroundable(project, "Project closing ${project.name}") {
             override fun run(indicator: ProgressIndicator) {
                 // limit clean up to 5s
                 try {
-                    Executors.newCachedThreadPool().submit {
+                    threadPool.submit {
                         // lets all running ProgressIndicators release MUTEX first
                         val ls = LanguageServerWrapper.getInstance()
                         if (ls.isInitialized) {

--- a/src/main/kotlin/io/snyk/plugin/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/Utils.kt
@@ -315,15 +315,16 @@ fun findPsiFileIgnoringExceptions(virtualFile: VirtualFile, project: Project): P
     }
 
 fun refreshAnnotationsForOpenFiles(project: Project) {
-    if (project.isDisposed) return
+    if (project.isDisposed || ApplicationManager.getApplication().isDisposed) return
     VirtualFileManager.getInstance().asyncRefresh()
 
     val openFiles = FileEditorManager.getInstance(project).openFiles
 
     ApplicationManager.getApplication().invokeLater {
-        project.service<CodeVisionHost>().invalidateProvider(CodeVisionHost.LensInvalidateSignal(null))
+        if (!project.isDisposed) {
+            project.service<CodeVisionHost>().invalidateProvider(CodeVisionHost.LensInvalidateSignal(null))
+        }
     }
-
     openFiles.forEach {
         val psiFile = findPsiFileIgnoringExceptions(it, project)
         if (psiFile != null) {

--- a/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
@@ -263,6 +263,7 @@ class SnykTaskQueueService(val project: Project) {
 
     fun downloadLatestRelease(force: Boolean = false) {
         // abort even before submitting a task
+        if (project.isDisposed || ApplicationManager.getApplication().isDisposed) return
         val cliDownloader = getSnykCliDownloaderService()
         if (!pluginSettings().manageBinariesAutomatically) {
             if (!isCliInstalled()) {

--- a/src/main/kotlin/io/snyk/plugin/services/download/CliDownloaderService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/download/CliDownloaderService.kt
@@ -32,7 +32,7 @@ class SnykCliDownloaderService {
 
     private var currentProgressIndicator: ProgressIndicator? = null
 
-    fun isCliDownloading() = currentProgressIndicator != null
+    fun isCliDownloading() = currentProgressIndicator != null && !ApplicationManager.getApplication().isDisposed
 
     fun stopCliDownload() = currentProgressIndicator?.let {
         it.cancel()

--- a/src/main/kotlin/io/snyk/plugin/snykcode/SnykCodeBulkFileListener.kt
+++ b/src/main/kotlin/io/snyk/plugin/snykcode/SnykCodeBulkFileListener.kt
@@ -43,7 +43,8 @@ class SnykCodeBulkFileListener : SnykBulkFileListener() {
             if (DumbService.getInstance(project).isDumb) return@runAsync
 
             val languageServerWrapper = LanguageServerWrapper.getInstance()
-            if (!languageServerWrapper.isInitialized) return@runAsync
+            if (languageServerWrapper.isDisposed() || !languageServerWrapper.isInitialized) return@runAsync
+
             val languageServer = languageServerWrapper.languageServer
             val cache = getSnykCachedResults(project)?.currentSnykCodeResultsLS
             val filesAffected = toSnykFileSet(project, virtualFilesAffected)

--- a/src/main/kotlin/io/snyk/plugin/snykcode/SnykCodeBulkFileListener.kt
+++ b/src/main/kotlin/io/snyk/plugin/snykcode/SnykCodeBulkFileListener.kt
@@ -2,12 +2,11 @@ package io.snyk.plugin.snykcode
 
 import com.google.common.cache.CacheBuilder
 import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
-import com.intellij.openapi.application.runInEdt
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.logger
-import com.intellij.openapi.progress.ProgressIndicator
-import com.intellij.openapi.progress.ProgressManager
-import com.intellij.openapi.progress.Task.Backgroundable
+import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.openapi.vfs.newvfs.events.VFileEvent
@@ -18,7 +17,9 @@ import io.snyk.plugin.toLanguageServerURL
 import io.snyk.plugin.toSnykFileSet
 import org.eclipse.lsp4j.DidSaveTextDocumentParams
 import org.eclipse.lsp4j.TextDocumentIdentifier
+import org.jetbrains.concurrency.runAsync
 import snyk.common.lsp.LanguageServerWrapper
+import java.io.File
 import java.time.Duration
 
 class SnykCodeBulkFileListener : SnykBulkFileListener() {
@@ -28,50 +29,70 @@ class SnykCodeBulkFileListener : SnykBulkFileListener() {
         CacheBuilder.newBuilder()
             .expireAfterWrite(Duration.ofMillis(1000)).build<String, Boolean>()
 
+    private val blackListedDirectories =
+        setOf(".idea", ".git", ".hg", ".svn")
+
     override fun before(project: Project, virtualFilesAffected: Set<VirtualFile>) = Unit
 
     override fun after(project: Project, virtualFilesAffected: Set<VirtualFile>) {
         if (virtualFilesAffected.isEmpty()) return
-        ProgressManager.getInstance().run(object : Backgroundable(
-            project,
-            "Snyk: forwarding save event to Language Server"
-        ) {
-            override fun run(indicator: ProgressIndicator) {
-                val languageServerWrapper = LanguageServerWrapper.getInstance()
-                if (!languageServerWrapper.isInitialized) return
-                val languageServer = languageServerWrapper.languageServer
-                val cache = getSnykCachedResults(project)?.currentSnykCodeResultsLS ?: return
-                val filesAffected = toSnykFileSet(project, virtualFilesAffected)
-                for (file in filesAffected) {
-                    val virtualFile = file.virtualFile
-                    if (!shouldProcess(virtualFile)) continue
-                    cache.remove(file)
-                    val param =
-                        DidSaveTextDocumentParams(
-                            TextDocumentIdentifier(virtualFile.toLanguageServerURL()),
-                            virtualFile.readText()
-                        )
-                    languageServer.textDocumentService.didSave(param)
-                }
 
-                VirtualFileManager.getInstance().asyncRefresh()
-                runInEdt { DaemonCodeAnalyzer.getInstance(project).restart() }
+        runAsync {
+            if (ApplicationManager.getApplication().isDisposed) return@runAsync
+            if (project.isDisposed) return@runAsync
+            if (DumbService.getInstance(project).isDumb) return@runAsync
+
+            val languageServerWrapper = LanguageServerWrapper.getInstance()
+            if (!languageServerWrapper.isInitialized) return@runAsync
+            val languageServer = languageServerWrapper.languageServer
+            val cache = getSnykCachedResults(project)?.currentSnykCodeResultsLS
+            val filesAffected = toSnykFileSet(project, virtualFilesAffected)
+            val index = ProjectFileIndex.getInstance(project)
+
+            for (file in filesAffected) {
+                val virtualFile = file.virtualFile
+                if (!shouldProcess(virtualFile, index, project)) continue
+                cache?.remove(file)
+                val param =
+                    DidSaveTextDocumentParams(
+                        TextDocumentIdentifier(virtualFile.toLanguageServerURL()),
+                        virtualFile.readText()
+                    )
+                languageServer.textDocumentService.didSave(param)
             }
-        })
-
+            VirtualFileManager.getInstance().asyncRefresh()
+            DaemonCodeAnalyzer.getInstance(project).restart()
+        }
     }
 
-    private fun shouldProcess(file: VirtualFile): Boolean {
-        val inCache = debounceFileCache.getIfPresent(file.path)
+    private fun shouldProcess(file: VirtualFile, index: ProjectFileIndex, project: Project): Boolean {
+        var shouldProcess = false
+        val application = ApplicationManager.getApplication()
+        if (application.isDisposed) return false
+        if (project.isDisposed) return false
+        if (DumbService.getInstance(project).isDumb) shouldProcess = false
 
-        return if (inCache != null) {
-            logger<SnykCodeBulkFileListener>().info("not forwarding file event to ls, debouncing")
-            false
-        } else {
-            debounceFileCache.put(file.path, true)
-            logger<SnykCodeBulkFileListener>().info("forwarding file event to ls, not debouncing")
-            true
+        application.runReadAction {
+            val inCache = debounceFileCache.getIfPresent(file.path)
+            if (inCache != null) {
+                shouldProcess = false
+            } else {
+                debounceFileCache.put(file.path, true)
+                if (index.isInContent(file) && !isInBlacklistedParentDir(file)) {
+                    shouldProcess = true
+                } else {
+                    shouldProcess = false
+                    return@runReadAction
+                }
+            }
         }
+        return shouldProcess
+    }
+
+    private fun isInBlacklistedParentDir(file: VirtualFile): Boolean {
+        val path = file.path.split(File.separatorChar)
+            .filter { blackListedDirectories.contains(it.trimEnd(File.separatorChar)) }
+        return path.isNotEmpty()
     }
 
     override fun forwardEvents(events: MutableList<out VFileEvent>) = Unit

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
@@ -85,6 +85,7 @@ import snyk.container.ui.ContainerIssueTreeNode
 import snyk.iac.IacError
 import snyk.iac.IacIssue
 import snyk.iac.IacResult
+import snyk.iac.ignorableErrorCodes
 import snyk.iac.ui.toolwindow.IacFileTreeNode
 import snyk.iac.ui.toolwindow.IacIssueTreeNode
 import snyk.oss.OssResult
@@ -247,7 +248,7 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
                     override fun scanningIacError(snykError: SnykError) {
                         var iacResultsCount: Int? = null
                         ApplicationManager.getApplication().invokeLater {
-                            if (snykError.code == IacError.NO_IAC_FILES_CODE) {
+                            if (snykError.code != null && ignorableErrorCodes.contains(snykError.code)) {
                                 iacResultsCount = NODE_NOT_SUPPORTED_STATE
                             } else {
                                 SnykBalloonNotificationHelper.showError(snykError.message, project)

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLS.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLS.kt
@@ -38,11 +38,18 @@ class SnykToolWindowSnykScanListenerLS(
     private val rootQualityIssuesTreeNode: DefaultMutableTreeNode,
     private val rootOssIssuesTreeNode: DefaultMutableTreeNode,
 ) : SnykScanListenerLS, Disposable {
+    var disposed = false; get() { return project.isDisposed || ApplicationManager.getApplication().isDisposed || field }
     init {
         Disposer.register(SnykPluginDisposable.getInstance(project), this)
     }
+
+    override fun dispose() {
+        disposed = true
+    }
+    fun isDisposed() = disposed
+
     override fun scanningStarted(snykScan: SnykScanParams) {
-        if (ApplicationManager.getApplication().isDisposed || project.isDisposed) return
+        if (disposed) return
         ApplicationManager.getApplication().invokeLater {
             rootSecurityIssuesTreeNode.userObject = "$CODE_SECURITY_ROOT_TEXT (scanning...)"
             rootQualityIssuesTreeNode.userObject = "$CODE_QUALITY_ROOT_TEXT (scanning...)"
@@ -51,7 +58,7 @@ class SnykToolWindowSnykScanListenerLS(
     }
 
     override fun scanningSnykCodeFinished(snykResults: Map<SnykFile, List<ScanIssue>>) {
-        if (ApplicationManager.getApplication().isDisposed || project.isDisposed) return
+        if (disposed) return
         ApplicationManager.getApplication().invokeLater {
             this.snykToolWindowPanel.navigateToSourceEnabled = false
             displaySnykCodeResults(snykResults)
@@ -61,7 +68,7 @@ class SnykToolWindowSnykScanListenerLS(
     }
 
     override fun scanningOssFinished(snykResults: Map<SnykFile, List<ScanIssue>>) {
-        if (ApplicationManager.getApplication().isDisposed || project.isDisposed) return
+        if (disposed) return
         ApplicationManager.getApplication().invokeLater {
             this.snykToolWindowPanel.navigateToSourceEnabled = false
             displayOssResults(snykResults)
@@ -73,6 +80,7 @@ class SnykToolWindowSnykScanListenerLS(
     override fun scanningError(snykScan: SnykScanParams) = Unit
 
     fun displaySnykCodeResults(snykResults: Map<SnykFile, List<ScanIssue>>) {
+        if (disposed) return
         if (getSnykCachedResults(project)?.currentSnykCodeError != null) return
 
         val settings = pluginSettings()
@@ -109,6 +117,7 @@ class SnykToolWindowSnykScanListenerLS(
     }
 
     fun displayOssResults(snykResults: Map<SnykFile, List<ScanIssue>>) {
+        if (disposed) return
         if (getSnykCachedResults(project)?.currentOssError != null) return
 
         val settings = pluginSettings()
@@ -188,6 +197,8 @@ class SnykToolWindowSnykScanListenerLS(
         securityIssuesCount: Int? = null,
         fixableIssuesCount: Int? = null,
     ) {
+        if (disposed) return
+
         // only add these info tree nodes to Snyk Code security vulnerabilities for now
         if (securityIssuesCount == null) {
             return
@@ -277,8 +288,5 @@ class SnykToolWindowSnykScanListenerLS(
         val medium = results.values.flatten().count { it.getSeverityAsEnum() == Severity.MEDIUM }
         val low = results.values.flatten().count { it.getSeverityAsEnum() == Severity.LOW }
         return ": $high high, $medium medium, $low low"
-    }
-
-    override fun dispose() {
     }
 }

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLS.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLS.kt
@@ -38,7 +38,7 @@ class SnykToolWindowSnykScanListenerLS(
     private val rootQualityIssuesTreeNode: DefaultMutableTreeNode,
     private val rootOssIssuesTreeNode: DefaultMutableTreeNode,
 ) : SnykScanListenerLS, Disposable {
-    var disposed = false; get() { return project.isDisposed || ApplicationManager.getApplication().isDisposed || field }
+    private var disposed = false; get() { return project.isDisposed || ApplicationManager.getApplication().isDisposed || field }
     init {
         Disposer.register(SnykPluginDisposable.getInstance(project), this)
     }

--- a/src/main/kotlin/snyk/amplitude/api/AmplitudeExperimentApiClient.kt
+++ b/src/main/kotlin/snyk/amplitude/api/AmplitudeExperimentApiClient.kt
@@ -28,7 +28,8 @@ class AmplitudeExperimentApiClient private constructor(
         return try {
             val response = variantService().sdkVardata(user).execute()
             if (!response.isSuccessful) {
-                log.warn("Error response: $response")
+                // we don't really care
+                log.debug("Error response: $response")
                 return emptyMap()
             }
 
@@ -36,10 +37,10 @@ class AmplitudeExperimentApiClient private constructor(
             log.debug("Received variants: $variants")
             variants ?: emptyMap()
         } catch (e: IOException) {
-            log.warn("Could not fetch variants because of network communication error with amplitude server", e)
+            log.debug("Could not fetch variants because of network communication error with amplitude server. Continuing without", e)
             emptyMap()
         } catch (e: Exception) {
-            log.warn("Could not fetch variants because of unexpected error", e)
+            log.info("Could not fetch variants because of unexpected error. Continuing without.", e)
             emptyMap()
         }
     }

--- a/src/main/kotlin/snyk/common/AnnotatorCommon.kt
+++ b/src/main/kotlin/snyk/common/AnnotatorCommon.kt
@@ -1,5 +1,6 @@
 package snyk.common
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.invokeLater
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
@@ -28,6 +29,8 @@ object AnnotatorCommon {
         pluginSettings().hasSeverityEnabled(severity) || severity == Severity.UNKNOWN
 
     fun initRefreshing(project: Project) {
+        if (project.isDisposed) return
+        if (ApplicationManager.getApplication().isDisposed) return
         logger.debug("Initializing annotations refresh listener")
         project.messageBus.connect()
             .subscribe(

--- a/src/main/kotlin/snyk/common/SnykCachedResults.kt
+++ b/src/main/kotlin/snyk/common/SnykCachedResults.kt
@@ -23,7 +23,7 @@ import snyk.oss.OssResult
 @Service(Service.Level.PROJECT)
 class SnykCachedResults(val project: Project) : Disposable {
 
-    var disposed = false; get() { return project.isDisposed || ApplicationManager.getApplication().isDisposed || field }
+    private var disposed = false; get() { return project.isDisposed || ApplicationManager.getApplication().isDisposed || field }
     init {
         Disposer.register(SnykPluginDisposable.getInstance(project), this)
     }
@@ -135,19 +135,19 @@ class SnykCachedResults(val project: Project) : Disposable {
                 override fun scanningSnykCodeFinished(snykResults: Map<SnykFile, List<ScanIssue>>) {
                     currentSnykCodeResultsLS.clear()
                     currentSnykCodeResultsLS.putAll(snykResults)
-                    logger.info("scanning finished for project ${project.name}, assigning cache.")
+                    logger.info("Snyk Code: scanning finished for project ${project.name}, assigning cache.")
                 }
 
                 override fun scanningOssFinished(snykResults: Map<SnykFile, List<ScanIssue>>) {
                     currentOSSResultsLS.clear()
                     currentOSSResultsLS.putAll(snykResults)
-                    logger.info("scanning finished for project ${project.name}, assigning cache.")
+                    logger.info("Snyk OSS: scanning finished for project ${project.name}, assigning cache.")
                 }
 
                 override fun scanningError(snykScan: SnykScanParams) {
                     SnykBalloonNotificationHelper
                         .showError(
-                            "scanning error for project ${project.name}, emptying cache.Data: $snykScan",
+                            "scanning error for project ${project.name}. Data: $snykScan",
                             project
                         )
                 }

--- a/src/main/kotlin/snyk/common/SnykCachedResults.kt
+++ b/src/main/kotlin/snyk/common/SnykCachedResults.kt
@@ -1,6 +1,7 @@
 package snyk.common
 
 import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
@@ -21,6 +22,18 @@ import snyk.oss.OssResult
 
 @Service(Service.Level.PROJECT)
 class SnykCachedResults(val project: Project) : Disposable {
+
+    var disposed = false; get() { return project.isDisposed || ApplicationManager.getApplication().isDisposed || field }
+    init {
+        Disposer.register(SnykPluginDisposable.getInstance(project), this)
+    }
+
+    override fun dispose() {
+        disposed = true
+        cleanCaches()
+    }
+    fun isDisposed() = disposed
+
 
     val currentSnykCodeResultsLS: MutableMap<SnykFile, List<ScanIssue>> = mutableMapOf()
     val currentOSSResultsLS: MutableMap<SnykFile, List<ScanIssue>> = mutableMapOf()
@@ -140,14 +153,6 @@ class SnykCachedResults(val project: Project) : Disposable {
                 }
             }
         )
-    }
-
-    init {
-        Disposer.register(SnykPluginDisposable.getInstance(project), this)
-    }
-
-    override fun dispose() {
-        cleanCaches()
     }
 }
 

--- a/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
@@ -404,6 +404,7 @@ class LanguageServerWrapper(
     }
 
     override fun dispose() {
+        disposed = true
         shutdown()
     }
 }

--- a/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
@@ -194,7 +194,7 @@ class LanguageServerWrapper(
         return normalizedRoots
     }
 
-    private fun sendInitializeMessage() {
+    fun sendInitializeMessage() {
         val workspaceFolders = determineWorkspaceFolders()
 
         val params = InitializeParams()

--- a/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
@@ -68,6 +68,9 @@ class LanguageServerWrapper(
     private var initializeResult: InitializeResult? = null
     private val gson = com.google.gson.Gson()
     private var disposed = false ; get() { return ApplicationManager.getApplication().isDisposed || field }
+
+    fun isDisposed() = disposed
+
     val logger = Logger.getInstance("Snyk Language Server")
 
     /**

--- a/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
+++ b/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
@@ -58,6 +58,9 @@ import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 
+/**
+ * Processes Language Server requests and notifications from the server to the IDE
+ */
 class SnykLanguageClient : LanguageClient, Disposable {
     val logger = Logger.getInstance("Snyk Language Server")
     private var disposed = false; get() { return ApplicationManager.getApplication().isDisposed || field }

--- a/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
+++ b/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
@@ -61,7 +61,7 @@ import java.util.concurrent.TimeUnit
 class SnykLanguageClient : LanguageClient, Disposable {
     val logger = Logger.getInstance("Snyk Language Server")
     private var disposed = false; get() { return ApplicationManager.getApplication().isDisposed || field }
-
+    fun isDisposed() = disposed
     private val progresses: Cache<String, ProgressIndicator> =
         Caffeine.newBuilder()
             .expireAfterAccess(10, TimeUnit.SECONDS)

--- a/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
+++ b/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
@@ -17,7 +17,7 @@ import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectLocator
-import com.intellij.openapi.project.getOpenedProjects
+import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.util.io.toNioPathOrNull
 import com.intellij.openapi.vfs.VirtualFileManager
@@ -116,7 +116,7 @@ class SnykLanguageClient : LanguageClient, Disposable {
         val completedFuture: CompletableFuture<Void> = CompletableFuture.completedFuture(null)
         if (disposed) return completedFuture
 
-        ProjectUtil.getOpenProjects()
+        ProjectManager.getInstance().openProjects
             .filter { !it.isDisposed }
             .forEach { project ->
                 ReadAction.run<RuntimeException> {
@@ -199,7 +199,7 @@ class SnykLanguageClient : LanguageClient, Disposable {
     }
 
     private fun getProjectsForFolderPath(folderPath: String) =
-        getOpenedProjects().filter {
+        ProjectManager.getInstance().openProjects.filter {
             it.getContentRootVirtualFiles()
                 .contains(folderPath.toVirtualFile())
         }
@@ -239,7 +239,7 @@ class SnykLanguageClient : LanguageClient, Disposable {
 
         pluginSettings().token = param.token
 
-        ProjectUtil.getOpenProjects().forEach {
+        ProjectManager.getInstance().openProjects.forEach {
             LanguageServerWrapper.getInstance().sendScanCommand(it)
         }
 

--- a/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
+++ b/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
@@ -109,11 +109,16 @@ class SnykLanguageClient() : LanguageClient {
 
     private fun refreshUI(): CompletableFuture<Void> {
         val completedFuture: CompletableFuture<Void> = CompletableFuture.completedFuture(null)
-        ProjectUtil.getOpenProjects().forEach { project ->
-            ReadAction.run<RuntimeException> {
-                refreshAnnotationsForOpenFiles(project)
+
+        if (ApplicationManager.getApplication().isDisposed) return completedFuture
+
+        ProjectUtil.getOpenProjects()
+            .filter { !it.isDisposed }
+            .forEach { project ->
+                ReadAction.run<RuntimeException> {
+                    refreshAnnotationsForOpenFiles(project)
+                }
             }
-        }
         VirtualFileManager.getInstance().asyncRefresh()
         return completedFuture
     }

--- a/src/main/kotlin/snyk/iac/IacResult.kt
+++ b/src/main/kotlin/snyk/iac/IacResult.kt
@@ -7,6 +7,7 @@ import snyk.common.SnykError
 // List of IaC errors that are not relevant for users. E.g. IaC fails to parse a non-IaC file for certain reasons.
 // These should not be surfaced.
 val ignorableErrorCodes = intArrayOf(
+    IacError.NO_IAC_FILES_CODE,
     IacError.INVALID_JSON_FILE_ERROR,
     IacError.INVALID_YAML_FILE_ERROR,
     IacError.FAILED_TO_PARSE_INPUT,

--- a/src/main/kotlin/snyk/iac/IacResult.kt
+++ b/src/main/kotlin/snyk/iac/IacResult.kt
@@ -6,7 +6,7 @@ import snyk.common.SnykError
 
 // List of IaC errors that are not relevant for users. E.g. IaC fails to parse a non-IaC file for certain reasons.
 // These should not be surfaced.
-private val ignorableErrorCodes = intArrayOf(
+val ignorableErrorCodes = intArrayOf(
     IacError.INVALID_JSON_FILE_ERROR,
     IacError.INVALID_YAML_FILE_ERROR,
     IacError.FAILED_TO_PARSE_INPUT,

--- a/src/main/kotlin/snyk/trust/TrustedProjects.kt
+++ b/src/main/kotlin/snyk/trust/TrustedProjects.kt
@@ -2,6 +2,7 @@
 
 package snyk.trust
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.invokeAndWaitIfNeeded
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
@@ -20,6 +21,7 @@ private val LOG = Logger.getInstance("snyk.trust.TrustedProjects")
  * @return `false` if the user chose not to scan the project at all; `true` otherwise
  */
 fun confirmScanningAndSetWorkspaceTrustedStateIfNeeded(project: Project): Boolean {
+    if (project.isDisposed || ApplicationManager.getApplication().isDisposed) return false
     val paths = project.getContentRootPaths()
     val trustService = service<WorkspaceTrustService>()
     for (path in paths) {

--- a/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanelIntegTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanelIntegTest.kt
@@ -274,6 +274,7 @@ class SnykToolWindowPanelIntegTest : HeavyPlatformTestCase() {
 
         val snykError =
             SnykError(SnykToolWindowPanel.NO_IAC_FILES, project.basePath.toString(), IacError.NO_IAC_FILES_CODE)
+
         val snykErrorControl = SnykError("control", project.basePath.toString())
 
         scanPublisher.scanningIacError(snykErrorControl)
@@ -282,8 +283,9 @@ class SnykToolWindowPanelIntegTest : HeavyPlatformTestCase() {
 
         // flow and internal state check
         verify(exactly = 1, timeout = 2000) {
-            SnykBalloonNotificationHelper.showError(any(), project)
+            SnykBalloonNotificationHelper.showError(snykErrorControl.message, project)
         }
+
         assertTrue(getSnykCachedResults(project)?.currentIacError == null)
         assertTrue(getSnykCachedResults(project)?.currentIacResult == null)
         // node check

--- a/src/test/kotlin/snyk/common/lsp/SnykLanguageClientTest.kt
+++ b/src/test/kotlin/snyk/common/lsp/SnykLanguageClientTest.kt
@@ -1,0 +1,157 @@
+package snyk.common.lsp
+
+import com.intellij.openapi.application.Application
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.project.DumbService
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.ProjectManager
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import io.snyk.plugin.pluginSettings
+import io.snyk.plugin.services.SnykApplicationSettingsStateService
+import io.snyk.plugin.ui.toolwindow.SnykPluginDisposable
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+import org.junit.Assert.*
+import snyk.pluginInfo
+import snyk.trust.WorkspaceTrustService
+import kotlin.io.path.Path
+
+class SnykLanguageClientTest {
+    private lateinit var cut: SnykLanguageClient
+    private var snykPluginDisposable = SnykPluginDisposable()
+
+    private val applicationMock: Application = mockk()
+    private val projectMock: Project = mockk()
+    private val settings = SnykApplicationSettingsStateService()
+    private val trustServiceMock = mockk<WorkspaceTrustService>(relaxed = true)
+    private val dumbServiceMock = mockk<DumbService>()
+    private val projectManagerMock = mockk<ProjectManager>()
+
+    @Before
+    fun setUp() {
+        unmockkAll()
+        mockkStatic("io.snyk.plugin.UtilsKt")
+        mockkStatic(ApplicationManager::class)
+
+        every { ApplicationManager.getApplication() } returns applicationMock
+        every { applicationMock.getService(WorkspaceTrustService::class.java) } returns trustServiceMock
+
+        every { applicationMock.getService(ProjectManager::class.java) } returns projectManagerMock
+        every { applicationMock.getService(SnykPluginDisposable::class.java) } returns snykPluginDisposable
+        every { applicationMock.isDisposed } returns false
+
+        every { projectManagerMock.openProjects } returns arrayOf(projectMock)
+        every { projectMock.isDisposed } returns false
+        every { projectMock.getService(DumbService::class.java) } returns dumbServiceMock
+        every { dumbServiceMock.isDumb } returns false
+
+        every { pluginSettings() } returns settings
+        mockkStatic("snyk.PluginInformationKt")
+        every { pluginInfo } returns mockk(relaxed = true)
+        every { pluginInfo.integrationName } returns "Snyk Intellij Plugin"
+        every { pluginInfo.integrationVersion } returns "2.4.61"
+        every { pluginInfo.integrationEnvironment } returns "IntelliJ IDEA"
+        every { pluginInfo.integrationEnvironmentVersion } returns "2020.3.2"
+
+        snykPluginDisposable = SnykPluginDisposable()
+
+        cut = SnykLanguageClient()
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun applyEdit() {
+    }
+
+    @Test
+    fun `refreshCodeLenses does not run when disposed`() {
+        every { applicationMock.isDisposed } returns true
+
+        cut.refreshCodeLenses()
+
+        verify(exactly = 0) { projectManagerMock.openProjects }
+    }
+
+    @Test
+    fun `refreshInlineValues does not run when disposed`() {
+        every { applicationMock.isDisposed } returns true
+
+        cut.refreshCodeLenses()
+
+        verify(exactly = 0) { projectManagerMock.openProjects }
+    }
+
+    @Test
+    fun `snykScan does not run when disposed`() {
+        every { applicationMock.isDisposed } returns true
+        val mockIssue = mockk<ScanIssue>()
+        val param = SnykScanParams("success", "code", "testFolder", listOf(mockIssue))
+
+        cut.snykScan(param)
+
+        // you cannot display / forward the issues without mapping them to open projects
+        verify (exactly = 0) { projectManagerMock.openProjects }
+    }
+
+    @Test
+    fun `hasAuthenticated does not run when disposed`(){
+        every { applicationMock.isDisposed } returns true
+
+        val unexpected = "abc"
+        cut.hasAuthenticated(HasAuthenticatedParam(unexpected))
+
+        assertNotEquals(unexpected, settings.token)
+    }
+
+    @Test
+    fun `addTrustedPaths should not run when disposed`() {
+        every { applicationMock.isDisposed } returns true
+
+        val unexpected = "abc"
+        cut.addTrustedPaths(SnykTrustedFoldersParams(listOf(unexpected)))
+
+        verify (exactly = 0){ applicationMock.getService(WorkspaceTrustService::class.java) }
+    }
+
+    @Test
+    fun `addTrustedPaths should add path to trusted paths`() {
+        val path = "abc"
+        cut.addTrustedPaths(SnykTrustedFoldersParams(listOf(path)))
+
+        verify { trustServiceMock.addTrustedPath(eq(Path(path))) }
+    }
+
+    @Test
+    fun createProgress() {
+    }
+
+    @Test
+    fun notifyProgress() {
+    }
+
+    @Test
+    fun logTrace() {
+    }
+
+    @Test
+    fun showMessage() {
+    }
+
+    @Test
+    fun showMessageRequest() {
+    }
+
+    @Test
+    fun logMessage() {
+    }
+}

--- a/src/test/kotlin/snyk/common/lsp/SnykLanguageClientTest.kt
+++ b/src/test/kotlin/snyk/common/lsp/SnykLanguageClientTest.kt
@@ -130,28 +130,4 @@ class SnykLanguageClientTest {
 
         verify { trustServiceMock.addTrustedPath(eq(Path(path))) }
     }
-
-    @Test
-    fun createProgress() {
-    }
-
-    @Test
-    fun notifyProgress() {
-    }
-
-    @Test
-    fun logTrace() {
-    }
-
-    @Test
-    fun showMessage() {
-    }
-
-    @Test
-    fun showMessageRequest() {
-    }
-
-    @Test
-    fun logMessage() {
-    }
 }


### PR DESCRIPTION
### Description
- don't display IaC ignored errors in balloon notification
- don't process directories in file listener
- don't output amplitude connection problems as error in logs
- add disposal handling
- add dumb mode (don't run during indexing) handling
- added a few unit (not integration) tests

This fixes https://plugins.jetbrains.com/plugin/10972-snyk-security/reviews#review=101648 (at least the display)

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

You can see, no balloon notification:

![image](https://github.com/snyk/snyk-intellij-plugin/assets/20150761/52e832ca-e683-42fe-9a7c-1986f0c02883)