### PR TITLE
chore: add release branch for prodsec security scan (non default)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ jobs:
       - prodsec/security_scans:
           mode: auto
           open-source-additional-arguments: --exclude=test
+          release-branch: master
           iac-scan: disabled
 
 workflows:


### PR DESCRIPTION
### Description

Add release-branch parameter to security-scans, as the default one is set to "main"

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
