### PR TITLE
fix: better error handling for OSS scans via LS [IDE-486]

### DIFF
--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
@@ -1059,9 +1059,6 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
     @TestOnly
     fun getRootOssIssuesTreeNode() = rootOssTreeNode
 
-    @TestOnly
-    fun getRootCodeQualityIssuesTreeNode() = rootQualityIssuesTreeNode
-
     fun getTree() = vulnerabilitiesTree
 
     @TestOnly

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
@@ -104,7 +104,10 @@ import javax.swing.tree.TreePath
  * Main panel for Snyk tool window.
  */
 @Service(Service.Level.PROJECT)
-class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
+class SnykToolWindowPanel(
+    val project: Project,
+) : JPanel(),
+    Disposable {
     internal val descriptionPanel = SimpleToolWindowPanel(true, true).apply { name = "descriptionPanel" }
     private val logger = Logger.getInstance(this::class.java)
     private val rootTreeNode = DefaultMutableTreeNode("")
@@ -174,7 +177,8 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
                 scanListener
             }
 
-        project.messageBus.connect(this)
+        project.messageBus
+            .connect(this)
             .subscribe(
                 SnykScanListener.SNYK_SCAN_TOPIC,
                 object : SnykScanListener {
@@ -288,7 +292,8 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
                 },
             )
 
-        project.messageBus.connect(this)
+        project.messageBus
+            .connect(this)
             .subscribe(
                 SnykResultsFilteringListener.SNYK_FILTERING_TOPIC,
                 object : SnykResultsFilteringListener {
@@ -319,7 +324,10 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
                 },
             )
 
-        ApplicationManager.getApplication().messageBus.connect(this)
+        ApplicationManager
+            .getApplication()
+            .messageBus
+            .connect(this)
             .subscribe(
                 SnykCliDownloadListener.CLI_DOWNLOAD_TOPIC,
                 object : SnykCliDownloadListener {
@@ -333,7 +341,8 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
                 },
             )
 
-        project.messageBus.connect(this)
+        project.messageBus
+            .connect(this)
             .subscribe(
                 SnykSettingsListener.SNYK_SETTINGS_TOPIC,
                 object : SnykSettingsListener {
@@ -344,7 +353,8 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
                 },
             )
 
