### PR TITLE
fix: ignore counts in info tree node [IDE-413]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Snyk Security Changelog
 
+## [2.8.7]
+### Fixes
+- fix issue counts when there are ignores and add some warnings about the Issue View Options
+
 ## [2.8.6]
 ### Fixed
 - automatically migrate old-format endpoint to https://api.xxx.snyk.io endpoint and save it in settings. Also, add tooltip to custom endpoint field explaining the format.

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
@@ -82,7 +82,6 @@ import snyk.container.ContainerResult
 import snyk.container.ContainerService
 import snyk.container.ui.ContainerImageTreeNode
 import snyk.container.ui.ContainerIssueTreeNode
-import snyk.iac.IacError
 import snyk.iac.IacIssue
 import snyk.iac.IacResult
 import snyk.iac.ignorableErrorCodes
@@ -134,18 +133,20 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
 
     var navigateToSourceEnabled = true
 
-    private val treeNodeStub = object : RootTreeNodeBase("", project) {
-        override fun getSnykError(): SnykError? = null
-    }
+    private val treeNodeStub =
+        object : RootTreeNodeBase("", project) {
+            override fun getSnykError(): SnykError? = null
+        }
 
     init {
         vulnerabilitiesTree.cellRenderer = SnykTreeCellRenderer()
         layout = BorderLayout()
 
         // convertor interface seems to be still used in TreeSpeedSearch, although it's marked obsolete
-        val convertor = Convertor<TreePath, String> {
-            TreeSpeedSearch.NODE_PRESENTATION_FUNCTION.apply(it)
-        }
+        val convertor =
+            Convertor<TreePath, String> {
+                TreeSpeedSearch.NODE_PRESENTATION_FUNCTION.apply(it)
+            }
         TreeUIHelper.getInstance().installTreeSpeedSearch(vulnerabilitiesTree, convertor, true)
 
         createTreeAndDescriptionPanel()
@@ -155,27 +156,28 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
             updateDescriptionPanelBySelectedTreeNode()
         }
 
-        val scanListenerLS = run {
-            val scanListener = SnykToolWindowSnykScanListenerLS(
-                project,
-                this,
-                vulnerabilitiesTree,
-                rootSecurityIssuesTreeNode,
-                rootQualityIssuesTreeNode,
-                rootOssTreeNode
-            )
-            project.messageBus.connect(this).subscribe(
-                SnykScanListenerLS.SNYK_SCAN_TOPIC,
+        val scanListenerLS =
+            run {
+                val scanListener =
+                    SnykToolWindowSnykScanListenerLS(
+                        project,
+                        this,
+                        vulnerabilitiesTree,
+                        rootSecurityIssuesTreeNode,
+                        rootQualityIssuesTreeNode,
+                        rootOssTreeNode,
+                    )
+                project.messageBus.connect(this).subscribe(
+                    SnykScanListenerLS.SNYK_SCAN_TOPIC,
+                    scanListener,
+                )
                 scanListener
-            )
-            scanListener
-        }
+            }
 
         project.messageBus.connect(this)
             .subscribe(
                 SnykScanListener.SNYK_SCAN_TOPIC,
                 object : SnykScanListener {
-
                     override fun scanningStarted() {
                         rootOssTreeNode.originalCliErrorMessage = null
                         ApplicationManager.getApplication().invokeLater {
@@ -210,7 +212,10 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
                         }
                     }
 
-                    private fun notifyAboutErrorsIfNeeded(prodType: ProductType, cliResult: CliResult<*>) {
+                    private fun notifyAboutErrorsIfNeeded(
+                        prodType: ProductType,
+                        cliResult: CliResult<*>,
+                    ) {
                         if (cliResult.isSuccessful() && cliResult.errors.isNotEmpty()) {
                             val message =
                                 "${prodType.productSelectionName} analysis finished with errors for some artifacts:\n" +
@@ -220,7 +225,7 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
                                 project,
                                 NotificationAction.createSimpleExpiring("Open Snyk Tool Window") {
                                     snykToolWindow(project)?.show()
-                                }
+                                },
                             )
                         }
                     }
@@ -280,7 +285,7 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
                             refreshAnnotationsForOpenFiles(project)
                         }
                     }
-                }
+                },
             )
 
         project.messageBus.connect(this)
@@ -311,14 +316,13 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
                             snykCachedResults.currentContainerResult?.let { displayContainerResults(it) }
                         }
                     }
-                }
+                },
             )
 
         ApplicationManager.getApplication().messageBus.connect(this)
             .subscribe(
                 SnykCliDownloadListener.CLI_DOWNLOAD_TOPIC,
                 object : SnykCliDownloadListener {
-
                     override fun checkCliExistsFinished() =
                         ApplicationManager.getApplication().invokeLater {
                             chooseMainPanelToDisplay()
@@ -326,19 +330,18 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
 
                     override fun cliDownloadStarted() =
                         ApplicationManager.getApplication().invokeLater { displayDownloadMessage() }
-                }
+                },
             )
 
         project.messageBus.connect(this)
             .subscribe(
                 SnykSettingsListener.SNYK_SETTINGS_TOPIC,
                 object : SnykSettingsListener {
-
                     override fun settingsChanged() =
                         ApplicationManager.getApplication().invokeLater {
                             chooseMainPanelToDisplay()
                         }
-                }
+                },
             )
 
         project.messageBus.connect(this)
@@ -349,18 +352,18 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
                         wasOssRunning: Boolean,
                         wasSnykCodeRunning: Boolean,
                         wasIacRunning: Boolean,
