### PR TITLE
fix: include ignored issues in AI fix count [IDE-346]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [2.8.7]
 ### Fixes
 - fix issue counts when there are ignores and add some warnings about the Issue View Options
+- fix AI fix counts when there are ignores
 
 ## [2.8.6]
 ### Fixed

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLS.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLS.kt
@@ -167,7 +167,12 @@ class SnykToolWindowSnykScanListenerLS(
             rootNodePostFix = buildSeveritiesPostfixForFileNode(snykResults)
 
             if (filterTree) {
-                addInfoTreeNodes(rootNode, snykResults.values.flatten().distinct(), fixableIssuesCount)
+                addInfoTreeNodes(
+                    rootNode = rootNode,
+                    issues = snykResults.values.flatten().distinct(),
+                    securityIssuesCount = securityIssuesCount,
+                    fixableIssuesCount = fixableIssuesCount,
+                )
 
                 var includeIgnoredIssues = true
                 var includeOpenedIssues = true

--- a/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLSTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLSTest.kt
@@ -56,7 +56,10 @@ class SnykToolWindowSnykScanListenerLSTest : BasePlatformTestCase() {
         rootQualityIssuesTreeNode = RootQualityIssuesTreeNode(project)
     }
 
-    private fun mockScanIssues(isIgnored: Boolean? = false): List<ScanIssue> {
+    private fun mockScanIssues(
+        isIgnored: Boolean? = false,
+        hasAIFix: Boolean? = false,
+    ): List<ScanIssue> {
         val issue =
             ScanIssue(
                 id = "id",
@@ -78,7 +81,7 @@ class SnykToolWindowSnykScanListenerLSTest : BasePlatformTestCase() {
                         rows = null,
                         isSecurityType = true,
                         priorityScore = 0,
-                        hasAIFix = true,
+                        hasAIFix = hasAIFix!!,
                         dataFlow = listOf(DataFlow(0, getTestDataPath(), Range(Position(1, 1), Position(1, 1)), "")),
                         license = null,
                         identifiers = null,
@@ -191,9 +194,20 @@ class SnykToolWindowSnykScanListenerLSTest : BasePlatformTestCase() {
         TestCase.assertEquals(3, rootTreeNode.childCount)
         cut.addInfoTreeNodes(rootTreeNode, mockScanIssues(), 1, 1)
         TestCase.assertEquals(5, rootTreeNode.childCount)
+        TestCase.assertEquals(rootTreeNode.children().toList()[0].toString(), " Open Source")
+        TestCase.assertEquals(rootTreeNode.children().toList()[1].toString(), " Code Security")
+        TestCase.assertEquals(rootTreeNode.children().toList()[2].toString(), " Code Quality")
+        TestCase.assertEquals(
+            rootTreeNode.children().toList()[3].toString(),
+            "1 vulnerability found by Snyk, 0 ignored",
+        )
+        TestCase.assertEquals(
+            rootTreeNode.children().toList()[4].toString(),
+            "⚡ 1 vulnerabilities can be fixed by Snyk DeepCode AI",
+        )
     }
 
-    fun `testAddInfoTreeNodes adds new tree nodes for code security if  all ignored issues are hidden`() {
+    fun `testAddInfoTreeNodes adds new tree nodes for code security if all ignored issues are hidden`() {
         pluginSettings().isGlobalIgnoresFeatureEnabled = true
         pluginSettings().ignoredIssuesEnabled = false
 


### PR DESCRIPTION
### Description

We want to include ignored issues in the fixable issues count. Also, turns out that the info node for AI fixes wasn't being rendered anyway because of how the `addInfoTreeNode` function was called, which means that `fixableIssuesCount` was null`.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