-        project.messageBus.connect(this)
+        project.messageBus
+            .connect(this)
             .subscribe(
                 SnykTaskQueueListener.TASK_QUEUE_TOPIC,
                 object : SnykTaskQueueListener {
@@ -484,7 +494,8 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
 
     private fun triggerScan() {
         getSnykAnalyticsService().logAnalysisIsTriggered(
-            AnalysisIsTriggered.builder()
+            AnalysisIsTriggered
+                .builder()
                 .analysisType(getSelectedProducts(pluginSettings()))
                 .ide(AnalysisIsTriggered.Ide.JETBRAINS)
                 .triggeredByUser(true)
@@ -504,7 +515,8 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
         revalidate()
 
         getSnykAnalyticsService().logWelcomeIsViewed(
-            WelcomeIsViewed.builder()
+            WelcomeIsViewed
+                .builder()
                 .ide(JETBRAINS)
                 .build(),
         )
@@ -566,10 +578,13 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
     ) {
         val settings = pluginSettings()
 
+        val realError = getSnykCachedResults(project)?.currentOssError != null
+            && ossResultsCount != NODE_NOT_SUPPORTED_STATE
+
         val newOssTreeNodeText =
             when {
-                getSnykCachedResults(project)?.currentOssError != null -> "$OSS_ROOT_TEXT (error)"
                 isOssRunning(project) && settings.ossScanEnable -> "$OSS_ROOT_TEXT (scanning...)"
+                realError -> "$OSS_ROOT_TEXT (error)"
 
                 else ->
                     ossResultsCount?.let { count ->
@@ -590,7 +605,8 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
                 getSnykCachedResults(project)?.currentSnykCodeError != null -> "$CODE_SECURITY_ROOT_TEXT (error)"
                 isSnykCodeRunning(
                     project,
-                ) && settings.snykCodeSecurityIssuesScanEnable -> "$CODE_SECURITY_ROOT_TEXT (scanning...)"
+                ) &&
+                    settings.snykCodeSecurityIssuesScanEnable -> "$CODE_SECURITY_ROOT_TEXT (scanning...)"
 
                 else ->
                     securityIssuesCount?.let { count ->
@@ -610,7 +626,8 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
                 getSnykCachedResults(project)?.currentSnykCodeError != null -> "$CODE_QUALITY_ROOT_TEXT (error)"
                 isSnykCodeRunning(
                     project,
-                ) && settings.snykCodeQualityIssuesScanEnable -> "$CODE_QUALITY_ROOT_TEXT (scanning...)"
+                ) &&
+                    settings.snykCodeQualityIssuesScanEnable -> "$CODE_QUALITY_ROOT_TEXT (scanning...)"
 
                 else ->
                     qualityIssuesCount?.let { count ->
@@ -1086,7 +1103,7 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
         const val NO_SUPPORTED_PACKAGE_MANAGER_FOUND = " - No supported package manager found"
         private const val TOOL_WINDOW_SPLITTER_PROPORTION_KEY = "SNYK_TOOL_WINDOW_SPLITTER_PROPORTION"
         internal const val NODE_INITIAL_STATE = -1
-        private const val NODE_NOT_SUPPORTED_STATE = -2
+        const val NODE_NOT_SUPPORTED_STATE = -2
 
         private val CONTAINER_DOCS_TEXT_WITH_LINK =
             """

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
@@ -105,7 +105,7 @@ import javax.swing.tree.TreePath
  */
 @Service(Service.Level.PROJECT)
 class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
-    private val descriptionPanel = SimpleToolWindowPanel(true, true).apply { name = "descriptionPanel" }
+    internal val descriptionPanel = SimpleToolWindowPanel(true, true).apply { name = "descriptionPanel" }
     private val logger = Logger.getInstance(this::class.java)
     private val rootTreeNode = DefaultMutableTreeNode("")
     private val rootOssTreeNode = RootOssTreeNode(project)

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
@@ -233,7 +233,7 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
                     override fun scanningOssError(snykError: SnykError) {
                         var ossResultsCount: Int? = null
                         ApplicationManager.getApplication().invokeLater {
-                            if (snykError.message.startsWith(NO_OSS_FILES)) {
+                            if (snykError.message.contains(NO_OSS_FILES)) {
                                 rootOssTreeNode.originalCliErrorMessage = snykError.message
                                 ossResultsCount = NODE_NOT_SUPPORTED_STATE
                             } else {

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLS.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLS.kt
@@ -87,7 +87,6 @@ class SnykToolWindowSnykScanListenerLS(
             "oss" -> {
                 this.rootOssIssuesTreeNode.removeAllChildren()
                 this.rootOssIssuesTreeNode.userObject = "$OSS_ROOT_TEXT (error)"
-                refreshAnnotationsForOpenFiles(project)
             }
 
             "code" -> {

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLS.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLS.kt
@@ -15,6 +15,8 @@ import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.refreshAnnotationsForOpenFiles
 import io.snyk.plugin.ui.toolwindow.SnykToolWindowPanel.Companion.CODE_QUALITY_ROOT_TEXT
 import io.snyk.plugin.ui.toolwindow.SnykToolWindowPanel.Companion.CODE_SECURITY_ROOT_TEXT
+import io.snyk.plugin.ui.toolwindow.SnykToolWindowPanel.Companion.NODE_NOT_SUPPORTED_STATE
+import io.snyk.plugin.ui.toolwindow.SnykToolWindowPanel.Companion.NO_OSS_FILES
 import io.snyk.plugin.ui.toolwindow.SnykToolWindowPanel.Companion.OSS_ROOT_TEXT
 import io.snyk.plugin.ui.toolwindow.nodes.leaf.SuggestionTreeNode
 import io.snyk.plugin.ui.toolwindow.nodes.root.RootContainerIssuesTreeNode
@@ -25,6 +27,7 @@ import io.snyk.plugin.ui.toolwindow.nodes.root.RootSecurityIssuesTreeNode
 import io.snyk.plugin.ui.toolwindow.nodes.secondlevel.InfoTreeNode
 import io.snyk.plugin.ui.toolwindow.nodes.secondlevel.SnykCodeFileTreeNode
 import snyk.common.ProductType
+import snyk.common.lsp.CliError
 import snyk.common.lsp.ScanIssue
 import snyk.common.lsp.SnykScanParams
 import javax.swing.JTree
@@ -218,10 +221,19 @@ class SnykToolWindowSnykScanListenerLS(
             }
         }
 
+        val currentOssError = getSnykCachedResults(project)?.currentOssError
+        val cliErrorMessage = currentOssError?.message
+
+        var ossResultsCountForDisplay = ossResultsCount
+        if (cliErrorMessage?.contains(NO_OSS_FILES) == true) {
+            snykToolWindowPanel.getRootOssIssuesTreeNode().originalCliErrorMessage = cliErrorMessage
+            ossResultsCountForDisplay = NODE_NOT_SUPPORTED_STATE
+        }
+
         snykToolWindowPanel.updateTreeRootNodesPresentation(
             securityIssuesCount = securityIssuesCount,
             qualityIssuesCount = qualityIssuesCount,
-            ossResultsCount = ossResultsCount,
+            ossResultsCount = ossResultsCountForDisplay,
             iacResultsCount = iacResultsCount,
             containerResultsCount = containerResultsCount,
             addHMLPostfix = rootNodePostFix,

--- a/src/main/kotlin/snyk/common/SnykCachedResults.kt
+++ b/src/main/kotlin/snyk/common/SnykCachedResults.kt
@@ -21,7 +21,9 @@ import snyk.iac.IacResult
 import snyk.oss.OssResult
 
 @Service(Service.Level.PROJECT)
-class SnykCachedResults(val project: Project) : Disposable {
+class SnykCachedResults(
+    val project: Project,
+) : Disposable {
     private var disposed = false
         get() {
             return project.isDisposed || ApplicationManager.getApplication().isDisposed || field
@@ -155,25 +157,34 @@ class SnykCachedResults(val project: Project) : Disposable {
                     when (snykScan.product) {
                         "oss" -> {
                             currentOssError =
-                                SnykError("Failed to run Snyk OpenSource scan", snykScan.folderPath)
+                                SnykError(
+                                    "Failed to run Snyk Open Source scan: ${snykScan.errorMessage}",
+                                    snykScan.folderPath,
+                                )
                         }
 
                         "code" -> {
                             currentSnykCodeError =
-                                SnykError("Failed to run Snyk Code scan", snykScan.folderPath)
+                                SnykError(
+                                    "Failed to run Snyk Code scan: ${snykScan.errorMessage}",
+                                    snykScan.folderPath,
+                                )
                         }
 
                         "iac" -> {
                             currentIacError =
                                 SnykError(
-                                    "Failed to run Snyk Infrastructure as Code scan",
+                                    "Failed to run Snyk Infrastructure as Code scan: ${snykScan.errorMessage}",
                                     snykScan.folderPath,
                                 )
                         }
 
                         "container" -> {
                             currentContainerError =
-                                SnykError("Failed to run Snyk Container scan", snykScan.folderPath)
+                                SnykError(
+                                    "Failed to run Snyk Container scan: ${snykScan.errorMessage}",
+                                    snykScan.folderPath,
+                                )
                         }
                     }
                     SnykBalloonNotificationHelper

--- a/src/main/kotlin/snyk/common/SnykCachedResults.kt
+++ b/src/main/kotlin/snyk/common/SnykCachedResults.kt
@@ -160,6 +160,7 @@ class SnykCachedResults(
                                 SnykError(
                                     "Failed to run Snyk Open Source scan: ${snykScan.errorMessage}",
                                     snykScan.folderPath,
+                                    snykScan.errorCode
                                 )
                         }
 
@@ -168,6 +169,7 @@ class SnykCachedResults(
                                 SnykError(
                                     "Failed to run Snyk Code scan: ${snykScan.errorMessage}",
                                     snykScan.folderPath,
+                                    snykScan.errorCode
                                 )
                         }
 
@@ -176,6 +178,7 @@ class SnykCachedResults(
                                 SnykError(
                                     "Failed to run Snyk Infrastructure as Code scan: ${snykScan.errorMessage}",
                                     snykScan.folderPath,
+                                    snykScan.errorCode
                                 )
                         }
 
@@ -184,6 +187,7 @@ class SnykCachedResults(
                                 SnykError(
                                     "Failed to run Snyk Container scan: ${snykScan.errorMessage}",
                                     snykScan.folderPath,
+                                    snykScan.errorCode
                                 )
                         }
                     }

--- a/src/main/kotlin/snyk/common/SnykCachedResults.kt
+++ b/src/main/kotlin/snyk/common/SnykCachedResults.kt
@@ -158,36 +158,39 @@ class SnykCachedResults(
                         "oss" -> {
                             currentOssError =
                                 SnykError(
-                                    "Failed to run Snyk Open Source scan: ${snykScan.errorMessage}",
-                                    snykScan.folderPath,
-                                    snykScan.errorCode
+                                    snykScan.cliError?.error ?: snykScan.errorMessage
+                                    ?: "Failed to run Snyk Open Source Scan",
+                                    snykScan.cliError?.path ?: snykScan.folderPath,
+                                    snykScan.cliError?.code,
                                 )
                         }
 
                         "code" -> {
                             currentSnykCodeError =
                                 SnykError(
-                                    "Failed to run Snyk Code scan: ${snykScan.errorMessage}",
-                                    snykScan.folderPath,
-                                    snykScan.errorCode
+                                    snykScan.cliError?.error ?: snykScan.errorMessage
+                                        ?: "Failed to run Snyk Code Scan",
+                                    snykScan.cliError?.path ?: snykScan.folderPath,
+                                    snykScan.cliError?.code,
                                 )
                         }
 
                         "iac" -> {
                             currentIacError =
                                 SnykError(
-                                    "Failed to run Snyk Infrastructure as Code scan: ${snykScan.errorMessage}",
-                                    snykScan.folderPath,
-                                    snykScan.errorCode
+                                    snykScan.cliError?.error ?: snykScan.errorMessage ?: "Failed to run Snyk IaC Scan",
+                                    snykScan.cliError?.path ?: snykScan.folderPath,
+                                    snykScan.cliError?.code,
                                 )
                         }
 
                         "container" -> {
                             currentContainerError =
                                 SnykError(
-                                    "Failed to run Snyk Container scan: ${snykScan.errorMessage}",
-                                    snykScan.folderPath,
-                                    snykScan.errorCode
+                                    snykScan.cliError?.error ?: snykScan.errorMessage
+                                    ?: "Failed to run Snyk Container Scan",
+                                    snykScan.cliError?.path ?: snykScan.folderPath,
+                                    snykScan.cliError?.code,
                                 )
                         }
                     }

--- a/src/main/kotlin/snyk/common/lsp/Types.kt
+++ b/src/main/kotlin/snyk/common/lsp/Types.kt
@@ -25,6 +25,7 @@ data class SnykScanParams(
     val folderPath: String, // FolderPath is the root-folder of the current scan
     val issues: List<ScanIssue>, // Issues contain the scan results in the common issues model
     val errorMessage: String? = null,
+    val errorCode: Int? = 0,
 )
 
 // Define the ScanIssue data class

--- a/src/main/kotlin/snyk/common/lsp/Types.kt
+++ b/src/main/kotlin/snyk/common/lsp/Types.kt
@@ -18,14 +18,26 @@ import java.util.Date
 import java.util.Locale
 import javax.swing.Icon
 
+// type CliOutput struct {
+//	Code         int    `json:"code,omitempty"`
+//	ErrorMessage string `json:"error,omitempty"`
+//	Path         string `json:"path,omitempty"`
+//	Command      string `json:"command,omitempty"`
+//}
+data class CliError (
+    val code: Int? = 0,
+    val error: String? = null,
+    val path: String? = null,
+    val command: String? = null,
+)
 // Define the SnykScanParams data class
 data class SnykScanParams(
     val status: String, // Status can be either Initial, InProgress, Success or Error
     val product: String, // Product under scan (Snyk Code, Snyk Open Source, etc...)
     val folderPath: String, // FolderPath is the root-folder of the current scan
     val issues: List<ScanIssue>, // Issues contain the scan results in the common issues model
-    val errorMessage: String? = null,
-    val errorCode: Int? = 0,
+    val errorMessage: String? = null, // Error Message if applicable
+    val cliError: CliError? = null, // structured error information if applicable
 )
 
 // Define the ScanIssue data class

--- a/src/main/kotlin/snyk/common/lsp/Types.kt
+++ b/src/main/kotlin/snyk/common/lsp/Types.kt
@@ -20,10 +20,11 @@ import javax.swing.Icon
 
 // Define the SnykScanParams data class
 data class SnykScanParams(
-    val status: String, // Status can be either Initial, InProgress or Success
+    val status: String, // Status can be either Initial, InProgress, Success or Error
     val product: String, // Product under scan (Snyk Code, Snyk Open Source, etc...)
     val folderPath: String, // FolderPath is the root-folder of the current scan
     val issues: List<ScanIssue>, // Issues contain the scan results in the common issues model
+    val errorMessage: String? = null,
 )
 
 // Define the ScanIssue data class


### PR DESCRIPTION
### Description

Propagate scan error from LS to IntelliJ and display it.

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

![image](https://github.com/user-attachments/assets/76df7850-9bc7-477d-8e76-a2e2c19e4aa8)
