### PR TITLE
refactor: CSS rules to support IDE themes for Code Issue panel [IDE-294]

### DIFF
--- a/src/main/resources/stylesheets/snyk_code_suggestion.scss
+++ b/src/main/resources/stylesheets/snyk_code_suggestion.scss
@@ -97,3 +97,13 @@ a,
 .ignore-action-container {
   display: none;
 }
+
+.light .dark-only,
+.high-contrast.high-contrast-light .dark-only {
+  display: none;
+}
+
+.dark .light-only,
+.high-contrast:not(.high-contrast-light) .light-only {
+  display: none;
+}


### PR DESCRIPTION
### Description

In the HTML template served by LSP, we have defined two SVG icons for the arrow navigation: one is shown for light themes the the other is shown for dark themes. To be able to toggle between them, we take advantage of the class names added by VSCode: `vscode-dark` and `vscode-light`. The work that enables this is [here](https://github.com/snyk/vscode-extension/pull/472).

This PR for IntelliJ follows this same idea: we added the CSS rules to be applied depending on the IDE theme selection. We do so by defining `.dark-only`, `.light-only` and `high-contrast` rules and they get applied by manipulating the DOM adding the correct class name to the body of document.

This PR also fixed the code diff colour for high contrast themes.

Related to the migration from tab-based to arrow-based navigation for Code Issue panel (see PR [#540](https://github.com/snyk/snyk-ls/pull/540)).


### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

- Arrows and diff blocks

|Dark|Light|High Contrast|
|-|-|-|
|![dark-theme](https://github.com/snyk/snyk-intellij-plugin/assets/1948377/cf657b1d-a961-4d02-b72f-9ab374ce2889)|![light-theme](https://github.com/snyk/snyk-intellij-plugin/assets/1948377/c798a6a3-2964-4652-bb74-ce09b52f29fb)|![high-contrast-theme](https://github.com/snyk/snyk-intellij-plugin/assets/1948377/e019fbd0-7d67-4a47-a8b5-9a23329b21f5)|




