### PR TITLE
feat: use intellij environment in ls startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Snyk Security Changelog
 
+## [2.9.1]
+
+### Changed
+- save git folder config in settings
+- propagate Jetbrains determined runtime environment to language server
+- automatically propagate standard file path for CLI if empty on apply in settings
+- guard base branch setting against being empty
+- better error messaging when unexpected loop occurs during initialization
+
+### Fixes
+- add name to code vision provider
+- add flashes for auto-fixable Open Source Issues
+- show code vision for Open Source also, when Snyk Code is still analysing
+- clean-up old open source scan functionality
+
 ## [2.9.0]
 ### Changed
 - Updated the language server protocol version to 14 to support new communication model.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - automatically propagate standard file path for CLI if empty on apply in settings
 - guard base branch setting against being empty
 - better error messaging when unexpected loop occurs during initialization
+- switch downloads to downloads.snyk.io
 
 ### Fixes
 - add name to code vision provider

--- a/src/main/kotlin/io/snyk/plugin/SnykFile.kt
+++ b/src/main/kotlin/io/snyk/plugin/SnykFile.kt
@@ -1,6 +1,5 @@
 package io.snyk.plugin
 
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Iconable
 import com.intellij.openapi.vfs.VirtualFile
@@ -8,13 +7,7 @@ import snyk.common.RelativePathHelper
 import javax.swing.Icon
 
 data class SnykFile(val project: Project, val virtualFile: VirtualFile) {
-    var icon: Icon? = null
     val relativePath = RelativePathHelper().getRelativePath(virtualFile, project)
-    init {
-        ApplicationManager.getApplication().runReadAction {
-            virtualFile.getPsiFile(project)?.getIcon(Iconable.ICON_FLAG_READ_STATUS)
-        }
-    }
 }
 
 fun toSnykFileSet(project: Project, virtualFiles: Set<VirtualFile>) =

--- a/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
@@ -12,7 +12,6 @@ import io.snyk.plugin.cli.Platform
 import io.snyk.plugin.getPluginPath
 import io.snyk.plugin.getSnykProjectSettingsService
 import io.snyk.plugin.isProjectSettingsAvailable
-import snyk.common.lsp.FolderConfig
 import java.io.File.separator
 import java.time.Instant
 import java.time.LocalDate

--- a/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
@@ -33,7 +33,7 @@ class SnykApplicationSettingsStateService : PersistentStateComponent<SnykApplica
     var currentLSProtocolVersion: Int? = 0
     var autofixEnabled: Boolean? = false
     var isGlobalIgnoresFeatureEnabled = false
-    var cliBaseDownloadURL: String = "https://static.snyk.io"
+    var cliBaseDownloadURL: String = "https://downloads.snyk.io"
     var cliPath: String = getPluginPath() + separator + Platform.current().snykWrapperFileName
     var cliReleaseChannel = "stable"
     var manageBinariesAutomatically: Boolean = true

--- a/src/main/kotlin/io/snyk/plugin/ui/SnykSettingsDialog.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/SnykSettingsDialog.kt
@@ -618,8 +618,8 @@ class SnykSettingsDialog(
             gb.nextLine(),
         )
 
