### PR TITLE
fix: render error after failed ls scan [IDE-401]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Snyk Security Changelog
 
 ## [2.8.8]
+
 ### Fixes
 - change some of the colours used in the HTML panel so it's consistent with designs
+- renders errors or Snyk Code and Snyk OpenSource failed scans through the Language Server
 
 ## [2.8.7]
 ### Fixes

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLS.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLS.kt
@@ -82,7 +82,30 @@ class SnykToolWindowSnykScanListenerLS(
         }
     }
 
-    override fun scanningError(snykScan: SnykScanParams) = Unit
+    override fun scanningError(snykScan: SnykScanParams) {
+        when (snykScan.product) {
+            "oss" -> {
+                this.rootOssIssuesTreeNode.removeAllChildren()
+                this.rootOssIssuesTreeNode.userObject = "$OSS_ROOT_TEXT (error)"
+                refreshAnnotationsForOpenFiles(project)
+            }
+
+            "code" -> {
+                this.rootSecurityIssuesTreeNode.removeAllChildren()
+                this.rootSecurityIssuesTreeNode.userObject = "$CODE_SECURITY_ROOT_TEXT (error)"
+                this.rootQualityIssuesTreeNode.removeAllChildren()
+                this.rootQualityIssuesTreeNode.userObject = "$CODE_QUALITY_ROOT_TEXT (error)"
+            }
+
+            "iac" -> {
+                // TODO implement
+            }
+
+            "container" -> {
+                // TODO implement
+            }
+        }
+    }
 
     fun displaySnykCodeResults(snykResults: Map<SnykFile, List<ScanIssue>>) {
         if (disposed) return

--- a/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
+++ b/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
@@ -200,6 +200,10 @@ class SnykLanguageClient : LanguageClient, Disposable {
             "iac" -> {
                 // TODO implement
             }
+
+            "container" -> {
+                // TODO implement
+            }
         }
     }
 


### PR DESCRIPTION
### Description

When failing scans via the LS we forgot to render the error state. So this PR does that and also makes sure the error state is persisted in-between changes of the settings.

There are some linting changes too.

To test this, I used `juice-shop` since for some reason it fails when I try to scan it using OpenSource in prod. Then:
- I trigger a scan and notice the new `(error)` string appended to the open source tree node
- I enable Container scans and notice that the `(error)` string does not disappear
- I trigger a new scan and notice the `(error`) string temporarily gets replaced by the `(scanning...)` string

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

<img width="1728" alt="Screenshot 2024-06-26 at 11 52 28" src="https://github.com/snyk/snyk-intellij-plugin/assets/81559517/c355b6cc-a300-48ae-b82d-fc2c8282c4ac">

<img width="1727" alt="Screenshot 2024-06-26 at 13 32 35" src="https://github.com/snyk/snyk-intellij-plugin/assets/81559517/ab15eca1-a2ad-4f45-baf6-0298252a7017">
