### PR TITLE
fix: mark our annotators as dumbaware [IDA-117]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - guard base branch setting against being empty
 - better error messaging when unexpected loop occurs during initialization
 - switch downloads to downloads.snyk.io
+- allow annotations during IntelliJ indexing
 
 ### Fixes
 - add name to code vision provider

--- a/src/main/kotlin/snyk/code/annotator/SnykAnnotator.kt
+++ b/src/main/kotlin/snyk/code/annotator/SnykAnnotator.kt
@@ -7,6 +7,7 @@ import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiFile
 import io.snyk.plugin.getSnykCachedResultsForProduct
@@ -26,7 +27,7 @@ import java.util.concurrent.TimeoutException
 private const val CODEACTION_TIMEOUT = 5000L
 
 abstract class SnykAnnotator(private val product: ProductType) :
-    ExternalAnnotator<Pair<PsiFile, List<ScanIssue>>, List<SnykAnnotation>>(), Disposable {
+    ExternalAnnotator<Pair<PsiFile, List<ScanIssue>>, List<SnykAnnotation>>(), Disposable, DumbAware {
     val logger = logger<SnykAnnotator>()
     protected var disposed = false
         get() {


### PR DESCRIPTION
### Description

Dumbaware annotators allow displaying of annotations during indexing. This may help with displaying them even when a project does not compile or the file cannot be parsed well.

From the IntelliJ [docs](https://plugins.jetbrains.com/docs/intellij/syntax-highlighting-and-error-highlighting.html#annotator):

> Annotators not requiring information from indexes can be marked dumb aware to work during indexing (e.g., for additional syntax highlighting). (2023.1+)


### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