-                        wasContainerRunning: Boolean
+                        wasContainerRunning: Boolean,
                     ) = ApplicationManager.getApplication().invokeLater {
                         updateTreeRootNodesPresentation(
                             ossResultsCount = if (wasOssRunning) NODE_INITIAL_STATE else null,
                             securityIssuesCount = if (wasSnykCodeRunning) NODE_INITIAL_STATE else null,
                             qualityIssuesCount = if (wasSnykCodeRunning) NODE_INITIAL_STATE else null,
                             iacResultsCount = if (wasIacRunning) NODE_INITIAL_STATE else null,
-                            containerResultsCount = if (wasContainerRunning) NODE_INITIAL_STATE else null
+                            containerResultsCount = if (wasContainerRunning) NODE_INITIAL_STATE else null,
                         )
                         displayEmptyDescription()
                     }
-                }
+                },
             )
     }
 
@@ -383,7 +386,7 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
                     is DescriptionHolderTreeNode -> {
                         descriptionPanel.add(
                             selectedNode.getDescriptionPanel(logEventNeeded = !capturedSmartReloadMode),
-                            BorderLayout.CENTER
+                            BorderLayout.CENTER,
                         )
                     }
 
@@ -404,6 +407,7 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
     }
 
     var isDisposed: Boolean = false
+
     override fun dispose() {
         isDisposed = true
     }
@@ -419,7 +423,6 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
             }
         }
 
-
         ApplicationManager.getApplication().invokeLater {
             doCleanUi(true)
             refreshAnnotationsForOpenFiles(project)
@@ -433,7 +436,7 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
             securityIssuesCount = NODE_INITIAL_STATE,
             qualityIssuesCount = NODE_INITIAL_STATE,
             iacResultsCount = NODE_INITIAL_STATE,
-            containerResultsCount = NODE_INITIAL_STATE
+            containerResultsCount = NODE_INITIAL_STATE,
         )
         (vulnerabilitiesTree.model as DefaultTreeModel).reload()
 
@@ -443,13 +446,14 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
     }
 
     private fun removeAllChildren(
-        rootNodesToUpdate: List<DefaultMutableTreeNode> = listOf(
-            rootOssTreeNode,
-            rootSecurityIssuesTreeNode,
-            rootQualityIssuesTreeNode,
-            rootIacIssuesTreeNode,
-            rootContainerIssuesTreeNode
-        )
+        rootNodesToUpdate: List<DefaultMutableTreeNode> =
+            listOf(
+                rootOssTreeNode,
+                rootSecurityIssuesTreeNode,
+                rootQualityIssuesTreeNode,
+                rootIacIssuesTreeNode,
+                rootContainerIssuesTreeNode,
+            ),
     ) {
         rootNodesToUpdate.forEach {
             it.removeAllChildren()
@@ -484,7 +488,7 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
                 .analysisType(getSelectedProducts(pluginSettings()))
                 .ide(AnalysisIsTriggered.Ide.JETBRAINS)
                 .triggeredByUser(true)
-                .build()
+                .build(),
         )
 
         getSnykTaskQueueService(project)?.scan(false)
@@ -502,7 +506,7 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
         getSnykAnalyticsService().logWelcomeIsViewed(
             WelcomeIsViewed.builder()
                 .ide(JETBRAINS)
-                .build()
+                .build(),
         )
     }
 
@@ -539,11 +543,12 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
         }
     }
 
