### PR TITLE
fix: colours, font family, and font size for consistent ignores [IDE-386]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Snyk Security Changelog
 
+## [2.8.8]
+### Fixes
+- change some of the colours used in the HTML panel so it's consistent with designs
+
 ## [2.8.7]
 ### Fixes
 - fix issue counts when there are ignores and add some warnings about the Issue View Options
 - fix AI fix counts when there are ignores
-- change some of the colours used in the HTML panel so it's consistent with designs
 
 ## [2.8.6]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixes
 - fix issue counts when there are ignores and add some warnings about the Issue View Options
 - fix AI fix counts when there are ignores
+- change some of the colours used in the HTML panel so it's consistent with designs
 
 ## [2.8.6]
 ### Fixed

--- a/src/main/kotlin/io/snyk/plugin/ui/jcef/OpenFileLoadHandlerGenerator.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/jcef/OpenFileLoadHandlerGenerator.kt
@@ -5,9 +5,9 @@ import com.intellij.openapi.editor.colors.ColorKey
 import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.ui.JBColor
 import com.intellij.ui.jcef.JBCefBrowserBase
 import com.intellij.ui.jcef.JBCefJSQuery
+import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.UIUtil
 import io.snyk.plugin.getDocument
 import io.snyk.plugin.navigateToSource
