### PR TITLE
feat: warn user if ls does not support required protocol version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Fixes
 - fix issue counts when there are ignores and add some warnings about the Issue View Options
 
+### Changes
+- warn users if CLI is outdated
+
 ## [2.8.6]
 ### Fixed
 - automatically migrate old-format endpoint to https://api.xxx.snyk.io endpoint and save it in settings. Also, add tooltip to custom endpoint field explaining the format.

--- a/src/main/kotlin/io/snyk/plugin/services/download/CliDownloader.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/download/CliDownloader.kt
@@ -19,6 +19,8 @@ class CliDownloader {
             get() = pluginSettings().cliBaseDownloadURL
         val LATEST_RELEASES_URL: String
             get() = "$BASE_URL/cli/${pluginSettings().cliReleaseChannel}/ls-protocol-version-"+ pluginSettings().requiredLsProtocolVersion
+
+        fun getDownloadURL(cliVersion: String) = "$BASE_URL/cli/v$cliVersion/${Platform.current().snykWrapperFileName}"
     }
 
     fun calculateSha256(bytes: ByteArray): String {
@@ -87,6 +89,4 @@ class CliDownloader {
         val request = createRequest(downloadURL)
         return request.readString().split(" ")[0]
     }
-
-    private fun getDownloadURL(cliVersion: String) = "$BASE_URL/cli/v$cliVersion/${Platform.current().snykWrapperFileName}"
 }

--- a/src/test/kotlin/snyk/common/lsp/LanguageServerWrapperTest.kt
+++ b/src/test/kotlin/snyk/common/lsp/LanguageServerWrapperTest.kt
@@ -60,6 +60,7 @@ class LanguageServerWrapperTest {
         every { applicationMock.getService(ProjectManager::class.java) } returns projectManagerMock
         every { applicationMock.getService(SnykPluginDisposable::class.java) } returns snykPluginDisposable
         every { applicationMock.isDisposed } returns false
+        every { applicationMock.isUnitTestMode } returns true
 
         every { projectManagerMock.openProjects } returns arrayOf(projectMock)
         every { projectMock.isDisposed } returns false
@@ -347,5 +348,19 @@ class LanguageServerWrapperTest {
 
         // Assert
         assertEquals(true, result)
+    }
+
+    @Test
+    fun `addContentRoots flips protocolVersionChecked on first run`() {
+        simulateRunningLS()
+        val rootManagerMock = mockk<ProjectRootManager>(relaxed = true)
+        every { projectMock.getService(ProjectRootManager::class.java) } returns rootManagerMock
+        every { rootManagerMock.contentRoots } returns emptyArray()
+
+        cut.protocolVersionChecked = false
+
+        cut.addContentRoots(projectMock)
+
+        assertTrue(cut.protocolVersionChecked)
     }
 }


### PR DESCRIPTION
### Description

If an outdated LS is used and automatic management of binaries is disabled, the plugin now warns you and offers the manual download.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

![image](https://github.com/snyk/snyk-intellij-plugin/assets/20150761/186e7e09-4931-41a4-b567-e49c49ebcc7d)