### PR TITLE
fix: automatically migrate old endpoint [IDE-407]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [2.8.6]
 ### Fixed
-- automatically migrate old-format endpoint to https://api.xxx.snyk.io endpoint and save it in settings
+- automatically migrate old-format endpoint to https://api.xxx.snyk.io endpoint and save it in settings. Also, add tooltip to custom endpoint field explaining the format.
 
 ## [2.8.5]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Snyk Security Changelog
 
+## [2.8.6]
+### Fixed
+- automatically migrate old-format endpoint to https://api.xxx.snyk.io endpoint and save it in settings
+
 ## [2.8.5]
 ### Fixed
 - don't display balloon warnings if IaC error is ignored (e.g. no IaC files found)

--- a/src/main/kotlin/io/snyk/plugin/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/Utils.kt
@@ -169,6 +169,13 @@ fun <L : Any> getSyncPublisher(project: Project, topic: Topic<L>): L? {
 val <T> List<T>.head: T
     get() = first()
 
+fun isAdditionalParametersValid(params: String?): Boolean {
+    params.isNullOrEmpty() && return true
+
+    val list = params!!.split(" ")
+    return !list.contains("-d")
+}
+
 fun isUrlValid(url: String?): Boolean {
     url.isNullOrEmpty() && return true
 

--- a/src/main/kotlin/io/snyk/plugin/ui/SnykSettingsDialog.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/SnykSettingsDialog.kt
@@ -78,7 +78,7 @@ class SnykSettingsDialog(
     private val tokenTextField = JBPasswordField()
     private val receiveTokenButton = JButton("Connect IDE to Snyk")
     private val customEndpointTextField = JTextField()
-    private val organizationTextField: JTextField = JTextField().apply { toolTipText = "The UUID of your organization" }
+    private val organizationTextField: JTextField = JTextField().apply { toolTipText = "The UUID of your organization or the org stub" }
     private val ignoreUnknownCACheckBox: JCheckBox = JCheckBox().apply { toolTipText = "Enabling this causes SSL certificate validation to be disabled" }
     private val usageAnalyticsCheckBox: JCheckBox = JCheckBox().apply { toolTipText = "If enabled, send analytics to Amplitude" }
     private val crashReportingCheckBox = JCheckBox().apply { toolTipText = "If enabled, send error reports to Sentry" }

--- a/src/main/kotlin/io/snyk/plugin/ui/SnykSettingsDialog.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/SnykSettingsDialog.kt
@@ -215,7 +215,7 @@ class SnykSettingsDialog(
         )
 
         val customEndpointLabel = JLabel("Custom endpoint:")
-        val customEndpointTooltip = "The correct endpoint format is https://api.xxx.snyk.io, e.g. https://api.eu.snyk.io"
+        val customEndpointTooltip = "The correct endpoint format is https://api.xxx.snyk[gov].io, e.g. https://api.eu.snyk.io"
         customEndpointLabel.toolTipText = customEndpointTooltip
         customEndpointLabel.labelFor = customEndpointTextField
         customEndpointTextField.toolTipText = customEndpointTooltip
@@ -645,7 +645,7 @@ class SnykSettingsDialog(
 
     private fun initializeValidation() {
         setupValidation(tokenTextField, "Invalid token", ::isTokenValid)
-        setupValidation(customEndpointTextField, "Invalid custom endpoint URL", ::isUrlValid)
+        setupValidation(customEndpointTextField, "Invalid custom endpoint URL, please use https://api.xxx.snyk[gov].io", ::isUrlValid)
     }
 
     private fun setupValidation(textField: JTextField, message: String, isValidText: (sourceStr: String?) -> Boolean) {

--- a/src/main/kotlin/io/snyk/plugin/ui/SnykSettingsDialog.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/SnykSettingsDialog.kt
@@ -215,7 +215,10 @@ class SnykSettingsDialog(
         )
 
         val customEndpointLabel = JLabel("Custom endpoint:")
+        val customEndpointTooltip = "The correct endpoint format is https://api.xxx.snyk.io, e.g. https://api.eu.snyk.io"
+        customEndpointLabel.toolTipText = customEndpointTooltip
         customEndpointLabel.labelFor = customEndpointTextField
+        customEndpointTextField.toolTipText = customEndpointTooltip
         generalSettingsPanel.add(
             customEndpointLabel,
             baseGridConstraintsAnchorWest(

--- a/src/main/kotlin/io/snyk/plugin/ui/SnykSettingsDialog.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/SnykSettingsDialog.kt
@@ -32,6 +32,7 @@ import io.snyk.plugin.events.SnykCliDownloadListener
 import io.snyk.plugin.getCliFile
 import io.snyk.plugin.getSnykCliAuthenticationService
 import io.snyk.plugin.getSnykCliDownloaderService
+import io.snyk.plugin.isAdditionalParametersValid
 import io.snyk.plugin.isProjectSettingsAvailable
 import io.snyk.plugin.isUrlValid
 import io.snyk.plugin.pluginSettings
@@ -77,12 +78,12 @@ class SnykSettingsDialog(
     private val tokenTextField = JBPasswordField()
     private val receiveTokenButton = JButton("Connect IDE to Snyk")
     private val customEndpointTextField = JTextField()
-    private val organizationTextField: JTextField = JTextField()
-    private val ignoreUnknownCACheckBox: JCheckBox = JCheckBox()
-    private val usageAnalyticsCheckBox: JCheckBox = JCheckBox()
-    private val crashReportingCheckBox = JCheckBox()
-    private val scanOnSaveCheckbox = JCheckBox()
-    private val additionalParametersTextField: JTextField = ExpandableTextField()
+    private val organizationTextField: JTextField = JTextField().apply { toolTipText = "The UUID of your organization" }
+    private val ignoreUnknownCACheckBox: JCheckBox = JCheckBox().apply { toolTipText = "Enabling this causes SSL certificate validation to be disabled" }
+    private val usageAnalyticsCheckBox: JCheckBox = JCheckBox().apply { toolTipText = "If enabled, send analytics to Amplitude" }
+    private val crashReportingCheckBox = JCheckBox().apply { toolTipText = "If enabled, send error reports to Sentry" }
+    private val scanOnSaveCheckbox = JCheckBox().apply { toolTipText = "If enabled, automatically scan on save, start-up and configuration change" }
+    private val additionalParametersTextField: JTextField = ExpandableTextField().apply { toolTipText = "--all-projects is already defaulted, -d causes problems" }
 
     private val scanTypesPanelOuter = ScanTypesPanel(project, rootPanel)
     private val codeAlertPanel = scanTypesPanelOuter.codeAlertPanel
@@ -646,6 +647,7 @@ class SnykSettingsDialog(
     private fun initializeValidation() {
         setupValidation(tokenTextField, "Invalid token", ::isTokenValid)
         setupValidation(customEndpointTextField, "Invalid custom endpoint URL, please use https://api.xxx.snyk[gov].io", ::isUrlValid)
+        setupValidation(additionalParametersTextField, "The -d option is not supported by the Snyk IntelliJ plugin", ::isAdditionalParametersValid)
     }
 
     private fun setupValidation(textField: JTextField, message: String, isValidText: (sourceStr: String?) -> Boolean) {

--- a/src/main/kotlin/snyk/common/CustomEndpoints.kt
+++ b/src/main/kotlin/snyk/common/CustomEndpoints.kt
@@ -92,12 +92,17 @@ fun isSnykCodeAvailable(endpointUrl: String?): Boolean {
  */
 internal fun resolveCustomEndpoint(endpointUrl: String?): String {
     return if (endpointUrl.isNullOrEmpty()) {
-        "https://api.snyk.io"
+        val normalizedEndpointURL = "https://api.snyk.io"
+        pluginSettings().customEndpointUrl = normalizedEndpointURL
+        normalizedEndpointURL
     } else {
-        endpointUrl
+        val normalizedEndpointURL = endpointUrl
             .removeTrailingSlashesIfPresent()
             .removeSuffix("/api")
+            .replace("https://snyk.io", "https://api.snyk.io")
             .replace("https://app.", "https://api.")
+        pluginSettings().customEndpointUrl = normalizedEndpointURL
+        normalizedEndpointURL
     }
 }
 

--- a/src/test/kotlin/io/snyk/plugin/UtilsKtTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/UtilsKtTest.kt
@@ -74,4 +74,10 @@ class UtilsKtTest {
 
         assertFalse(virtualFile.urlContainsDriveLetter())
     }
+
+    @Test
+    fun isAdditionalParametersValid() {
+        assertFalse(isAdditionalParametersValid("-d"))
+        assertTrue(isAdditionalParametersValid("asdf"))
+    }
 }

--- a/src/test/kotlin/io/snyk/plugin/cli/ConsoleCommandRunnerTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/cli/ConsoleCommandRunnerTest.kt
@@ -116,7 +116,7 @@ class ConsoleCommandRunnerTest : LightPlatformTestCase() {
         val oldEndpoint = pluginSettings().customEndpointUrl
         try {
             val generalCommandLine = GeneralCommandLine("")
-            val expectedEndpoint = "https://snyk.io/v1"
+            val expectedEndpoint = "https://api.snyk.io/v1"
             generalCommandLine.environment["INTERNAL_OAUTH_TOKEN_STORAGE"] = "{}"
             assertFalse(URI(expectedEndpoint).isOauth())
 


### PR DESCRIPTION
### Description

- Converts the old endpoint syntax to the new and saves it in the settings. Also saves the default endpoint explicitly, if no endpoint is given.
- Adds tooltips to explain the right endpoint format and other settings.
- Adds a validation to not enter `-d` as additional parameter, which is not supported by IntelliJ

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

![image](https://github.com/snyk/snyk-intellij-plugin/assets/20150761/98ba45f4-a54a-4179-836a-a8780ad58b11)
![image](https://github.com/snyk/snyk-intellij-plugin/assets/20150761/626e639a-ebd3-4a4b-8e26-a9a93047116b)
![image](https://github.com/snyk/snyk-intellij-plugin/assets/20150761/a46ed8ca-0af0-4aa2-a8f3-0e0dc5a08594)