@@ -126,9 +126,12 @@ class OpenFileLoadHandlerGenerator(
                     val baseColor = UIUtil.getTextFieldBackground()
                     val (addedColor, removedColor) = getCodeDiffColors(baseColor, isHighContrast)
 
-                    val textColor = toCssHex(JBColor.namedColor("Label.foreground", JBColor.BLACK))
-                    val linkColor = toCssHex(JBColor.namedColor("Link.activeForeground", JBColor.BLUE))
+                    val textColor = toCssHex(JBUI.CurrentTheme.Label.foreground())
+                    val linkColor = toCssHex(JBUI.CurrentTheme.Link.Foreground.ENABLED)
                     val dataFlowColor = toCssHex(baseColor)
+                    val borderColor = toCssHex(JBUI.CurrentTheme.CustomFrameDecorations.separatorForeground())
+                    val editorColor =
+                        toCssHex(UIUtil.getTextFieldBackground())
 
                     val globalScheme = EditorColorsManager.getInstance().globalScheme
                     val tearLineColor =
@@ -153,6 +156,8 @@ class OpenFileLoadHandlerGenerator(
                                 '--tab-item-hover-color': "${tabItemHoverColor?.let { toCssHex(it) }}",
                                 '--scrollbar-thumb-color': "${tearLineColor?.let { toCssHex(it) }}",
                                 '--tabs-bottom-color': "${tearLineColor?.let { toCssHex(it) }}",
+                                '--border-color': "$borderColor",
+                                '--editor-color': "$editorColor",
                             };
                             for (let [property, value] of Object.entries(properties)) {
                                 document.documentElement.style.setProperty(property, value);

--- a/src/main/kotlin/io/snyk/plugin/ui/jcef/OpenFileLoadHandlerGenerator.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/jcef/OpenFileLoadHandlerGenerator.kt
@@ -3,6 +3,8 @@ package io.snyk.plugin.ui.jcef
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.editor.colors.ColorKey
 import com.intellij.openapi.editor.colors.EditorColorsManager
+import com.intellij.openapi.editor.colors.EditorColorsScheme
+import com.intellij.openapi.editor.colors.FontPreferences
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.ui.jcef.JBCefBrowserBase
@@ -139,6 +141,11 @@ class OpenFileLoadHandlerGenerator(
                     val tabItemHoverColor =
                         globalScheme.getColor(ColorKey.find("INDENT_GUIDE")) // The closest color to target_rgb = RGB (235, 236, 240)
 
+                    val editorColorsManager = EditorColorsManager.getInstance()
+                    val editorColorsScheme: EditorColorsScheme = editorColorsManager.globalScheme
+                    val fontPreferences: FontPreferences = editorColorsScheme.fontPreferences
+                    val editorFont = fontPreferences.fontFamily
+
                     val themeScript = """
                         (function(){
                         if (window.themeApplied) {
@@ -158,6 +165,7 @@ class OpenFileLoadHandlerGenerator(
                                 '--tabs-bottom-color': "${tearLineColor?.let { toCssHex(it) }}",
                                 '--border-color': "$borderColor",
                                 '--editor-color': "$editorColor",
+                                '--editor-font': "'$editorFont'",
                             };
                             for (let [property, value] of Object.entries(properties)) {
                                 document.documentElement.style.setProperty(property, value);

--- a/src/main/kotlin/io/snyk/plugin/ui/jcef/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/jcef/Utils.kt
@@ -17,7 +17,7 @@ object JCEFUtils {
         val cefClient = JBCefApp.getInstance().createClient()
         cefClient.setProperty("JS_QUERY_POOL_SIZE", 1)
         val jbCefBrowser =
-            JBCefBrowserBuilder().setClient(cefClient).setEnableOpenDevToolsMenuItem(true)
+            JBCefBrowserBuilder().setClient(cefClient).setEnableOpenDevToolsMenuItem(false)
                 .setMouseWheelEventEnable(true).build()
         jbCefBrowser.setOpenLinksInExternalBrowser(true)
 

--- a/src/main/resources/stylesheets/snyk_code_suggestion.scss
+++ b/src/main/resources/stylesheets/snyk_code_suggestion.scss
@@ -26,6 +26,8 @@ a,
   color: var(--link-color);
 }
 
+// TODO: remove ignore styling at the end of cycle 5 2025
+// TODO: keep the font-size
 .ignore-warning {
   background: #FFF4ED;
   color: #B6540B;

--- a/src/main/resources/stylesheets/snyk_code_suggestion.scss
+++ b/src/main/resources/stylesheets/snyk_code_suggestion.scss
@@ -44,13 +44,6 @@ a,
   border-top: 1px solid var(--border-color)
 }
 
-/* Need to override h2 settings for the markdown*/
-h2 {
-  line-height: 1.25rem;
-  font-size: 1.4rem;
-  margin-bottom: 10px;
-}
-
 .issue-overview-header,
 .ignore-details-header,
 .data-flow-header,
@@ -66,7 +59,7 @@ h2 {
 
 .data-flow-text {
   font-family: var(--editor-font);
-  font-size: 1.1rem;
+  font-size: 1.05rem;
 }
 
 .data-flow-clickable-row {
@@ -99,7 +92,7 @@ h2 {
 
 .example-line > code {
   font-family: var(--editor-font);
-  font-size: 1.1rem;
+  font-size: 1.05rem;
 }
 
 .example-line.added {

--- a/src/main/resources/stylesheets/snyk_code_suggestion.scss
+++ b/src/main/resources/stylesheets/snyk_code_suggestion.scss
@@ -55,7 +55,8 @@ h2 {
 .ignore-details-header,
 .data-flow-header,
 .ai-fix-header,
-.example-fixes-header {
+.example-fixes-header,
+.overview-text > h2 {
   font-size: 0.85rem;
 }
 

--- a/src/main/resources/stylesheets/snyk_code_suggestion.scss
+++ b/src/main/resources/stylesheets/snyk_code_suggestion.scss
@@ -6,7 +6,7 @@
   background: #595a5c;
 }
 
-html,body {
+html, body {
   height: 100%;
   font-size: 16px;
   display: flex;
@@ -26,10 +26,6 @@ a,
   color: var(--link-color);
 }
 
-.delimiter {
-  border: 1px solid #505254;
-}
-
 .ignore-warning {
   background: #FFF4ED;
   color: #B6540B;
@@ -42,6 +38,17 @@ a,
   color: #B6540B;
   border: 1px solid #E27122;
   font-size: 0.75rem;
+}
+
+.delimiter-top {
+  border-top: 1px solid var(--border-color)
+}
+
+/* Need to override h2 settings for the markdown*/
+h2 {
+  line-height: 1.25rem;
+  font-size: 1.4rem;
+  margin-bottom: 10px;
 }
 
 .issue-overview-header,
@@ -60,15 +67,11 @@ a,
   color: var(--link-color);
 }
 
-.data-flow-delimiter {
-  color: #BBBBBB;
-}
-
 .tabs-nav {
   border-bottom: 1px solid var(--tabs-bottom-color);
 }
 
-.tab-item{
+.tab-item {
   font-size: 0.85rem;
 }
 
@@ -82,6 +85,14 @@ a,
 
 .tab-item.is-selected {
   border-bottom: 3px solid #3474f0;
+}
+
+.example-line {
+  background-color: var(--editor-color);
+}
+
+.example-line > code {
+  font-family: "Courier New", Courier, monospace;
 }
 
 .example-line.added {

--- a/src/main/resources/stylesheets/snyk_code_suggestion.scss
+++ b/src/main/resources/stylesheets/snyk_code_suggestion.scss
@@ -63,6 +63,11 @@ h2 {
   font-size: 0.85rem;
 }
 
+.data-flow-text {
+  font-family: var(--editor-font);
+  font-size: 1.1rem;
+}
+
 .data-flow-clickable-row {
   color: var(--link-color);
 }
@@ -92,7 +97,8 @@ h2 {
 }
 
 .example-line > code {
-  font-family: "Courier New", Courier, monospace;
+  font-family: var(--editor-font);
+  font-size: 1.1rem;
 }
 
 .example-line.added {


### PR DESCRIPTION
### Description


Changes some colours in order to match the [designs](https://www.figma.com/design/hcI2QHUtHfcIjgrpYlMqff/Holistic-Ignores?node-id=2292-61688&t=larzTCeHFfRtz6av-0)

Make sure to run https://github.com/snyk/snyk-ls/pull/552 first if you want to call out any inconsistent UI elements, in case they're already addressed there.

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

