### PR TITLE
feat: load html for oss in ls [IDE-285]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 - Updated Open Source, Containers and IaC products to include `.snyk` in the list of supported build files.
 - When a `.snyk` file changes, the OSS cache will be dropped triggering a scan.
+- Render the OSS suggestion panel using HTML from the Languag Server.
 
 Related PRs:
 - [Language Server PR #563](https://github.com/snyk/snyk-ls/pull/563)

--- a/src/main/kotlin/io/snyk/plugin/ui/jcef/OpenFileLoadHandlerGenerator.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/jcef/OpenFileLoadHandlerGenerator.kt
@@ -1,22 +1,16 @@
 package io.snyk.plugin.ui.jcef
 
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.editor.colors.ColorKey
 import com.intellij.openapi.editor.colors.EditorColorsManager
-import com.intellij.openapi.editor.colors.EditorColorsScheme
-import com.intellij.openapi.editor.colors.FontPreferences
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.ui.jcef.JBCefBrowserBase
 import com.intellij.ui.jcef.JBCefJSQuery
-import com.intellij.util.ui.JBUI
-import com.intellij.util.ui.UIUtil
 import io.snyk.plugin.getDocument
 import io.snyk.plugin.navigateToSource
 import org.cef.browser.CefBrowser
 import org.cef.browser.CefFrame
 import org.cef.handler.CefLoadHandlerAdapter
-import java.awt.Color
 
 class OpenFileLoadHandlerGenerator(
     private val project: Project,
@@ -43,38 +37,6 @@ class OpenFileLoadHandlerGenerator(
         }
 
         return JBCefJSQuery.Response("success")
-    }
-
-    fun toCssHex(color: Color): String {
-        return "#%02x%02x%02x".format(color.red, color.green, color.blue)
-    }
-
-    fun shift(
-        colorComponent: Int,
-        d: Double,
-    ): Int {
-        val n = (colorComponent * d).toInt()
-        return n.coerceIn(0, 255)
-    }
-
-    fun getCodeDiffColors(
-        baseColor: Color,
-        isHighContrast: Boolean,
-    ): Pair<Color, Color> {
-        val addedColor =
-            if (isHighContrast) {
-                Color(28, 68, 40) // high contrast green
-            } else {
-                Color(shift(baseColor.red, 0.75), baseColor.green, shift(baseColor.blue, 0.75))
-            }
-
-        val removedColor =
-            if (isHighContrast) {
-                Color(84, 36, 38) // high contrast red
-            } else {
-                Color(shift(baseColor.red, 1.25), shift(baseColor.green, 0.85), shift(baseColor.blue, 0.85))
-            }
-        return Pair(addedColor, removedColor)
     }
 
     fun generate(jbCefBrowser: JBCefBrowserBase): CefLoadHandlerAdapter {
@@ -124,60 +86,6 @@ class OpenFileLoadHandlerGenerator(
                     })();
                 """
                     browser.executeJavaScript(script, browser.url, 0)
-
-                    val baseColor = UIUtil.getTextFieldBackground()
-                    val (addedColor, removedColor) = getCodeDiffColors(baseColor, isHighContrast)
-
-                    val textColor = toCssHex(JBUI.CurrentTheme.Label.foreground())
-                    val linkColor = toCssHex(JBUI.CurrentTheme.Link.Foreground.ENABLED)
-                    val dataFlowColor = toCssHex(baseColor)
-                    val borderColor = toCssHex(JBUI.CurrentTheme.CustomFrameDecorations.separatorForeground())
-                    val editorColor =
-                        toCssHex(UIUtil.getTextFieldBackground())
-
-                    val globalScheme = EditorColorsManager.getInstance().globalScheme
-                    val tearLineColor =
-                        globalScheme.getColor(ColorKey.find("TEARLINE_COLOR")) // The closest color to target_rgb = (198, 198, 200)
-                    val tabItemHoverColor =
-                        globalScheme.getColor(ColorKey.find("INDENT_GUIDE")) // The closest color to target_rgb = RGB (235, 236, 240)
-
-                    val editorColorsManager = EditorColorsManager.getInstance()
-                    val editorColorsScheme: EditorColorsScheme = editorColorsManager.globalScheme
-                    val fontPreferences: FontPreferences = editorColorsScheme.fontPreferences
-                    val editorFont = fontPreferences.fontFamily
-
-                    val themeScript = """
-                        (function(){
-                        if (window.themeApplied) {
-                            return;
-                        }
-                        window.themeApplied = true;
-                        const style = getComputedStyle(document.documentElement);
-                            const properties = {
-                                '--text-color': "$textColor",
-                                '--link-color': "$linkColor",
-                                '--data-flow-body-color': "$dataFlowColor",
-                                '--example-line-added-color': "${toCssHex(addedColor)}",
-                                '--example-line-removed-color': "${toCssHex(removedColor)}",
-                                '--tab-item-github-icon-color': "$textColor",
-                                '--tab-item-hover-color': "${tabItemHoverColor?.let { toCssHex(it) }}",
-                                '--scrollbar-thumb-color': "${tearLineColor?.let { toCssHex(it) }}",
-                                '--tabs-bottom-color': "${tearLineColor?.let { toCssHex(it) }}",
-                                '--border-color': "$borderColor",
-                                '--editor-color': "$editorColor",
-                                '--editor-font': "'$editorFont'",
-                            };
-                            for (let [property, value] of Object.entries(properties)) {
-                                document.documentElement.style.setProperty(property, value);
-                            }
-
-                            // Add theme class to body
-                            const isDarkTheme = $isDarkTheme;
-                            const isHighContrast = $isHighContrast;
-                            document.body.classList.add(isHighContrast ? 'high-contrast' : (isDarkTheme ? 'dark' : 'light'));
-                        })();
-                        """
-                    browser.executeJavaScript(themeScript, browser.url, 0)
                 }
             }
         }

--- a/src/main/kotlin/io/snyk/plugin/ui/jcef/ThemeBasedStylingGenerator.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/jcef/ThemeBasedStylingGenerator.kt
@@ -1,0 +1,119 @@
+package io.snyk.plugin.ui.jcef
+
+import com.intellij.openapi.editor.colors.ColorKey
+import com.intellij.openapi.editor.colors.EditorColorsManager
+import com.intellij.openapi.editor.colors.EditorColorsScheme
+import com.intellij.openapi.editor.colors.FontPreferences
+import com.intellij.ui.jcef.JBCefBrowserBase
+import com.intellij.util.ui.JBUI
+import com.intellij.util.ui.UIUtil
+import org.cef.browser.CefBrowser
+import org.cef.browser.CefFrame
+import org.cef.handler.CefLoadHandlerAdapter
+import java.awt.Color
+
+class ThemeBasedStylingGenerator {
+    fun toCssHex(color: Color): String {
+        return "#%02x%02x%02x".format(color.red, color.green, color.blue)
+    }
+
+    fun shift(
+        colorComponent: Int,
+        d: Double,
+    ): Int {
+        val n = (colorComponent * d).toInt()
+        return n.coerceIn(0, 255)
+    }
+
+    fun getCodeDiffColors(
+        baseColor: Color,
+        isHighContrast: Boolean,
+    ): Pair<Color, Color> {
+        val addedColor =
+            if (isHighContrast) {
+                Color(28, 68, 40) // high contrast green
+            } else {
+                Color(shift(baseColor.red, 0.75), baseColor.green, shift(baseColor.blue, 0.75))
+            }
+
+        val removedColor =
+            if (isHighContrast) {
+                Color(84, 36, 38) // high contrast red
+            } else {
+                Color(shift(baseColor.red, 1.25), shift(baseColor.green, 0.85), shift(baseColor.blue, 0.85))
+            }
+        return Pair(addedColor, removedColor)
+    }
+
+    fun generate(jbCefBrowser: JBCefBrowserBase): CefLoadHandlerAdapter {
+        val isDarkTheme = EditorColorsManager.getInstance().isDarkEditor
+        val isHighContrast =
+            EditorColorsManager.getInstance().globalScheme.name.contains("High contrast", ignoreCase = true)
+
+        return object : CefLoadHandlerAdapter() {
+            override fun onLoadEnd(
+                browser: CefBrowser,
+                frame: CefFrame,
+                httpStatusCode: Int,
+            ) {
+                if (frame.isMain) {
+                    val baseColor = UIUtil.getTextFieldBackground()
+                    val (addedColor, removedColor) = getCodeDiffColors(baseColor, isHighContrast)
+
+                    val textColor = toCssHex(JBUI.CurrentTheme.Label.foreground())
+                    val linkColor = toCssHex(JBUI.CurrentTheme.Link.Foreground.ENABLED)
+                    val dataFlowColor = toCssHex(baseColor)
+                    val borderColor = toCssHex(JBUI.CurrentTheme.CustomFrameDecorations.separatorForeground())
+                    val editorColor =
+                        toCssHex(UIUtil.getTextFieldBackground())
+                    val labelColor = toCssHex(JBUI.CurrentTheme.Label.foreground())
+
+                    val globalScheme = EditorColorsManager.getInstance().globalScheme
+                    val tearLineColor =
+                        globalScheme.getColor(ColorKey.find("TEARLINE_COLOR")) // The closest color to target_rgb = (198, 198, 200)
+                    val tabItemHoverColor =
+                        globalScheme.getColor(ColorKey.find("INDENT_GUIDE")) // The closest color to target_rgb = RGB (235, 236, 240)
+
+                    val editorColorsManager = EditorColorsManager.getInstance()
+                    val editorColorsScheme: EditorColorsScheme = editorColorsManager.globalScheme
+                    val fontPreferences: FontPreferences = editorColorsScheme.fontPreferences
+                    val editorFont = fontPreferences.fontFamily
+
+                    val themeScript = """
+                        (function(){
+                        if (window.themeApplied) {
+                            return;
+                        }
+                        window.themeApplied = true;
+                        const style = getComputedStyle(document.documentElement);
+                            const properties = {
+                                '--text-color': "$textColor",
+                                '--link-color': "$linkColor",
+                                '--data-flow-body-color': "$dataFlowColor",
+                                '--example-line-added-color': "${toCssHex(addedColor)}",
+                                '--example-line-removed-color': "${toCssHex(removedColor)}",
+                                '--tab-item-github-icon-color': "$textColor",
+                                '--tab-item-hover-color': "${tabItemHoverColor?.let { toCssHex(it) }}",
+                                '--scrollbar-thumb-color': "${tearLineColor?.let { toCssHex(it) }}",
+                                '--tabs-bottom-color': "${tearLineColor?.let { toCssHex(it) }}",
+                                '--border-color': "$borderColor",
+                                '--editor-color': "$editorColor",
+                                '--editor-font': "'$editorFont'",
+                                '--label-color': "'$labelColor'",
+                            };
+                            for (let [property, value] of Object.entries(properties)) {
+                                document.documentElement.style.setProperty(property, value);
+                            }
+
+                            // Add theme class to body
+                            const isDarkTheme = $isDarkTheme;
+                            const isHighContrast = $isHighContrast;
+                            document.body.classList.add(isHighContrast ? 'high-contrast' : (isDarkTheme ? 'dark' : 'light'));
+                        })();
+                        """
+                    browser.executeJavaScript(themeScript, browser.url, 0)
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/io/snyk/plugin/ui/jcef/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/jcef/Utils.kt
@@ -6,10 +6,12 @@ import com.intellij.ui.jcef.JBCefBrowserBuilder
 import org.cef.handler.CefLoadHandlerAdapter
 import java.awt.Component
 
+typealias LoadHandlerGenerator = (jbCefBrowser: JBCefBrowser) -> CefLoadHandlerAdapter
+
 object JCEFUtils {
     fun getJBCefBrowserComponentIfSupported(
         html: String,
-        loadHandlerGenerator: (jbCefBrowser: JBCefBrowser) -> CefLoadHandlerAdapter,
+        loadHandlerGenerators: List<LoadHandlerGenerator>,
     ): Component? {
         if (!JBCefApp.isSupported()) {
             return null
@@ -21,9 +23,10 @@ object JCEFUtils {
                 .setMouseWheelEventEnable(true).build()
         jbCefBrowser.setOpenLinksInExternalBrowser(true)
 
-        val loadHandler = loadHandlerGenerator(jbCefBrowser)
-        cefClient.addLoadHandler(loadHandler, jbCefBrowser.cefBrowser)
-
+        for (loadHandlerGenerator in loadHandlerGenerators) {
+            val loadHandler = loadHandlerGenerator(jbCefBrowser)
+            cefClient.addLoadHandler(loadHandler, jbCefBrowser.cefBrowser)
+        }
         jbCefBrowser.loadHTML(html, jbCefBrowser.cefBrowser.url)
 
         return jbCefBrowser.component

--- a/src/main/kotlin/snyk/common/lsp/Types.kt
+++ b/src/main/kotlin/snyk/common/lsp/Types.kt
@@ -261,8 +261,10 @@ data class ScanIssue(
 
     fun canLoadSuggestionPanelFromHTML(): Boolean {
         return when (this.additionalData.getProductType()) {
-            ProductType.OSS -> false
-            ProductType.CODE_SECURITY, ProductType.CODE_QUALITY -> this.additionalData.details != null
+            ProductType.OSS -> true
+            ProductType.CODE_SECURITY, ProductType.CODE_QUALITY ->
+                pluginSettings().isGlobalIgnoresFeatureEnabled && this.additionalData.details != null
+
             else -> TODO()
         }
     }

--- a/src/main/kotlin/stylesheets/SnykStylesheets.kt
+++ b/src/main/kotlin/stylesheets/SnykStylesheets.kt
@@ -3,9 +3,9 @@ package stylesheets
 object SnykStylesheets {
     private fun getStylesheet(name: String): String {
         return this::class.java.getResource(name)?.readText()
-            ?:  ""
+            ?: ""
     }
 
     val SnykCodeSuggestion = getStylesheet("/stylesheets/snyk_code_suggestion.css")
+    val SnykOSSSuggestion = getStylesheet("/stylesheets/snyk_oss_suggestion.css")
 }
-

--- a/src/main/resources/stylesheets/snyk_oss_suggestion.scss
+++ b/src/main/resources/stylesheets/snyk_oss_suggestion.scss
@@ -1,0 +1,78 @@
+::-webkit-scrollbar-thumb {
+  background: var(--scrollbar-thumb-color);
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: #595a5c;
+}
+
+html, body {
+  height: 100%;
+  font-size: 16px;
+  display: flex;
+  flex-direction: column;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  color: var(--text-color);
+  font-weight: 400;
+  font-size: 0.875rem;
+}
+
+.font-light {
+  font-weight: bold;
+}
+
+a,
+.link {
+  color: var(--link-color);
+}
+
+.delimiter {
+  border-right: 1px solid var(--border-color);
+}
+
+.suggestion--header {
+  padding-top: 10px;
+}
+
+.suggestion .suggestion-text {
+  font-size: 1.5rem;
+  position: relative;
+  top: -5%;
+}
+
+.summary .summary-item {
+  margin-bottom: 0.8em;
+}
+
+.summary .label {
+  font-size: 0.8rem;
+}
+
+.suggestion--header > h2,
+.summary > h2,
+.vulnerability-overview > h2 {
+  font-size: 0.9rem;
+  margin-bottom: 1.5em;
+}
+
+.identifiers {
+  padding-bottom: 20px;
+}
+
+.vulnerability-overview pre {
+  font-size: 1.05rem;
+  font-family: var(--editor-font);
+  background-color: transparent;
+  border: 1px solid transparent;
+  padding: 0;
+}
+
+.vulnerability-overview code {
+  background-color: transparent;
+  font-size: 1.05rem;
+  font-family: var(--editor-font);
+}

--- a/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SuggestionDescriptionPanelFromLSCodeTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SuggestionDescriptionPanelFromLSCodeTest.kt
@@ -12,7 +12,6 @@ import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import io.snyk.plugin.Severity
 import io.snyk.plugin.SnykFile
-import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.resetSettings
 import io.snyk.plugin.ui.jcef.JCEFUtils
 import io.snyk.plugin.ui.toolwindow.panels.SuggestionDescriptionPanelFromLS
@@ -82,7 +81,9 @@ class SuggestionDescriptionPanelFromLSCodeTest : BasePlatformTestCase() {
     }
 
     @Test
-    fun `test createUI should build the right panels for Snyk Code`() {
+    fun `test createUI should build the right panels for Snyk Code if HTML is not allowed`() {
+        every { issue.canLoadSuggestionPanelFromHTML() } returns false
+
         cut = SuggestionDescriptionPanelFromLS(snykFile, issue)
 
         val issueNaming = getJLabelByText(cut, issue.issueNaming())
@@ -108,22 +109,9 @@ class SuggestionDescriptionPanelFromLSCodeTest : BasePlatformTestCase() {
     }
 
     @Test
-    fun `test createUI should build panel with issue message as overview label if the feature flag is not enabled`() {
-        every { issue.details() } returns ""
-        cut = SuggestionDescriptionPanelFromLS(snykFile, issue)
-
-        val actual = getJLabelByText(cut, "<html>Test message</html>")
-        assertNotNull(actual)
-
-        val actualBrowser = getJBCEFBrowser(cut)
-        assertNull(actualBrowser)
-    }
-
-    @Test
-    fun `test createUI should build panel with issue message as overview label if HTML is not allowed, even if the feature flag is enabled`() {
-        pluginSettings().isGlobalIgnoresFeatureEnabled = true
-
+    fun `test createUI should build panel with issue message as overview label if HTML is not allowed`() {
         every { issue.canLoadSuggestionPanelFromHTML() } returns false
+
         cut = SuggestionDescriptionPanelFromLS(snykFile, issue)
 
         val actual = getJLabelByText(cut, "<html>Test message</html>")
@@ -134,9 +122,7 @@ class SuggestionDescriptionPanelFromLSCodeTest : BasePlatformTestCase() {
     }
 
     @Test
-    fun `test createUI should show nothing if feature flag is enabled but JCEF is not`() {
-        pluginSettings().isGlobalIgnoresFeatureEnabled = true
-
+    fun `test createUI should show nothing if HTML is allowed but JCEF is not supported`() {
         mockkObject(JCEFUtils)
         every { JCEFUtils.getJBCefBrowserComponentIfSupported(eq("<html>HTML message</html>"), any()) } returns null
 
@@ -152,9 +138,7 @@ class SuggestionDescriptionPanelFromLSCodeTest : BasePlatformTestCase() {
     }
 
     @Test
-    fun `test createUI should build panel with HTML from details if feature flag is enabled`() {
-        pluginSettings().isGlobalIgnoresFeatureEnabled = true
-
+    fun `test createUI should build panel with HTML from details if allowed`() {
         val mockJBCefBrowserComponent = JLabel("<html>HTML message</html>")
         mockkObject(JCEFUtils)
         every {
@@ -173,9 +157,7 @@ class SuggestionDescriptionPanelFromLSCodeTest : BasePlatformTestCase() {
     }
 
     @Test
-    fun `test getStyledHTML should inject CSS into the HTML`() {
-        pluginSettings().isGlobalIgnoresFeatureEnabled = true
-
+    fun `test getStyledHTML should inject CSS into the HTML if allowed`() {
         every { issue.details() } returns "<html><head>\${ideStyle}</head>HTML message</html>"
         every { issue.canLoadSuggestionPanelFromHTML() } returns true
         cut = SuggestionDescriptionPanelFromLS(snykFile, issue)


### PR DESCRIPTION
### Description

Adds some styling so that the new HTML panel and the native panel look more or less the same. The only noticeable differences are:
- The text in the `Detailed paths` changed from `Fix` to `Remediation`
- The font for the code, which now matches the one chosen by the customer
- The labels don't have a colon anymore, which matches what we see in VSCode too (could add the colons back if needed via CSS)

Refactors the code a bit too so that we can re-use more of it for both Snyk Code and Snyk OSS.

Needs https://github.com/snyk/cli/pull/5356 for testing.

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs
Native:
<img width="1723" alt="goal 1" src="https://github.com/snyk/snyk-intellij-plugin/assets/81559517/23cde999-51fe-41a2-a589-20f0d739d0fe">
<img width="1709" alt="goal 2" src="https://github.com/snyk/snyk-intellij-plugin/assets/81559517/a91cfa37-0608-4aba-abfb-1e7d6e5c4e2f">

HTML:
<img width="1715" alt="Screenshot 2024-07-10 at 13 24 10" src="https://github.com/snyk/snyk-intellij-plugin/assets/81559517/88344954-5258-4abd-8d48-e06dd45d64d1">
<img width="1711" alt="Screenshot 2024-07-10 at 13 24 21" src="https://github.com/snyk/snyk-intellij-plugin/assets/81559517/fbede79f-601e-4876-888b-a5838c66ce61">
