### PR TITLE
feat: add support for `.snyk` file for OSS, Container and IaC products [IDE-253]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Snyk Security Changelog
 
+## [2.8.9]
+### Added
+- Updated Open Source, Containers and IaC products to include `.snyk` in the list of supported build files.
+- When a `.snyk` file changes, the OSS cache will be dropped triggering a scan.
+
+Related PRs:
+- [Language Server PR #563](https://github.com/snyk/snyk-ls/pull/563)
+
 ## [2.8.8]
 ### Added
 - renders code actions and code lenses for OpenSource scans via the LS

--- a/src/main/kotlin/snyk/iac/IacBulkFileListener.kt
+++ b/src/main/kotlin/snyk/iac/IacBulkFileListener.kt
@@ -38,7 +38,7 @@ class IacBulkFileListener : SnykBulkFileListener() {
         val allIacIssuesForFiles = currentIacResult.allCliIssues ?: return
 
         val iacRelatedVFsAffected = virtualFilesAffected
-            .filter { iacFileExtensions.contains(it.extension) }
+            .filter { scanInvalidatingFiles.contains(it.extension) }
             .filter { ProjectRootManager.getInstance(project).fileIndex.isInContent(it) }
 
         allIacIssuesForFiles
@@ -66,11 +66,12 @@ class IacBulkFileListener : SnykBulkFileListener() {
 
     companion object {
         // see https://github.com/snyk/snyk/blob/master/src/lib/iac/constants.ts#L7
-        private val iacFileExtensions = listOf(
+        private val scanInvalidatingFiles = listOf(
             "yaml",
             "yml",
             "json",
-            "tf"
+            "tf",
+            ".snyk"
         )
     }
 }

--- a/src/main/kotlin/snyk/oss/OssBulkFileListener.kt
+++ b/src/main/kotlin/snyk/oss/OssBulkFileListener.kt
@@ -68,7 +68,7 @@ class OssBulkFileListener : SnykBulkFileListener() {
         val snykCachedResults = getSnykCachedResults(project)
         if (snykCachedResults?.currentOssResults != null) {
             val buildFileChanged = virtualFilesAffected
-                .filter { supportedBuildFiles.contains(it.name) }
+                .filter { scanInvalidatingFiles.contains(it.name) }
                 .find { ProjectRootManager.getInstance(project).fileIndex.isInContent(it) }
             if (buildFileChanged != null) {
                 snykCachedResults.currentOssResults = null
@@ -88,7 +88,7 @@ class OssBulkFileListener : SnykBulkFileListener() {
 
     companion object {
         // see https://github.com/snyk/snyk/blob/master/src/lib/detect.ts#L10
-        private val supportedBuildFiles = listOf(
+        private val scanInvalidatingFiles = listOf(
             "yarn.lock",
             "package-lock.json",
             "package.json",
@@ -111,7 +111,8 @@ class OssBulkFileListener : SnykBulkFileListener() {
             "Podfile",
             "Podfile.lock",
             "pyproject.toml",
-            "poetry.lock"
+            "poetry.lock",
+            ".snyk"
         )
     }
 }


### PR DESCRIPTION
### Description

This PR adds support for handling `.snyk` file. It relates to the changes made in the Language Server (PR: https://github.com/snyk/snyk-ls/pull/563), where logic for handling `textDocumentDidSaveHandler` events for `.snyk` files was added.

When a `.snyk` file changes, the all the products cache will be dropped triggering a re-scan.

### Related PRs

- Language Server PR: https://github.com/snyk/snyk-ls/pull/563


### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs


https://github.com/snyk/snyk-intellij-plugin/assets/1948377/021fd2ac-8845-4c6d-adcb-87e85de1127c