-    private fun noIssuesInAnyProductFound() = rootOssTreeNode.childCount == 0 &&
-        rootSecurityIssuesTreeNode.childCount == 0 &&
-        rootQualityIssuesTreeNode.childCount == 0 &&
-        rootIacIssuesTreeNode.childCount == 0 &&
-        rootContainerIssuesTreeNode.childCount == 0
+    private fun noIssuesInAnyProductFound() =
+        rootOssTreeNode.childCount == 0 &&
+            rootSecurityIssuesTreeNode.childCount == 0 &&
+            rootQualityIssuesTreeNode.childCount == 0 &&
+            rootIacIssuesTreeNode.childCount == 0 &&
+            rootContainerIssuesTreeNode.childCount == 0
 
     /**
      * public only for Tests
@@ -557,7 +562,7 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
         qualityIssuesCount: Int? = null,
         iacResultsCount: Int? = null,
         containerResultsCount: Int? = null,
-        addHMLPostfix: String = ""
+        addHMLPostfix: String = "",
     ) {
         val settings = pluginSettings()
 
@@ -566,74 +571,99 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
                 getSnykCachedResults(project)?.currentOssError != null -> "$OSS_ROOT_TEXT (error)"
                 isOssRunning(project) && settings.ossScanEnable -> "$OSS_ROOT_TEXT (scanning...)"
 
-                else -> ossResultsCount?.let { count ->
-                    OSS_ROOT_TEXT + when {
-                        count == NODE_INITIAL_STATE -> ""
-                        count == 0 -> NO_ISSUES_FOUND_TEXT
-                        count > 0 -> ProductType.OSS.getCountText(count, isUniqueCount = true) + addHMLPostfix
-                        count == NODE_NOT_SUPPORTED_STATE -> NO_SUPPORTED_PACKAGE_MANAGER_FOUND
-                        else -> throw IllegalStateException("ResultsCount is meaningful")
+                else ->
+                    ossResultsCount?.let { count ->
+                        OSS_ROOT_TEXT +
+                            when {
+                                count == NODE_INITIAL_STATE -> ""
+                                count == 0 -> NO_ISSUES_FOUND_TEXT
+                                count > 0 -> ProductType.OSS.getCountText(count, isUniqueCount = true) + addHMLPostfix
+                                count == NODE_NOT_SUPPORTED_STATE -> NO_SUPPORTED_PACKAGE_MANAGER_FOUND
+                                else -> throw IllegalStateException("ResultsCount is meaningful")
+                            }
                     }
-                }
             }
         newOssTreeNodeText?.let { rootOssTreeNode.userObject = it }
 
-        val newSecurityIssuesNodeText = when {
-            getSnykCachedResults(project)?.currentSnykCodeError != null -> "$CODE_SECURITY_ROOT_TEXT (error)"
-            isSnykCodeRunning(project) && settings.snykCodeSecurityIssuesScanEnable -> "$CODE_SECURITY_ROOT_TEXT (scanning...)"
-            else -> securityIssuesCount?.let { count ->
-                CODE_SECURITY_ROOT_TEXT + when {
-                    count == NODE_INITIAL_STATE -> ""
-                    count == 0 -> NO_ISSUES_FOUND_TEXT
-                    count > 0 -> ProductType.CODE_SECURITY.getCountText(count) + addHMLPostfix
-                    else -> throw IllegalStateException("ResultsCount is meaningful")
-                }
+        val newSecurityIssuesNodeText =
+            when {
+                getSnykCachedResults(project)?.currentSnykCodeError != null -> "$CODE_SECURITY_ROOT_TEXT (error)"
+                isSnykCodeRunning(
+                    project,
+                ) && settings.snykCodeSecurityIssuesScanEnable -> "$CODE_SECURITY_ROOT_TEXT (scanning...)"
+
+                else ->
+                    securityIssuesCount?.let { count ->
+                        CODE_SECURITY_ROOT_TEXT +
+                            when {
+                                count == NODE_INITIAL_STATE -> ""
+                                count == 0 -> NO_ISSUES_FOUND_TEXT
+                                count > 0 -> ProductType.CODE_SECURITY.getCountText(count) + addHMLPostfix
+                                else -> throw IllegalStateException("ResultsCount is meaningful")
+                            }
+                    }
             }
-        }
         newSecurityIssuesNodeText?.let { rootSecurityIssuesTreeNode.userObject = it }
 
-        val newQualityIssuesNodeText = when {
-            getSnykCachedResults(project)?.currentSnykCodeError != null -> "$CODE_QUALITY_ROOT_TEXT (error)"
-            isSnykCodeRunning(project) && settings.snykCodeQualityIssuesScanEnable -> "$CODE_QUALITY_ROOT_TEXT (scanning...)"
-            else -> qualityIssuesCount?.let { count ->
-                CODE_QUALITY_ROOT_TEXT + when {
-                    count == NODE_INITIAL_STATE -> ""
-                    count == 0 -> NO_ISSUES_FOUND_TEXT
-                    count > 0 -> ProductType.CODE_QUALITY.getCountText(count) + addHMLPostfix
-                    else -> throw IllegalStateException("ResultsCount is meaningful")
-                }
+        val newQualityIssuesNodeText =
+            when {
+                getSnykCachedResults(project)?.currentSnykCodeError != null -> "$CODE_QUALITY_ROOT_TEXT (error)"
+                isSnykCodeRunning(
+                    project,
+                ) && settings.snykCodeQualityIssuesScanEnable -> "$CODE_QUALITY_ROOT_TEXT (scanning...)"
+
+                else ->
+                    qualityIssuesCount?.let { count ->
+                        CODE_QUALITY_ROOT_TEXT +
+                            when {
+                                count == NODE_INITIAL_STATE -> ""
+                                count == 0 -> NO_ISSUES_FOUND_TEXT
+                                count > 0 -> ProductType.CODE_QUALITY.getCountText(count) + addHMLPostfix
+                                else -> throw IllegalStateException("ResultsCount is meaningful")
+                            }
+                    }
             }
-        }
         newQualityIssuesNodeText?.let { rootQualityIssuesTreeNode.userObject = it }
 
-        val newIacTreeNodeText = when {
-            getSnykCachedResults(project)?.currentIacError != null -> "$IAC_ROOT_TEXT (error)"
-            isIacRunning(project) && settings.iacScanEnabled -> "$IAC_ROOT_TEXT (scanning...)"
-            else -> iacResultsCount?.let { count ->
-                IAC_ROOT_TEXT + when {
-                    count == NODE_INITIAL_STATE -> ""
-                    count == 0 -> NO_ISSUES_FOUND_TEXT
-                    count > 0 -> ProductType.IAC.getCountText(count, isUniqueCount = true) + addHMLPostfix
-                    count == NODE_NOT_SUPPORTED_STATE -> NO_SUPPORTED_IAC_FILES_FOUND
-                    else -> throw IllegalStateException("ResultsCount is meaningful")
-                }
+        val newIacTreeNodeText =
+            when {
+                getSnykCachedResults(project)?.currentIacError != null -> "$IAC_ROOT_TEXT (error)"
+                isIacRunning(project) && settings.iacScanEnabled -> "$IAC_ROOT_TEXT (scanning...)"
+                else ->
+                    iacResultsCount?.let { count ->
+                        IAC_ROOT_TEXT +
+                            when {
+                                count == NODE_INITIAL_STATE -> ""
+                                count == 0 -> NO_ISSUES_FOUND_TEXT
+                                count > 0 -> ProductType.IAC.getCountText(count, isUniqueCount = true) + addHMLPostfix
+                                count == NODE_NOT_SUPPORTED_STATE -> NO_SUPPORTED_IAC_FILES_FOUND
+                                else -> throw IllegalStateException("ResultsCount is meaningful")
+                            }
+                    }
             }
-        }
         newIacTreeNodeText?.let { rootIacIssuesTreeNode.userObject = it }
 
-        val newContainerTreeNodeText = when {
-            getSnykCachedResults(project)?.currentContainerError != null -> "$CONTAINER_ROOT_TEXT (error)"
-            isContainerRunning(project) && settings.containerScanEnabled -> "$CONTAINER_ROOT_TEXT (scanning...)"
-            else -> containerResultsCount?.let { count ->
-                CONTAINER_ROOT_TEXT + when {
-                    count == NODE_INITIAL_STATE -> ""
-                    count == 0 -> NO_ISSUES_FOUND_TEXT
-                    count > 0 -> ProductType.CONTAINER.getCountText(count, isUniqueCount = true) + addHMLPostfix
-                    count == NODE_NOT_SUPPORTED_STATE -> NO_CONTAINER_IMAGES_FOUND
-                    else -> throw IllegalStateException("ResultsCount is meaningful")
-                }
+        val newContainerTreeNodeText =
+            when {
+                getSnykCachedResults(project)?.currentContainerError != null -> "$CONTAINER_ROOT_TEXT (error)"
+                isContainerRunning(project) && settings.containerScanEnabled -> "$CONTAINER_ROOT_TEXT (scanning...)"
+                else ->
+                    containerResultsCount?.let { count ->
+                        CONTAINER_ROOT_TEXT +
+                            when {
+                                count == NODE_INITIAL_STATE -> ""
+                                count == 0 -> NO_ISSUES_FOUND_TEXT
+                                count > 0 ->
+                                    ProductType.CONTAINER.getCountText(
+                                        count,
+                                        isUniqueCount = true,
+                                    ) + addHMLPostfix
+
+                                count == NODE_NOT_SUPPORTED_STATE -> NO_CONTAINER_IMAGES_FOUND
+                                else -> throw IllegalStateException("ResultsCount is meaningful")
+                            }
+                    }
             }
-        }
         newContainerTreeNodeText?.let { rootContainerIssuesTreeNode.userObject = it }
     }
 
@@ -644,10 +674,11 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
             vulnerabilitiesTree.selectionPath?.lastPathComponent as? RootTreeNodeBase ?: treeNodeStub
         val messageHtmlText = selectedTreeNode.getNoVulnerabilitiesMessage()
 
-        val emptyStatePanel = StatePanel(
-            messageHtmlText,
-            "Run Scan"
-        ) { triggerScan() }
+        val emptyStatePanel =
+            StatePanel(
+                messageHtmlText,
+                "Run Scan",
+            ) { triggerScan() }
 
         descriptionPanel.add(wrapWithScrollPane(emptyStatePanel), BorderLayout.CENTER)
         revalidate()
@@ -660,10 +691,11 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
             vulnerabilitiesTree.selectionPath?.lastPathComponent as? RootTreeNodeBase ?: treeNodeStub
         val messageHtmlText = selectedTreeNode.getScanningMessage()
 
-        val statePanel = StatePanel(
-            messageHtmlText,
-            "Stop Scanning"
-        ) { getSnykTaskQueueService(project)?.stopScan() }
+        val statePanel =
+            StatePanel(
+                messageHtmlText,
+                "Stop Scanning",
+            ) { getSnykTaskQueueService(project)?.stopScan() }
 
         descriptionPanel.add(wrapWithScrollPane(statePanel), BorderLayout.CENTER)
 
@@ -673,13 +705,14 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
     private fun displayDownloadMessage() {
         descriptionPanel.removeAll()
 
-        val statePanel = StatePanel(
-            "Downloading Snyk CLI...",
-            "Stop Downloading"
-        ) {
-            getSnykCliDownloaderService().stopCliDownload()
-            displayEmptyDescription()
-        }
+        val statePanel =
+            StatePanel(
+                "Downloading Snyk CLI...",
+                "Stop Downloading",
+            ) {
+                getSnykCliDownloaderService().stopCliDownload()
+                displayEmptyDescription()
+            }
 
         descriptionPanel.add(wrapWithScrollPane(statePanel), BorderLayout.CENTER)
 
@@ -692,23 +725,27 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
 
         rootOssTreeNode.removeAllChildren()
 
-        fun navigateToOssVulnerability(filePath: String, vulnerability: Vulnerability?): () -> Unit = {
-            val virtualFile = VirtualFileManager.getInstance().findFileByNioPath(Paths.get(filePath))
-            if (virtualFile != null && virtualFile.isValid) {
-                if (vulnerability == null) {
-                    navigateToSource(project, virtualFile, 0)
-                } else {
-                    val psiFile = PsiManager.getInstance(project).findFile(virtualFile)
-                    val textRange = psiFile?.let { getOssTextRangeFinderService().findTextRange(it, vulnerability) }
-                    navigateToSource(
-                        project = project,
-                        virtualFile = virtualFile,
-                        selectionStartOffset = textRange?.startOffset ?: 0,
-                        selectionEndOffset = textRange?.endOffset
-                    )
+        fun navigateToOssVulnerability(
+            filePath: String,
+            vulnerability: Vulnerability?,
+        ): () -> Unit =
+            {
+                val virtualFile = VirtualFileManager.getInstance().findFileByNioPath(Paths.get(filePath))
+                if (virtualFile != null && virtualFile.isValid) {
+                    if (vulnerability == null) {
+                        navigateToSource(project, virtualFile, 0)
+                    } else {
+                        val psiFile = PsiManager.getInstance(project).findFile(virtualFile)
+                        val textRange = psiFile?.let { getOssTextRangeFinderService().findTextRange(it, vulnerability) }
+                        navigateToSource(
+                            project = project,
+                            virtualFile = virtualFile,
+                            selectionStartOffset = textRange?.startOffset ?: 0,
+                            selectionEndOffset = textRange?.endOffset,
+                        )
+                    }
                 }
             }
-        }
 
         val settings = pluginSettings()
         if (settings.ossScanEnable && settings.treeFiltering.ossResults) {
@@ -722,26 +759,27 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
                         .filter { settings.hasSeverityEnabledAndFiltered(it.head.getSeverity()) }
                         .sortedByDescending { it.head.getSeverity() }
                         .forEach {
-                            val navigateToSource = try {
-                                val filePath = sanitizeNavigationalFilePath(vulnsForFile)
-                                navigateToOssVulnerability(filePath, it.head)
-                            } catch (ignore: InvalidPathException) {
-                                // empty navigation function for invalid path
-                                {}
-                            }
+                            val navigateToSource =
+                                try {
+                                    val filePath = sanitizeNavigationalFilePath(vulnsForFile)
+                                    navigateToOssVulnerability(filePath, it.head)
+                                } catch (ignore: InvalidPathException) {
+                                    // empty navigation function for invalid path
+                                    {}
+                                }
                             fileTreeNode.add(VulnerabilityTreeNode(it, project, navigateToSource))
                         }
                 }
             }
             ossResult.errors.forEach { snykError ->
                 rootOssTreeNode.add(
-                    ErrorTreeNode(snykError, project, navigateToOssVulnerability(snykError.path, null))
+                    ErrorTreeNode(snykError, project, navigateToOssVulnerability(snykError.path, null)),
                 )
             }
         }
         updateTreeRootNodesPresentation(
             ossResultsCount = ossResult.issuesCount,
-            addHMLPostfix = buildHMLpostfix(ossResult)
+            addHMLPostfix = buildHMLpostfix(ossResult),
         )
 
         smartReloadRootNode(rootOssTreeNode, userObjectsForExpandedChildren, selectedNodeUserObject)
@@ -750,11 +788,12 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
     fun sanitizeNavigationalFilePath(vulnsForFile: OssVulnerabilitiesForFile): String {
         val dirPath = vulnsForFile.path
         val targetFilePath = vulnsForFile.sanitizedTargetFile
-        val filePath = if (Paths.get(targetFilePath).isAbsolute) {
-            targetFilePath
-        } else {
-            Paths.get(dirPath, targetFilePath).toString()
-        }
+        val filePath =
+            if (Paths.get(targetFilePath).isAbsolute) {
+                targetFilePath
+            } else {
+                Paths.get(dirPath, targetFilePath).toString()
+            }
         return filePath
     }
 
@@ -764,11 +803,15 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
 
         rootIacIssuesTreeNode.removeAllChildren()
 
-        fun navigateToIaCIssue(virtualFile: VirtualFile?, lineStartOffset: Int): () -> Unit = {
-            if (virtualFile?.isValid == true) {
-                navigateToSource(project, virtualFile, lineStartOffset)
+        fun navigateToIaCIssue(
+            virtualFile: VirtualFile?,
+            lineStartOffset: Int,
+        ): () -> Unit =
+            {
+                if (virtualFile?.isValid == true) {
+                    navigateToSource(project, virtualFile, lineStartOffset)
+                }
             }
-        }
 
         val settings = pluginSettings()
         if (settings.iacScanEnabled && settings.treeFiltering.iacResults) {
@@ -781,24 +824,25 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
                         .filter { settings.hasSeverityEnabledAndFiltered(it.getSeverity()) }
                         .sortedByDescending { it.getSeverity() }
                         .forEach {
-                            val navigateToSource = navigateToIaCIssue(
-                                iacVulnerabilitiesForFile.virtualFile,
-                                it.lineStartOffset
-                            )
+                            val navigateToSource =
+                                navigateToIaCIssue(
+                                    iacVulnerabilitiesForFile.virtualFile,
+                                    it.lineStartOffset,
+                                )
                             fileTreeNode.add(IacIssueTreeNode(it, project, navigateToSource))
                         }
                 }
             }
             iacResult.getVisibleErrors().forEach { snykError ->
                 rootIacIssuesTreeNode.add(
-                    ErrorTreeNode(snykError, project, navigateToIaCIssue(snykError.virtualFile, 0))
+                    ErrorTreeNode(snykError, project, navigateToIaCIssue(snykError.virtualFile, 0)),
                 )
             }
         }
 
         updateTreeRootNodesPresentation(
             iacResultsCount = iacResult.issuesCount,
-            addHMLPostfix = buildHMLpostfix(iacResult)
+            addHMLPostfix = buildHMLpostfix(iacResult),
         )
 
         smartReloadRootNode(rootIacIssuesTreeNode, userObjectsForExpandedChildren, selectedNodeUserObject)
@@ -810,18 +854,22 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
 
         rootContainerIssuesTreeNode.removeAllChildren()
 
-        fun navigateToImage(issuesForImage: ContainerIssuesForImage?, virtualFile: VirtualFile?): () -> Unit = {
-            val image = issuesForImage?.workloadImages?.getOrNull(0)
+        fun navigateToImage(
+            issuesForImage: ContainerIssuesForImage?,
+            virtualFile: VirtualFile?,
+        ): () -> Unit =
+            {
+                val image = issuesForImage?.workloadImages?.getOrNull(0)
 
-            var file = virtualFile
-            if (image != null) {
-                file = image.virtualFile
-            }
+                var file = virtualFile
+                if (image != null) {
+                    file = image.virtualFile
+                }
 
-            if (file?.isValid == true) {
-                navigateToSource(project, file, image?.lineStartOffset ?: 0)
+                if (file?.isValid == true) {
+                    navigateToSource(project, file, image?.lineStartOffset ?: 0)
+                }
             }
-        }
 
         val settings = pluginSettings()
         if (settings.containerScanEnabled && settings.treeFiltering.containerResults) {
@@ -835,8 +883,8 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
                             project,
                             navigateToImage(
                                 issuesForImage,
-                                virtualFile
-                            )
+                                virtualFile,
+                            ),
                         )
                     rootContainerIssuesTreeNode.add(imageTreeNode)
 
@@ -850,23 +898,23 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
                                     project,
                                     navigateToImage(
                                         issuesForImage,
-                                        virtualFile
-                                    )
-                                )
+                                        virtualFile,
+                                    ),
+                                ),
                             )
                         }
                 }
             }
             containerResult.errors.forEach { snykError ->
                 rootContainerIssuesTreeNode.add(
-                    ErrorTreeNode(snykError, project, navigateToImage(null, snykError.virtualFile))
+                    ErrorTreeNode(snykError, project, navigateToImage(null, snykError.virtualFile)),
                 )
             }
         }
 
         updateTreeRootNodesPresentation(
             containerResultsCount = containerResult.issuesCount,
-            addHMLPostfix = buildHMLpostfix(containerResult)
+            addHMLPostfix = buildHMLpostfix(containerResult),
         )
 
         smartReloadRootNode(rootContainerIssuesTreeNode, userObjectsForExpandedChildren, selectedNodeUserObject)
@@ -877,10 +925,15 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
             cliResult.criticalSeveritiesCount(),
             cliResult.highSeveritiesCount(),
             cliResult.mediumSeveritiesCount(),
-            cliResult.lowSeveritiesCount()
+            cliResult.lowSeveritiesCount(),
         )
 
-    private fun buildHMLpostfix(criticalCount: Int = 0, errorsCount: Int, warnsCount: Int, infosCount: Int): String {
+    private fun buildHMLpostfix(
+        criticalCount: Int = 0,
+        errorsCount: Int,
+        warnsCount: Int,
+        infosCount: Int,
+    ): String {
         var result = ""
         if (criticalCount > 0) result += ", $criticalCount ${Severity.CRITICAL}"
         if (errorsCount > 0) result += ", $errorsCount ${Severity.HIGH}"
@@ -930,7 +983,7 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
     internal fun smartReloadRootNode(
         nodeToReload: DefaultMutableTreeNode,
         userObjectsForExpandedChildren: List<Any>?,
-        selectedNodeUserObject: Any?
+        selectedNodeUserObject: Any?,
     ) {
         val selectedNode = TreeUtil.findNodeWithObject(rootTreeNode, selectedNodeUserObject)
 
@@ -1040,16 +1093,16 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
 
         private val CONTAINER_DOCS_TEXT_WITH_LINK =
             """
-                If you are curious to know more about how the Snyk Container integration works, have a look at our
-                <a href="https://docs.snyk.io/features/integrations/ide-tools/jetbrains-plugins#analysis-results-snyk-container">docs</a>.
+            If you are curious to know more about how the Snyk Container integration works, have a look at our
+            <a href="https://docs.snyk.io/features/integrations/ide-tools/jetbrains-plugins#analysis-results-snyk-container">docs</a>.
             """.trimIndent()
 
         private val CONTAINER_SCAN_COMMON_POSTFIX =
             """
-                The plugin searches for Kubernetes workload files (*.yaml, *.yml) and extracts the used images.<br>
-                During testing the image, the CLI will download the image
-                if it is not already available locally in your Docker daemon.<br><br>
-                $CONTAINER_DOCS_TEXT_WITH_LINK
+            The plugin searches for Kubernetes workload files (*.yaml, *.yml) and extracts the used images.<br>
+            During testing the image, the CLI will download the image
+            if it is not already available locally in your Docker daemon.<br><br>
+            $CONTAINER_DOCS_TEXT_WITH_LINK
             """.trimIndent()
 
         val CONTAINER_SCAN_START_TEXT =
@@ -1059,11 +1112,11 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
 
         private val CONTAINER_NO_FOUND_COMMON_POSTFIX =
             """
-                The plugin searches for Kubernetes workload files (*.yaml, *.yml) and extracts the used images.<br>
-                Consider checking if your container application definition has an image specified.<br>
-                Make sure that the container image has been successfully built locally
-                and/or pushed to a container registry.<br><br>
-                $CONTAINER_DOCS_TEXT_WITH_LINK
+            The plugin searches for Kubernetes workload files (*.yaml, *.yml) and extracts the used images.<br>
+            Consider checking if your container application definition has an image specified.<br>
+            Make sure that the container image has been successfully built locally
+            and/or pushed to a container registry.<br><br>
+            $CONTAINER_DOCS_TEXT_WITH_LINK
             """.trimIndent()
 
         val CONTAINER_NO_ISSUES_FOUND_TEXT =

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLS.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLS.kt
@@ -169,10 +169,12 @@ class SnykToolWindowSnykScanListenerLS(
             if (filterTree) {
                 addInfoTreeNodes(rootNode, snykResults.values.flatten().distinct(), fixableIssuesCount)
 
-                val includeIgnoredIssues =
-                    !(settings.isGlobalIgnoresFeatureEnabled && !settings.ignoredIssuesEnabled)
-                val includeOpenedIssues =
-                    !(settings.isGlobalIgnoresFeatureEnabled && !settings.openIssuesEnabled)
+                var includeIgnoredIssues = true
+                var includeOpenedIssues = true
+                if (settings.isGlobalIgnoresFeatureEnabled) {
+                    includeOpenedIssues = settings.openIssuesEnabled
+                    includeIgnoredIssues = settings.ignoredIssuesEnabled
+                }
 
                 val resultsToDisplay =
                     snykResults.map { entry ->
@@ -268,7 +270,7 @@ class SnykToolWindowSnykScanListenerLS(
         } else if (ignoredIssuesCount == 0 && !settings.openIssuesEnabled) {
             rootNode.add(
                 InfoTreeNode(
-                    "Adjust your Issue View Options to open ignored issues.",
+                    "Adjust your Issue View Options to open issues.",
                     project,
                 ),
             )

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLS.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLS.kt
@@ -38,7 +38,11 @@ class SnykToolWindowSnykScanListenerLS(
     private val rootQualityIssuesTreeNode: DefaultMutableTreeNode,
     private val rootOssIssuesTreeNode: DefaultMutableTreeNode,
 ) : SnykScanListenerLS, Disposable {
-    private var disposed = false; get() { return project.isDisposed || ApplicationManager.getApplication().isDisposed || field }
+    private var disposed = false
+        get() {
+            return project.isDisposed || ApplicationManager.getApplication().isDisposed || field
+        }
+
     init {
         Disposer.register(SnykPluginDisposable.getInstance(project), this)
     }
@@ -46,6 +50,7 @@ class SnykToolWindowSnykScanListenerLS(
     override fun dispose() {
         disposed = true
     }
+
     fun isDisposed() = disposed
 
     override fun scanningStarted(snykScan: SnykScanParams) {
@@ -97,7 +102,7 @@ class SnykToolWindowSnykScanListenerLS(
             snykResults = securityIssues,
             rootNode = this.rootSecurityIssuesTreeNode,
             securityIssuesCount = securityIssues.values.flatten().distinct().size,
-            fixableIssuesCount = securityIssues.values.flatten().distinct().count { it.hasAIFix() }
+            fixableIssuesCount = securityIssues.values.flatten().distinct().count { it.hasAIFix() },
         )
 
         // display Quality (non Security) issues
@@ -112,7 +117,7 @@ class SnykToolWindowSnykScanListenerLS(
             snykResults = qualityIssues,
             rootNode = this.rootQualityIssuesTreeNode,
             qualityIssuesCount = qualityIssues.values.flatten().distinct().size,
-            fixableIssuesCount = qualityIssues.values.flatten().distinct().count { it.hasAIFix() }
+            fixableIssuesCount = qualityIssues.values.flatten().distinct().count { it.hasAIFix() },
         )
     }
 
@@ -143,7 +148,9 @@ class SnykToolWindowSnykScanListenerLS(
         containerResultsCount: Int? = null,
         fixableIssuesCount: Int? = null,
     ) {
-        if (pluginSettings().token.isNullOrEmpty()) {
+        val settings = pluginSettings()
+
+        if (settings.token.isNullOrEmpty()) {
             snykToolWindowPanel.displayAuthPanel()
             return
         }
@@ -151,7 +158,6 @@ class SnykToolWindowSnykScanListenerLS(
         val userObjectsForExpandedNodes =
             snykToolWindowPanel.userObjectsForExpandedNodes(rootNode)
         val selectedNodeUserObject = TreeUtil.findObjectInPath(vulnerabilitiesTree.selectionPath, Any::class.java)
-        val settings = pluginSettings()
 
         rootNode.removeAllChildren()
 
@@ -163,11 +169,20 @@ class SnykToolWindowSnykScanListenerLS(
             if (filterTree) {
                 addInfoTreeNodes(rootNode, snykResults.values.flatten().distinct(), fixableIssuesCount)
 
+                val includeIgnoredIssues =
+                    !(settings.isGlobalIgnoresFeatureEnabled && !settings.ignoredIssuesEnabled)
+                val includeOpenedIssues =
+                    !(settings.isGlobalIgnoresFeatureEnabled && !settings.openIssuesEnabled)
+
                 val resultsToDisplay =
                     snykResults.map { entry ->
                         entry.key to
                             entry.value.filter {
-                                settings.hasSeverityEnabledAndFiltered(it.getSeverityAsEnum())
+                                settings.hasSeverityEnabledAndFiltered(it.getSeverityAsEnum()) &&
+                                    it.isVisible(
+                                        includeOpenedIssues,
+                                        includeIgnoredIssues,
+                                    )
                             }
                     }.toMap()
                 displayResultsForRootTreeNode(rootNode, resultsToDisplay)
@@ -180,7 +195,7 @@ class SnykToolWindowSnykScanListenerLS(
             ossResultsCount = ossResultsCount,
             iacResultsCount = iacResultsCount,
             containerResultsCount = containerResultsCount,
-            addHMLPostfix = rootNodePostFix
+            addHMLPostfix = rootNodePostFix,
         )
 
         snykToolWindowPanel.smartReloadRootNode(
@@ -242,11 +257,27 @@ class SnykToolWindowSnykScanListenerLS(
                 )
             }
         }
+
+        if (ignoredIssuesCount == issuesCount && !settings.ignoredIssuesEnabled) {
+            rootNode.add(
+                InfoTreeNode(
+                    "Adjust your Issue View Options to see ignored issues.",
+                    project,
+                ),
+            )
+        } else if (ignoredIssuesCount == 0 && !settings.openIssuesEnabled) {
+            rootNode.add(
+                InfoTreeNode(
+                    "Adjust your Issue View Options to open ignored issues.",
+                    project,
+                ),
+            )
+        }
     }
 
     private fun displayResultsForRootTreeNode(
         rootNode: DefaultMutableTreeNode,
-        issues: Map<SnykFile, List<ScanIssue>>
+        issues: Map<SnykFile, List<ScanIssue>>,
     ) {
         fun navigateToSource(
             virtualFile: VirtualFile,
@@ -276,8 +307,8 @@ class SnykToolWindowSnykScanListenerLS(
                         fileTreeNode.add(
                             SuggestionTreeNode(
                                 issue,
-                                navigateToSource(entry.key.virtualFile, issue.textRange ?: TextRange(0, 0))
-                            )
+                                navigateToSource(entry.key.virtualFile, issue.textRange ?: TextRange(0, 0)),
+                            ),
                         )
                     }
             }

--- a/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
+++ b/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
@@ -63,7 +63,11 @@ import java.util.concurrent.TimeUnit
  */
 class SnykLanguageClient : LanguageClient, Disposable {
     val logger = Logger.getInstance("Snyk Language Server")
-    private var disposed = false; get() { return ApplicationManager.getApplication().isDisposed || field }
+    private var disposed = false
+    get() {
+            return ApplicationManager.getApplication().isDisposed || field
+        }
+
     fun isDisposed() = disposed
     private val progresses: Cache<String, ProgressIndicator> =
         Caffeine.newBuilder()
@@ -212,17 +216,7 @@ class SnykLanguageClient : LanguageClient, Disposable {
         check(snykScan.product == "code" || snykScan.product == "oss") { "Expected Snyk Code or Snyk OSS scan result" }
         if (snykScan.issues.isNullOrEmpty()) return emptyMap()
 
-        val pluginSettings = pluginSettings()
-        val includeIgnoredIssues = pluginSettings.ignoredIssuesEnabled
-        val includeOpenedIssues = pluginSettings.openIssuesEnabled
-
-        val processedIssues = if (pluginSettings.isGlobalIgnoresFeatureEnabled) { //
-            snykScan.issues.filter { it.isVisible(includeOpenedIssues, includeIgnoredIssues) }
-        } else {
-            snykScan.issues
-        }
-
-        val map = processedIssues
+        val map = snykScan.issues
             .groupBy { it.filePath }
             .mapNotNull { (file, issues) -> SnykFile(project, file.toVirtualFile()) to issues.sorted() }
             .map {

--- a/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLSTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLSTest.kt
@@ -56,7 +56,7 @@ class SnykToolWindowSnykScanListenerLSTest : BasePlatformTestCase() {
         rootQualityIssuesTreeNode = RootQualityIssuesTreeNode(project)
     }
 
-    private fun mockScanIssues(): List<ScanIssue> {
+    private fun mockScanIssues(isIgnored: Boolean? = false): List<ScanIssue> {
         val issue =
             ScanIssue(
                 id = "id",
@@ -103,7 +103,7 @@ class SnykToolWindowSnykScanListenerLSTest : BasePlatformTestCase() {
                         details = "",
                         ruleId = "",
                     ),
-                isIgnored = false,
+                isIgnored = isIgnored,
                 ignoreDetails = null,
             )
         return listOf(issue)
@@ -191,5 +191,63 @@ class SnykToolWindowSnykScanListenerLSTest : BasePlatformTestCase() {
         TestCase.assertEquals(3, rootTreeNode.childCount)
         cut.addInfoTreeNodes(rootTreeNode, mockScanIssues(), 1, 1)
         TestCase.assertEquals(5, rootTreeNode.childCount)
+    }
+
+    fun `testAddInfoTreeNodes adds new tree nodes for code security if  all ignored issues are hidden`() {
+        pluginSettings().isGlobalIgnoresFeatureEnabled = true
+        pluginSettings().ignoredIssuesEnabled = false
+
+        // setup the rootTreeNode from scratch
+        rootTreeNode = DefaultMutableTreeNode("")
+        rootTreeNode.add(rootOssIssuesTreeNode)
+        rootTreeNode.add(rootSecurityIssuesTreeNode)
+        rootTreeNode.add(rootQualityIssuesTreeNode)
+        vulnerabilitiesTree =
+            Tree(rootTreeNode).apply {
+                this.isRootVisible = false
+            }
+
+        cut =
+            SnykToolWindowSnykScanListenerLS(
+                project,
+                snykToolWindowPanel,
+                vulnerabilitiesTree,
+                rootSecurityIssuesTreeNode,
+                rootQualityIssuesTreeNode,
+                rootOssIssuesTreeNode,
+            )
+
+        TestCase.assertEquals(3, rootTreeNode.childCount)
+        cut.addInfoTreeNodes(rootTreeNode, mockScanIssues(true), 1, 1)
+        TestCase.assertEquals(6, rootTreeNode.childCount)
+    }
+
+    fun `testAddInfoTreeNodes adds new tree nodes for code security if all open issues are hidden`() {
+        pluginSettings().isGlobalIgnoresFeatureEnabled = true
+        pluginSettings().openIssuesEnabled = false
+
+        // setup the rootTreeNode from scratch
+        rootTreeNode = DefaultMutableTreeNode("")
+        rootTreeNode.add(rootOssIssuesTreeNode)
+        rootTreeNode.add(rootSecurityIssuesTreeNode)
+        rootTreeNode.add(rootQualityIssuesTreeNode)
+        vulnerabilitiesTree =
+            Tree(rootTreeNode).apply {
+                this.isRootVisible = false
+            }
+
+        cut =
+            SnykToolWindowSnykScanListenerLS(
+                project,
+                snykToolWindowPanel,
+                vulnerabilitiesTree,
+                rootSecurityIssuesTreeNode,
+                rootQualityIssuesTreeNode,
+                rootOssIssuesTreeNode,
+            )
+
+        TestCase.assertEquals(3, rootTreeNode.childCount)
+        cut.addInfoTreeNodes(rootTreeNode, mockScanIssues(false), 1, 1)
+        TestCase.assertEquals(6, rootTreeNode.childCount)
     }
 }


### PR DESCRIPTION
### Description

Fixes the count of issues and ignored issues in the Tree View so that when the Issue View Options change the counts don't change, only the rendered issues do.

Also adds a missing warning that I should have added as part of https://snyksec.atlassian.net/browse/IDE-332 where there are no ignored issues and only showing ignored issues or there are no open issues and only showing open issues.

I enabled the default linter in IntellJ and it formatted a file. Let me know if you'd like me to undo that.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs
<img width="577" alt="Screenshot 2024-06-18 at 09 31 49" src="https://github.com/snyk/snyk-intellij-plugin/assets/81559517/01d2a335-4180-4f7b-88b3-05d5360855f0">

<img width="571" alt="Screenshot 2024-06-18 at 09 32 07" src="https://github.com/snyk/snyk-intellij-plugin/assets/81559517/45006bcb-555a-43c4-9ee2-98435929ff99">
