### PR TITLE
chore: add sign target to gradle builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,14 @@ jobs:
       - name: Publish Plugin
         if: ${{ !env.ACT }}
         env:
+          CERTIFICATECHAIN: ${{ secrets.CERTIFICATECHAIN }}
+          PRIVATEKEY: ${{ secrets.PRIVATEKEY }}
+          PASSWORD: ${{ secrets.PASSWORD }}
+
+
+      - name: Publish Plugin
+        if: ${{ !env.ACT }}
+        env:
           PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
           ORG_GRADLE_PROJECT_amplitudeExperimentApiKey: ${{ secrets.AMPLITUDE_EXPERIMENT_API_KEY }}
           ORG_GRADLE_PROJECT_environment: "PRODUCTION"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -182,6 +182,12 @@ tasks {
         changeNotes.set(provider { changelog.renderItem(changelog.getLatest(), Changelog.OutputType.HTML) })
     }
 
+    signPlugin {
+        certificateChain.set(System.getenv("CERTIFICATECHAIN").trimIndent())
+        privateKey.set(System.getenv("PRIVATEKEY").trimIndent())
+        password.set(System.getenv("PASSWORD"))
+    }
+
     publishPlugin {
         token.set(System.getenv("PUBLISH_TOKEN"))
         channels.set(listOf(properties("pluginVersion").split('-').getOrElse(1) { "default" }.split('.').first()))


### PR DESCRIPTION
### Description

These steps are needed to sign plugins:

1. Generate the certificate. https://plugins.jetbrains.com/docs/intellij/plugin-signing.html#plugin-signature-verification 
2. Add the certificate to Github secrets.
3. Implement the signPlugin task for Gradle.


This PR covers the implementation for step 3.

### Checklist

- [] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