-        cliBaseDownloadUrlTextField.toolTipText = "The default URL is https://static.snyk.io. " +
-            "for FIPS-enabled CLIs (only available for Windows and Linux), please use https://static.snyk.io/fips"
+        cliBaseDownloadUrlTextField.toolTipText = "The default URL is https://downloads.snyk.io. " +
+            "for FIPS-enabled CLIs (only available for Windows and Linux), please use https://downloads.snyk.io/fips"
         val cliBaseDownloadPanel =
             panel {
                 row {

--- a/src/main/kotlin/io/snyk/plugin/ui/SnykSettingsDialog.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/SnykSettingsDialog.kt
@@ -119,7 +119,7 @@ class SnykSettingsDialog(
     private val channels = listOf("stable", "rc", "preview").toArray(emptyArray())
     private val cliReleaseChannelDropDown = ComboBox(channels).apply { this.isEditable = true }
     private val cliBaseDownloadUrlTextField = JBTextField()
-    val baseBranchInfoLabel = JBLabel("Base branch: ")
+    private val baseBranchInfoLabel = JBLabel("Base branch: ")
 
     private val logger = Logger.getInstance(this::class.java)
 
@@ -182,8 +182,8 @@ class SnykSettingsDialog(
             scanOnSaveCheckbox.isSelected = applicationSettings.scanOnSave
             cliReleaseChannelDropDown.selectedItem = applicationSettings.cliReleaseChannel
 
-            baseBranchInfoLabel.text = service<FolderConfigSettings>().getAll()
-                .values.joinToString("\n") { "Base branch for ${it.folderPath}: ${it.baseBranch}" }
+            baseBranchInfoLabel.text = "<html>"+service<FolderConfigSettings>().getAll()
+                .values.joinToString("<br/>") { "Base branch for ${it.folderPath}: ${it.baseBranch}" }+"</html>"
         }
     }
 

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykTreeCellRenderer.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykTreeCellRenderer.kt
@@ -76,7 +76,7 @@ class SnykTreeCellRenderer : ColoredTreeCellRenderer() {
                 val file = entry.key
 
                 val pair = updateTextTooltipAndIcon(file, productType, value, entry.value.first())
-                nodeIcon = pair.first
+                pair.first?.let { nodeIcon = pair.first }
                 text = pair.second
                 val cachedIssues =
                     getSnykCachedResultsForProduct(entry.key.project, productType)
@@ -295,7 +295,7 @@ class SnykTreeCellRenderer : ColoredTreeCellRenderer() {
                 }
             }
 
-        val nodeIcon = firstIssue?.icon() ?: file.icon
+        val nodeIcon = firstIssue?.icon()
         return Pair(nodeIcon, text)
     }
 

--- a/src/main/kotlin/snyk/code/annotator/SnykOSSAnnotator.kt
+++ b/src/main/kotlin/snyk/code/annotator/SnykOSSAnnotator.kt
@@ -8,7 +8,7 @@ import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.ui.toolwindow.SnykPluginDisposable
 import snyk.common.ProductType
 
-class SnykOSSAnnotatorLS : SnykAnnotator(product = ProductType.OSS) {
+class SnykOSSAnnotator : SnykAnnotator(product = ProductType.OSS) {
     init {
         Disposer.register(SnykPluginDisposable.getInstance(), this)
     }

--- a/src/main/kotlin/snyk/common/EnvironmentHelper.kt
+++ b/src/main/kotlin/snyk/common/EnvironmentHelper.kt
@@ -1,5 +1,6 @@
 package snyk.common
 
+import com.intellij.util.EnvironmentUtil
 import com.intellij.util.net.HttpConfigurable
 import io.snyk.plugin.pluginSettings
 import snyk.pluginInfo
@@ -11,6 +12,8 @@ object EnvironmentHelper {
         environment: MutableMap<String, String>,
         apiToken: String,
     ) {
+        // first of all, use IntelliJ environment tool, to spice up env
+        environment.putAll(EnvironmentUtil.getEnvironmentMap())
         val endpoint = getEndpointUrl()
 
         val oauthEnabledEnvVar = "INTERNAL_SNYK_OAUTH_ENABLED"

--- a/src/main/kotlin/snyk/common/lsp/LSCodeVisionProvider.kt
+++ b/src/main/kotlin/snyk/common/lsp/LSCodeVisionProvider.kt
@@ -46,7 +46,6 @@ class LSCodeVisionProvider : CodeVisionProvider<Unit> {
     override fun computeCodeVision(editor: Editor, uiData: Unit): CodeVisionState {
         if (editor.project == null) return CodeVisionState.READY_EMPTY
         if (!LanguageServerWrapper.getInstance().isInitialized) return CodeVisionState.READY_EMPTY
-        if (isSnykCodeRunning(editor.project!!)) return CodeVisionState.READY_EMPTY
 
         return ReadAction.compute<CodeVisionState, RuntimeException> {
             val project = editor.project ?: return@compute CodeVisionState.READY_EMPTY

--- a/src/main/kotlin/snyk/common/lsp/LSCodeVisionProvider.kt
+++ b/src/main/kotlin/snyk/common/lsp/LSCodeVisionProvider.kt
@@ -17,7 +17,6 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiDocumentManager
 import icons.SnykIcons
-import io.snyk.plugin.isSnykCodeRunning
 import io.snyk.plugin.toLanguageServerURL
 import org.eclipse.lsp4j.CodeLens
 import org.eclipse.lsp4j.CodeLensParams
@@ -34,8 +33,8 @@ class LSCodeVisionProvider : CodeVisionProvider<Unit>, CodeVisionGroupSettingPro
     private val logger = logger<LSCodeVisionProvider>()
     override val defaultAnchor: CodeVisionAnchorKind = CodeVisionAnchorKind.Default
     override val id = "snyk.common.lsp.LSCodeVisionProvider"
-    override val name = "Snyk Language Server Code Vision Provider"
-    override val groupId: String = "Snyk"
+    override val name = "Snyk Security Language Server Code Vision Provider"
+    override val groupId: String = "Snyk Security"
     override val groupName: String = groupId
 
     override val relativeOrderings: List<CodeVisionRelativeOrdering>

--- a/src/main/kotlin/snyk/common/lsp/LSCodeVisionProvider.kt
+++ b/src/main/kotlin/snyk/common/lsp/LSCodeVisionProvider.kt
@@ -5,6 +5,7 @@ import com.intellij.codeInsight.codeVision.CodeVisionEntry
 import com.intellij.codeInsight.codeVision.CodeVisionProvider
 import com.intellij.codeInsight.codeVision.CodeVisionRelativeOrdering
 import com.intellij.codeInsight.codeVision.CodeVisionState
+import com.intellij.codeInsight.codeVision.settings.CodeVisionGroupSettingProvider
 import com.intellij.codeInsight.codeVision.ui.model.ClickableTextCodeVisionEntry
 import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.diagnostic.logger
@@ -29,11 +30,14 @@ import java.util.concurrent.TimeoutException
 private const val CODELENS_FETCH_TIMEOUT = 2L
 
 @Suppress("UnstableApiUsage")
-class LSCodeVisionProvider : CodeVisionProvider<Unit> {
+class LSCodeVisionProvider : CodeVisionProvider<Unit>, CodeVisionGroupSettingProvider {
     private val logger = logger<LSCodeVisionProvider>()
     override val defaultAnchor: CodeVisionAnchorKind = CodeVisionAnchorKind.Default
     override val id = "snyk.common.lsp.LSCodeVisionProvider"
     override val name = "Snyk Language Server Code Vision Provider"
+    override val groupId: String = "Snyk"
+    override val groupName: String = groupId
+
     override val relativeOrderings: List<CodeVisionRelativeOrdering>
         get() = emptyList()
 

--- a/src/main/kotlin/snyk/common/lsp/Types.kt
+++ b/src/main/kotlin/snyk/common/lsp/Types.kt
@@ -285,7 +285,8 @@ data class ScanIssue(
 
     fun hasAIFix(): Boolean {
         return when (this.additionalData.getProductType()) {
-            ProductType.OSS -> false
+            ProductType.OSS ->
+                return this.additionalData.isUpgradable == true
             ProductType.CODE_SECURITY, ProductType.CODE_QUALITY -> {
                 return this.additionalData.hasAIFix
             }
@@ -443,7 +444,7 @@ data class IssueData(
     @SerializedName("from") val from: List<String>,
     @SerializedName("upgradePath") val upgradePath: List<Any>,
     @SerializedName("isPatchable") val isPatchable: Boolean,
-    @SerializedName("isUpgradable") val isUpgradable: Boolean?,
+    @SerializedName("isUpgradable") val isUpgradable: Boolean,
     @SerializedName("projectName") val projectName: String,
     @SerializedName("displayTargetFile") val displayTargetFile: String?,
     @SerializedName("matchingIssues") val matchingIssues: List<IssueData>,

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -45,7 +45,7 @@
     <config.codeVisionGroupSettingProvider implementation="snyk.common.lsp.LSCodeVisionProvider" />
 
     <externalAnnotator language="" implementationClass="snyk.code.annotator.SnykCodeAnnotator"/>
-    <externalAnnotator language="" implementationClass="snyk.code.annotator.SnykOSSAnnotatorLS"/>
+    <externalAnnotator language="" implementationClass="snyk.code.annotator.SnykOSSAnnotator"/>
   </extensions>
 
   <actions>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -41,7 +41,8 @@
 
     <notificationGroup id="Snyk" displayType="BALLOON" toolWindowId="Snyk"/>
 
-    <codeInsight.codeVisionProvider implementation="snyk.common.lsp.LSCodeVisionProvider"/>
+    <codeInsight.codeVisionProvider implementation="snyk.common.lsp.LSCodeVisionProvider" id="snyk.common.lsp.LSCodeVisionProvider"/>
+    <config.codeVisionGroupSettingProvider implementation="snyk.common.lsp.LSCodeVisionProvider" />
 
     <externalAnnotator language="" implementationClass="snyk.code.annotator.SnykCodeAnnotator"/>
     <externalAnnotator language="" implementationClass="snyk.code.annotator.SnykOSSAnnotatorLS"/>

--- a/src/test/kotlin/io/snyk/plugin/services/download/CliDownloaderTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/services/download/CliDownloaderTest.kt
@@ -41,7 +41,7 @@ class CliDownloaderTest {
 
     @Test
     fun `should refer to snyk static website as base url`() {
-        assertEquals("https://static.snyk.io", CliDownloader.BASE_URL)
+        assertEquals("https://downloads.snyk.io", CliDownloader.BASE_URL)
     }
 
     @Test


### PR DESCRIPTION
### Description

- fixes the missing flash icon in the Open Source tree when packages can be upgraded automatically
- remove incorrect guard in code vision provider
- added name/description in code vision setting
- use intellij determined environment variables when starting up language server
- fixes a snyk file bug that seems to come from IntelliJ (icon usage)
- fixes display of base branch per project

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

![image](https://github.com/user-attachments/assets/e9bfbd2e-1f9c-4773-8920-438e064bc2d6)
![image](https://github.com/user-attachments/assets/85dad734-1233-4f5c-a414-3f03635554ec)
