### PR TITLE
fix: invalidate oss cache in ls when files change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Updated Open Source, Containers and IaC products to include `.snyk` in the list of supported build files.
 - When a `.snyk` file changes, the OSS cache will be dropped triggering a scan.
 
+### Fixed
+- Refresh the OSS cache for Language Server scans when a file is changed.   
+
 Related PRs:
 - [Language Server PR #563](https://github.com/snyk/snyk-ls/pull/563)
 

--- a/src/main/kotlin/snyk/oss/OssBulkFileListener.kt
+++ b/src/main/kotlin/snyk/oss/OssBulkFileListener.kt
@@ -23,17 +23,22 @@ import org.eclipse.lsp4j.TextDocumentIdentifier
 import snyk.common.lsp.LanguageServerWrapper
 
 class OssBulkFileListener : SnykBulkFileListener() {
-
     private val log = logger<OssBulkFileListener>()
 
-    override fun before(project: Project, virtualFilesAffected: Set<VirtualFile>) {
+    override fun before(
+        project: Project,
+        virtualFilesAffected: Set<VirtualFile>,
+    ) {
         if (isSnykOSSLSEnabled()) {
             return
         }
         dropOssCacheIfNeeded(project, virtualFilesAffected)
     }
 
-    override fun after(project: Project, virtualFilesAffected: Set<VirtualFile>) {
+    override fun after(
+        project: Project,
+        virtualFilesAffected: Set<VirtualFile>,
+    ) {
         if (isSnykOSSLSEnabled()) {
             val filesAffected = toSnykFileSet(project, virtualFilesAffected)
             updateCacheAndUI(filesAffected, project)
@@ -52,24 +57,34 @@ class OssBulkFileListener : SnykBulkFileListener() {
             if (event.file == null || !event.isFromSave) continue
             val file = event.file!!
             val activeProject = ProjectUtil.getActiveProject()
-            ProgressManager.getInstance().run(object : Task.Backgroundable(
-                activeProject,
-                "Snyk: forwarding save event to Language Server"
-            ) {
-                override fun run(indicator: ProgressIndicator) {
-                    val param = DidSaveTextDocumentParams(TextDocumentIdentifier(file.toLanguageServerURL()), file.readText())
-                    languageServer.textDocumentService.didSave(param)
-                }
-            })
+            ProgressManager.getInstance().run(
+                object : Task.Backgroundable(
+                    activeProject,
+                    "Snyk: forwarding save event to Language Server",
+                ) {
+                    override fun run(indicator: ProgressIndicator) {
+                        val param =
+                            DidSaveTextDocumentParams(
+                                TextDocumentIdentifier(file.toLanguageServerURL()),
+                                file.readText(),
+                            )
+                        languageServer.textDocumentService.didSave(param)
+                    }
+                },
+            )
         }
     }
 
-    private fun dropOssCacheIfNeeded(project: Project, virtualFilesAffected: Set<VirtualFile>) {
+    private fun dropOssCacheIfNeeded(
+        project: Project,
+        virtualFilesAffected: Set<VirtualFile>,
+    ) {
         val snykCachedResults = getSnykCachedResults(project)
         if (snykCachedResults?.currentOssResults != null) {
-            val buildFileChanged = virtualFilesAffected
-                .filter { scanInvalidatingFiles.contains(it.name) }
-                .find { ProjectRootManager.getInstance(project).fileIndex.isInContent(it) }
+            val buildFileChanged =
+                virtualFilesAffected
+                    .filter { scanInvalidatingFiles.contains(it.name) }
+                    .find { ProjectRootManager.getInstance(project).fileIndex.isInContent(it) }
             if (buildFileChanged != null) {
                 snykCachedResults.currentOssResults = null
                 log.debug("OSS cached results dropped due to changes in: $buildFileChanged")
@@ -77,8 +92,11 @@ class OssBulkFileListener : SnykBulkFileListener() {
         }
     }
 
-    private fun updateCacheAndUI(filesAffected: Set<SnykFile>, project: Project) {
-        val cache = getSnykCachedResults(project)?.currentSnykCodeResultsLS ?: return
+    private fun updateCacheAndUI(
+        filesAffected: Set<SnykFile>,
+        project: Project,
+    ) {
+        val cache = getSnykCachedResults(project)?.currentOSSResultsLS ?: return
         filesAffected.forEach {
             cache.remove(it)
         }
@@ -88,31 +106,32 @@ class OssBulkFileListener : SnykBulkFileListener() {
 
     companion object {
         // see https://github.com/snyk/snyk/blob/master/src/lib/detect.ts#L10
-        private val scanInvalidatingFiles = listOf(
-            "yarn.lock",
-            "package-lock.json",
-            "package.json",
-            "Gemfile",
-            "Gemfile.lock",
-            "pom.xml",
-            "build.gradle",
-            "build.gradle.kts",
-            "build.sbt",
-            "Pipfile",
-            "requirements.txt",
-            "Gopkg.lock",
-            "go.mod",
-            "vendor.json",
-            "project.assets.json",
-            "project.assets.json",
-            "packages.config",
-            "paket.dependencies",
-            "composer.lock",
-            "Podfile",
-            "Podfile.lock",
-            "pyproject.toml",
-            "poetry.lock",
-            ".snyk"
-        )
+        private val scanInvalidatingFiles =
+            listOf(
+                "yarn.lock",
+                "package-lock.json",
+                "package.json",
+                "Gemfile",
+                "Gemfile.lock",
+                "pom.xml",
+                "build.gradle",
+                "build.gradle.kts",
+                "build.sbt",
+                "Pipfile",
+                "requirements.txt",
+                "Gopkg.lock",
+                "go.mod",
+                "vendor.json",
+                "project.assets.json",
+                "project.assets.json",
+                "packages.config",
+                "paket.dependencies",
+                "composer.lock",
+                "Podfile",
+                "Podfile.lock",
+                "pyproject.toml",
+                "poetry.lock",
+                ".snyk",
+            )
     }
 }


### PR DESCRIPTION
### Description

Formatting mostly (because of the linter), the only actual change is line 99.

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing
