### PR TITLE
fix: `font-family` and `font-size` are set from Language Server

### DIFF
--- a/src/main/kotlin/io/snyk/plugin/ui/jcef/ThemeBasedStylingGenerator.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/jcef/ThemeBasedStylingGenerator.kt
@@ -74,10 +74,7 @@ class ThemeBasedStylingGenerator {
                     val tabItemHoverColor =
                         globalScheme.getColor(ColorKey.find("INDENT_GUIDE")) // The closest color to target_rgb = RGB (235, 236, 240)
 
-                    val editorColorsManager = EditorColorsManager.getInstance()
-                    val editorColorsScheme: EditorColorsScheme = editorColorsManager.globalScheme
-                    val fontPreferences: FontPreferences = editorColorsScheme.fontPreferences
-                    val editorFont = fontPreferences.fontFamily
+                    val preBackgroundColor = if (isDarkTheme) "#000000" else "#ffffff"
 
                     val themeScript = """
                         (function(){
@@ -98,6 +95,7 @@ class ThemeBasedStylingGenerator {
                                 '--tabs-bottom-color': "${tearLineColor?.let { toCssHex(it) }}",
                                 '--border-color': "$borderColor",
                                 '--editor-color': "$editorColor",
+                                '--vulnerability-overview-pre-background-color': "$preBackgroundColor",
                                 '--label-color': "'$labelColor'",
                             };
                             for (let [property, value] of Object.entries(properties)) {

--- a/src/main/kotlin/io/snyk/plugin/ui/jcef/ThemeBasedStylingGenerator.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/jcef/ThemeBasedStylingGenerator.kt
@@ -98,7 +98,6 @@ class ThemeBasedStylingGenerator {
                                 '--tabs-bottom-color': "${tearLineColor?.let { toCssHex(it) }}",
                                 '--border-color': "$borderColor",
                                 '--editor-color': "$editorColor",
-                                '--editor-font': "'$editorFont'",
                                 '--label-color': "'$labelColor'",
                             };
                             for (let [property, value] of Object.entries(properties)) {

--- a/src/main/kotlin/io/snyk/plugin/ui/jcef/ThemeBasedStylingGenerator.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/jcef/ThemeBasedStylingGenerator.kt
@@ -1,9 +1,9 @@
 package io.snyk.plugin.ui.jcef
 
 import com.intellij.openapi.editor.colors.ColorKey
+import com.intellij.openapi.editor.colors.EditorColors
 import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.editor.colors.EditorColorsScheme
-import com.intellij.openapi.editor.colors.FontPreferences
 import com.intellij.ui.jcef.JBCefBrowserBase
 import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.UIUtil
@@ -64,17 +64,13 @@ class ThemeBasedStylingGenerator {
                     val linkColor = toCssHex(JBUI.CurrentTheme.Link.Foreground.ENABLED)
                     val dataFlowColor = toCssHex(baseColor)
                     val borderColor = toCssHex(JBUI.CurrentTheme.CustomFrameDecorations.separatorForeground())
-                    val editorColor =
-                        toCssHex(UIUtil.getTextFieldBackground())
+                    val editorColor = toCssHex(UIUtil.getTextFieldBackground())
                     val labelColor = toCssHex(JBUI.CurrentTheme.Label.foreground())
 
                     val globalScheme = EditorColorsManager.getInstance().globalScheme
-                    val tearLineColor =
-                        globalScheme.getColor(ColorKey.find("TEARLINE_COLOR")) // The closest color to target_rgb = (198, 198, 200)
-                    val tabItemHoverColor =
-                        globalScheme.getColor(ColorKey.find("INDENT_GUIDE")) // The closest color to target_rgb = RGB (235, 236, 240)
-
-                    val preBackgroundColor = if (isDarkTheme) "#000000" else "#ffffff"
+                    val tearLineColor = globalScheme.getColor(ColorKey.find("TEARLINE_COLOR")) // The closest color to target_rgb = (198, 198, 200)
+                    val tabItemHoverColor = globalScheme.getColor(ColorKey.find("INDENT_GUIDE")) // The closest color to target_rgb = RGB (235, 236, 240)
+                    val codeTagBgColor = globalScheme.getColor(EditorColors.GUTTER_BACKGROUND)  ?: globalScheme.defaultBackground
 
                     val themeScript = """
                         (function(){
@@ -95,8 +91,8 @@ class ThemeBasedStylingGenerator {
                                 '--tabs-bottom-color': "${tearLineColor?.let { toCssHex(it) }}",
                                 '--border-color': "$borderColor",
                                 '--editor-color': "$editorColor",
-                                '--vulnerability-overview-pre-background-color': "$preBackgroundColor",
                                 '--label-color': "'$labelColor'",
+                                '--vulnerability-overview-pre-background-color': "${toCssHex(codeTagBgColor)}",
                             };
                             for (let [property, value] of Object.entries(properties)) {
                                 document.documentElement.style.setProperty(property, value);

--- a/src/main/resources/stylesheets/snyk_code_suggestion.scss
+++ b/src/main/resources/stylesheets/snyk_code_suggestion.scss
@@ -59,10 +59,6 @@ a,
   font-size: 0.85rem;
 }
 
-.data-flow-text {
-  font-size: 1.05rem;
-}
-
 .data-flow-clickable-row {
   color: var(--link-color);
 }
@@ -89,10 +85,6 @@ a,
 
 .example-line {
   background-color: var(--editor-color);
-}
-
-.example-line > code {
-  font-size: 1.05rem;
 }
 
 .example-line.added {

--- a/src/main/resources/stylesheets/snyk_code_suggestion.scss
+++ b/src/main/resources/stylesheets/snyk_code_suggestion.scss
@@ -27,7 +27,7 @@ a,
 }
 
 // TODO: remove ignore styling at the end of cycle 5 2025
-// TODO: keep the font-size
+// TODO: keep the font-size - it should come from Language Server
 .ignore-warning {
   background: #FFF4ED;
   color: #B6540B;
@@ -60,7 +60,6 @@ a,
 }
 
 .data-flow-text {
-  font-family: var(--editor-font);
   font-size: 1.05rem;
 }
 
@@ -93,7 +92,6 @@ a,
 }
 
 .example-line > code {
-  font-family: var(--editor-font);
   font-size: 1.05rem;
 }
 

--- a/src/main/resources/stylesheets/snyk_oss_suggestion.scss
+++ b/src/main/resources/stylesheets/snyk_oss_suggestion.scss
@@ -65,7 +65,6 @@ a,
 
 .vulnerability-overview pre {
   font-size: 1.05rem;
-  font-family: var(--editor-font);
   background-color: transparent;
   border: 1px solid transparent;
   padding: 0;
@@ -74,5 +73,4 @@ a,
 .vulnerability-overview code {
   background-color: transparent;
   font-size: 1.05rem;
-  font-family: var(--editor-font);
 }

--- a/src/main/resources/stylesheets/snyk_oss_suggestion.scss
+++ b/src/main/resources/stylesheets/snyk_oss_suggestion.scss
@@ -64,13 +64,6 @@ a,
 }
 
 .vulnerability-overview pre {
-  font-size: 1.05rem;
-  background-color: transparent;
+  background-color: var(--vulnerability-overview-pre-background-color); // VSCode does this styling by default
   border: 1px solid transparent;
-  padding: 0;
-}
-
-.vulnerability-overview code {
-  background-color: transparent;
-  font-size: 1.05rem;
 }


### PR DESCRIPTION
### Description

This PR fixes the `font-size`and `font-family` accordantly to Snyk Design System to keep the look and feel of products and experiences consistent.

> [!NOTE]  
> This change needs to be tested together with the Language Server https://github.com/snyk/snyk-ls/pull/627


### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs


|Before|After|
|-|-|
<img width="1488" alt="before-oss" src="https://github.com/user-attachments/assets/b16cc97d-161f-4caf-b0c2-8b82f611dbf5">|<img width="1479" alt="after-oss" src="https://github.com/user-attachments/assets/04f4a25a-6db0-4d7c-ae52-103163bb5197">|
|<img width="1488" alt="before-code" src="https://github.com/user-attachments/assets/6ede524d-f51c-4d71-adf8-234987b8ed3b">|<img width="1479" alt="after-code" src="https://github.com/user-attachments/assets/12490299-d04c-4076-803a-3ce27881a76b">|
<img width="1476" alt="before-oss-dark-theme" src="https://github.com/user-attachments/assets/2c60480d-73f9-49df-ad79-45e03ebcd84f">|<img width="1479" alt="after-oss-dark-theme" src="https://github.com/user-attachments/assets/ba803738-3a66-4ae2-b0e2-0039b7217067">|

