### PR TITLE
feat: add dialog to choose reference branch [IDE-601]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - allow annotations during IntelliJ indexing
 - add gutter icons for Snyk issues
 - add color and highlighting setting for Snyk issues
+- add dialog to choose reference branch when delta scanning
+- always display info nodes
 
 ### Fixes
 - add name to code vision provider

--- a/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
@@ -37,6 +37,7 @@ class SnykApplicationSettingsStateService : PersistentStateComponent<SnykApplica
     var cliReleaseChannel = "stable"
     var manageBinariesAutomatically: Boolean = true
     var fileListenerEnabled: Boolean = true
+    // TODO migrate to https://plugins.jetbrains.com/docs/intellij/persisting-sensitive-data.html?from=jetbrains.org
     var token: String? = null
     var customEndpointUrl: String? = null
     var organization: String? = null

--- a/src/main/kotlin/io/snyk/plugin/settings/SnykProjectSettingsConfigurable.kt
+++ b/src/main/kotlin/io/snyk/plugin/settings/SnykProjectSettingsConfigurable.kt
@@ -10,7 +10,6 @@ import com.intellij.openapi.project.Project
 import io.snyk.plugin.events.SnykProductsOrSeverityListener
 import io.snyk.plugin.events.SnykResultsFilteringListener
 import io.snyk.plugin.events.SnykSettingsListener
-import io.snyk.plugin.getContentRootPaths
 import io.snyk.plugin.getSnykProjectSettingsService
 import io.snyk.plugin.getSnykTaskQueueService
 import io.snyk.plugin.getSnykToolWindowPanel
@@ -104,13 +103,9 @@ class SnykProjectSettingsConfigurable(
             val snykProjectSettingsService = getSnykProjectSettingsService(project)
             snykProjectSettingsService?.additionalParameters = snykSettingsDialog.getAdditionalParameters()
             val fcs = service<FolderConfigSettings>()
-            project.getContentRootPaths().forEach {
-                val fc = fcs.getFolderConfig(it.toAbsolutePath().toString())
-                if (fc != null) {
-                    val newFC = fc.copy(additionalParameters = snykSettingsDialog.getAdditionalParameters().split(" "))
-                    fcs.addFolderConfig(newFC)
-                }
-            }
+            fcs.getAllForProject(project)
+                .map { it.copy(additionalParameters = snykSettingsDialog.getAdditionalParameters().split(" ")) }
+                .forEach { fcs.addFolderConfig(it) }
         }
 
         runBackgroundableTask("processing config changes", project, true) {

--- a/src/main/kotlin/io/snyk/plugin/ui/BranchChooserComboboxDialog.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/BranchChooserComboboxDialog.kt
@@ -1,0 +1,76 @@
+package io.snyk.plugin.ui
+
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.ComboBox
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.openapi.ui.ValidationInfo
+import com.intellij.util.ui.GridBag
+import com.intellij.util.ui.JBUI
+import org.jetbrains.concurrency.runAsync
+import snyk.common.lsp.FolderConfig
+import snyk.common.lsp.FolderConfigSettings
+import snyk.common.lsp.LanguageServerWrapper
+import java.awt.GridBagConstraints
+import java.awt.GridBagLayout
+import javax.swing.JComponent
+import javax.swing.JLabel
+import javax.swing.JPanel
+
+
+class BranchChooserComboBoxDialog(val project: Project) : DialogWrapper(true) {
+    private val comboBoxes : MutableList<ComboBox<String>> = mutableListOf()
+
+    init {
+        init()
+        title = "Choose base branch for net-new issue scanning"
+    }
+
+    override fun createCenterPanel(): JComponent {
+        val folderConfigs = service<FolderConfigSettings>().getAllForProject(project)
+        folderConfigs.forEach {
+            val comboBox = ComboBox(it.localBranches.sorted().toTypedArray())
+            comboBox.selectedItem = it.baseBranch
+            comboBox.name = it.folderPath
+            comboBoxes.add(comboBox)
+        }
+        val gridBagLayout = GridBagLayout()
+        val dialogPanel = JPanel(gridBagLayout)
+        val gridBag = GridBag()
+        gridBag.defaultFill = GridBagConstraints.HORIZONTAL
+        gridBag.insets = JBUI.insets(20)
+        comboBoxes.forEach {
+            dialogPanel.add(JLabel("Base Branch for ${it.name}: "))
+            dialogPanel.add(it, gridBag.nextLine())
+        }
+        return dialogPanel
+    }
+
+    override fun doOKAction() {
+        val folderConfigSettings = service<FolderConfigSettings>()
+        comboBoxes.forEach {
+            val folderConfig : FolderConfig? = folderConfigSettings.getFolderConfig(it.name)
+            if (folderConfig == null) {
+                SnykBalloonNotificationHelper.showError("Unexpectedly cannot retrieve folder config for ${it.name} for base branch updating.", project)
+                return@forEach
+            }
+
+            val baseBranch = it.selectedItem!!.toString() // validation makes sure it is not null and not empty
+            folderConfigSettings.addFolderConfig(folderConfig.copy(baseBranch = baseBranch))
+        }
+        runAsync {
+            LanguageServerWrapper.getInstance().updateConfiguration()
+            LanguageServerWrapper.getInstance().sendScanCommand(project)
+        }
+        super.doOKAction()
+    }
+
+    override fun doValidate(): ValidationInfo? {
+        comboBoxes.forEach {
+            if (it.selectedItem == null || it.selectedItem?.toString()?.isEmpty() == true) {
+                return ValidationInfo("Please select a base branch for ${it.name}", it)
+            }
+        }
+        return null
+    }
+}

--- a/src/main/kotlin/io/snyk/plugin/ui/BranchChooserComboboxDialog.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/BranchChooserComboboxDialog.kt
@@ -19,7 +19,7 @@ import javax.swing.JPanel
 
 
 class BranchChooserComboBoxDialog(val project: Project) : DialogWrapper(true) {
-    private val comboBoxes : MutableList<ComboBox<String>> = mutableListOf()
+    var comboBoxes: MutableList<ComboBox<String>> = mutableListOf()
 
     init {
         init()
@@ -47,11 +47,19 @@ class BranchChooserComboBoxDialog(val project: Project) : DialogWrapper(true) {
     }
 
     override fun doOKAction() {
+        execute()
+        super.doOKAction()
+    }
+
+    fun execute() {
         val folderConfigSettings = service<FolderConfigSettings>()
         comboBoxes.forEach {
-            val folderConfig : FolderConfig? = folderConfigSettings.getFolderConfig(it.name)
+            val folderConfig: FolderConfig? = folderConfigSettings.getFolderConfig(it.name)
             if (folderConfig == null) {
-                SnykBalloonNotificationHelper.showError("Unexpectedly cannot retrieve folder config for ${it.name} for base branch updating.", project)
+                SnykBalloonNotificationHelper.showError(
+                    "Unexpectedly cannot retrieve folder config for ${it.name} for base branch updating.",
+                    project
+                )
                 return@forEach
             }
 
@@ -62,7 +70,6 @@ class BranchChooserComboBoxDialog(val project: Project) : DialogWrapper(true) {
             LanguageServerWrapper.getInstance().updateConfiguration()
             LanguageServerWrapper.getInstance().sendScanCommand(project)
         }
-        super.doOKAction()
     }
 
     override fun doValidate(): ValidationInfo? {

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
@@ -3,6 +3,7 @@ package io.snyk.plugin.ui.toolwindow
 import com.intellij.notification.NotificationAction
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.invokeLater
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
@@ -910,12 +911,13 @@ class SnykToolWindowPanel(
     private fun selectAndDisplayNodeWithIssueDescription(selectCondition: (DefaultMutableTreeNode) -> Boolean) {
         val node = TreeUtil.findNode(rootTreeNode) { selectCondition(it) }
         if (node != null) {
-            navigateToSourceEnabled = false
-            try {
-                TreeUtil.selectNode(vulnerabilitiesTree, node)
-                // here TreeSelectionListener is invoked, so no needs for explicit updateDescriptionPanelBySelectedTreeNode()
-            } finally {
-                navigateToSourceEnabled = true
+            invokeLater {
+                try {
+                    navigateToSourceEnabled = false
+                    TreeUtil.selectNode(vulnerabilitiesTree, node)
+                } finally {
+                    navigateToSourceEnabled = true
+                }
             }
         }
     }

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLS.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLS.kt
@@ -2,6 +2,7 @@ package io.snyk.plugin.ui.toolwindow
 
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.util.TextRange
@@ -19,16 +20,19 @@ import io.snyk.plugin.ui.toolwindow.SnykToolWindowPanel.Companion.CODE_SECURITY_
 import io.snyk.plugin.ui.toolwindow.SnykToolWindowPanel.Companion.NODE_NOT_SUPPORTED_STATE
 import io.snyk.plugin.ui.toolwindow.SnykToolWindowPanel.Companion.NO_OSS_FILES
 import io.snyk.plugin.ui.toolwindow.SnykToolWindowPanel.Companion.OSS_ROOT_TEXT
+import io.snyk.plugin.ui.toolwindow.SnykToolWindowPanel.Companion.SCANNING_TEXT
 import io.snyk.plugin.ui.toolwindow.nodes.leaf.SuggestionTreeNode
 import io.snyk.plugin.ui.toolwindow.nodes.root.RootContainerIssuesTreeNode
 import io.snyk.plugin.ui.toolwindow.nodes.root.RootIacIssuesTreeNode
 import io.snyk.plugin.ui.toolwindow.nodes.root.RootOssTreeNode
 import io.snyk.plugin.ui.toolwindow.nodes.root.RootQualityIssuesTreeNode
 import io.snyk.plugin.ui.toolwindow.nodes.root.RootSecurityIssuesTreeNode
+import io.snyk.plugin.ui.toolwindow.nodes.secondlevel.ChooseBranchNode
 import io.snyk.plugin.ui.toolwindow.nodes.secondlevel.InfoTreeNode
 import io.snyk.plugin.ui.toolwindow.nodes.secondlevel.SnykFileTreeNode
 import snyk.common.ProductType
 import snyk.common.SnykFileIssueComparator
+import snyk.common.lsp.FolderConfigSettings
 import snyk.common.lsp.ScanIssue
 import snyk.common.lsp.SnykScanParams
 import javax.swing.JTree
@@ -70,11 +74,11 @@ class SnykToolWindowSnykScanListenerLS(
         ApplicationManager.getApplication().invokeLater {
             this.rootSecurityIssuesTreeNode.userObject = "$CODE_SECURITY_ROOT_TEXT (scanning finished)"
             this.rootQualityIssuesTreeNode.userObject = "$CODE_QUALITY_ROOT_TEXT (scanning finished)"
-            this.snykToolWindowPanel.navigateToSourceEnabled = false
+            this.snykToolWindowPanel.triggerSelectionListeners = false
             val snykCachedResults = getSnykCachedResults(project)
             displaySnykCodeResults(snykCachedResults?.currentSnykCodeResultsLS ?: emptyMap())
             refreshAnnotationsForOpenFiles(project)
-            this.snykToolWindowPanel.navigateToSourceEnabled = true
+            this.snykToolWindowPanel.triggerSelectionListeners = true
         }
     }
 
@@ -83,11 +87,11 @@ class SnykToolWindowSnykScanListenerLS(
         ApplicationManager.getApplication().invokeLater {
             cancelOssIndicator(project)
             this.rootOssIssuesTreeNode.userObject = "$OSS_ROOT_TEXT (scanning finished)"
-            this.snykToolWindowPanel.navigateToSourceEnabled = false
+            this.snykToolWindowPanel.triggerSelectionListeners = false
             val snykCachedResults = getSnykCachedResults(project)
             displayOssResults(snykCachedResults?.currentOSSResultsLS ?: emptyMap())
             refreshAnnotationsForOpenFiles(project)
-            this.snykToolWindowPanel.navigateToSourceEnabled = true
+            this.snykToolWindowPanel.triggerSelectionListeners = true
         }
     }
 
@@ -262,9 +266,24 @@ class SnykToolWindowSnykScanListenerLS(
         fixableIssuesCount: Int? = null,
     ) {
         if (disposed) return
-
+        if (rootNode.userObject == SCANNING_TEXT) {
+            return
+        }
 
         val settings = pluginSettings()
+        // TODO: check for delta findings
+        val deltaFindingsEnabled = true
+        if (deltaFindingsEnabled) {
+            // we need one choose branch node for each content root. sigh.
+            service<FolderConfigSettings>().getAllForProject(project).forEach {
+                val branchChooserTreeNode = ChooseBranchNode(
+                    project = project,
+                    info = "Click to choose base branch for ${it.folderPath} [ current: ${it.baseBranch} ]"
+                )
+                rootNode.add(branchChooserTreeNode)
+            }
+        }
+
         var text = "✅ Congrats! No vulnerabilities found!"
         val issuesCount = issues.size
         val ignoredIssuesCount = issues.count { it.isIgnored() }
@@ -274,7 +293,9 @@ class SnykToolWindowSnykScanListenerLS(
             } else {
                 "✋ $issuesCount vulnerabilities found by Snyk"
             }
-            text += ", $ignoredIssuesCount ignored"
+            if (pluginSettings().isGlobalIgnoresFeatureEnabled) {
+                text += ", $ignoredIssuesCount ignored"
+            }
         }
         rootNode.add(
             InfoTreeNode(
@@ -297,21 +318,22 @@ class SnykToolWindowSnykScanListenerLS(
                 )
             }
         }
-
-        if (ignoredIssuesCount == issuesCount && !settings.ignoredIssuesEnabled) {
-            rootNode.add(
-                InfoTreeNode(
-                    "Adjust your Issue View Options to see ignored issues.",
-                    project,
-                ),
-            )
-        } else if (ignoredIssuesCount == 0 && !settings.openIssuesEnabled) {
-            rootNode.add(
-                InfoTreeNode(
-                    "Adjust your Issue View Options to open issues.",
-                    project,
-                ),
-            )
+        if (pluginSettings().isGlobalIgnoresFeatureEnabled) {
+            if (ignoredIssuesCount == issuesCount && !settings.ignoredIssuesEnabled) {
+                rootNode.add(
+                    InfoTreeNode(
+                        "Adjust your Issue View Options to see ignored issues.",
+                        project,
+                    ),
+                )
+            } else if (ignoredIssuesCount == 0 && !settings.openIssuesEnabled) {
+                rootNode.add(
+                    InfoTreeNode(
+                        "Adjust your Issue View Options to open issues.",
+                        project,
+                    ),
+                )
+            }
         }
     }
 

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykTreeCellRenderer.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykTreeCellRenderer.kt
@@ -18,6 +18,7 @@ import io.snyk.plugin.ui.toolwindow.nodes.root.RootIacIssuesTreeNode
 import io.snyk.plugin.ui.toolwindow.nodes.root.RootOssTreeNode
 import io.snyk.plugin.ui.toolwindow.nodes.root.RootQualityIssuesTreeNode
 import io.snyk.plugin.ui.toolwindow.nodes.root.RootSecurityIssuesTreeNode
+import io.snyk.plugin.ui.toolwindow.nodes.secondlevel.ChooseBranchNode
 import io.snyk.plugin.ui.toolwindow.nodes.secondlevel.ErrorTreeNode
 import io.snyk.plugin.ui.toolwindow.nodes.secondlevel.InfoTreeNode
 import io.snyk.plugin.ui.toolwindow.nodes.secondlevel.SnykFileTreeNode
@@ -137,6 +138,11 @@ class SnykTreeCellRenderer : ColoredTreeCellRenderer() {
                 val snykError = value.userObject as SnykError
                 text = snykError.path + " - " + snykError.message
                 nodeIcon = AllIcons.General.Error
+            }
+
+            is ChooseBranchNode -> {
+                text = value.info
+                nodeIcon = value.icon
             }
 
             is InfoTreeNode -> {

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/nodes/secondlevel/InfoTreeNode.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/nodes/secondlevel/InfoTreeNode.kt
@@ -1,9 +1,14 @@
 package io.snyk.plugin.ui.toolwindow.nodes.secondlevel
 
+import com.intellij.icons.AllIcons
 import com.intellij.openapi.project.Project
 import javax.swing.tree.DefaultMutableTreeNode
 
-class InfoTreeNode(
-    private val info: String,
-    val project: Project,
+open class InfoTreeNode(
+    open val info: String,
+    open val project: Project,
 ) : DefaultMutableTreeNode(info)
+
+class ChooseBranchNode(override val info: String = "Choose base branch", override val project: Project) : InfoTreeNode(info, project) {
+    val icon = AllIcons.Vcs.BranchNode
+}

--- a/src/main/kotlin/snyk/common/annotator/SnykAnnotator.kt
+++ b/src/main/kotlin/snyk/common/annotator/SnykAnnotator.kt
@@ -25,6 +25,7 @@ import org.eclipse.lsp4j.CodeActionContext
 import org.eclipse.lsp4j.CodeActionParams
 import org.eclipse.lsp4j.Range
 import org.eclipse.lsp4j.TextDocumentIdentifier
+import org.jetbrains.concurrency.runAsync
 import snyk.common.AnnotatorCommon
 import snyk.common.ProductType
 import snyk.common.annotator.SnykAnnotationAttributeKey.critical
@@ -163,7 +164,7 @@ abstract class SnykAnnotator(private val product: ProductType) :
     }
 
     private fun getTextAttributeKeyBySeverity(severity: Severity): TextAttributesKey {
-        return when(severity) {
+        return when (severity) {
             Severity.UNKNOWN -> unknown
             Severity.LOW -> low
             Severity.MEDIUM -> medium
@@ -239,11 +240,10 @@ class SnykShowDetailsGutterRenderer(val annotation: SnykAnnotation) : GutterIcon
     private fun getShowDetailsNavigationAction(intention: ShowDetailsIntentionAction) =
         object : AnAction() {
             override fun actionPerformed(e: AnActionEvent) {
-                invokeLater {
-                    val virtualFile = intention.issue.virtualFile ?: return@invokeLater
-                    val project = guessProjectForFile(virtualFile) ?: return@invokeLater
-                    val toolWindowPanel = getSnykToolWindowPanel(project) ?: return@invokeLater
-
+                runAsync {
+                    val virtualFile = intention.issue.virtualFile ?: return@runAsync
+                    val project = guessProjectForFile(virtualFile) ?: return@runAsync
+                    val toolWindowPanel = getSnykToolWindowPanel(project) ?: return@runAsync
                     intention.selectNodeAndDisplayDescription(toolWindowPanel)
                 }
             }

--- a/src/main/kotlin/snyk/common/lsp/FolderConfigSettings.kt
+++ b/src/main/kotlin/snyk/common/lsp/FolderConfigSettings.kt
@@ -7,7 +7,10 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.SimplePersistentStateComponent
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
+import com.intellij.openapi.project.Project
 import com.intellij.util.xmlb.annotations.MapAnnotation
+import io.snyk.plugin.getContentRootPaths
+import java.util.stream.Collectors
 
 @Service
 @State(
@@ -25,11 +28,23 @@ class FolderConfigSettings : SimplePersistentStateComponent<FolderConfigSettings
         state.configs[folderConfig.folderPath] = gson.toJson(folderConfig)
     }
 
-    fun getFolderConfig(folderPath: String): FolderConfig? {
-        return gson.fromJson(state.configs[folderPath], FolderConfig::class.java)
+    @Suppress("USELESS_ELVIS", "SENSELESS_COMPARISON") // gson doesn't care about kotlin not null stuff
+    internal fun getFolderConfig(folderPath: String): FolderConfig? {
+        val fromJson = gson.fromJson(state.configs[folderPath], FolderConfig::class.java) ?: return null
+        if (fromJson.additionalParameters == null) {
+            val copy = fromJson.copy(
+                baseBranch = fromJson.baseBranch,
+                folderPath = fromJson.folderPath,
+                localBranches = fromJson.localBranches ?: emptyList(),
+                additionalParameters = fromJson.additionalParameters ?: emptyList(),
+            )
+            addFolderConfig(copy)
+            return copy
+        }
+        return fromJson
     }
 
-    fun getAll() : Map<String, FolderConfig> {
+    fun getAll(): Map<String, FolderConfig> {
         return state.configs.map {
             it.key to gson.fromJson(it.value, FolderConfig::class.java)
         }.toMap()
@@ -38,4 +53,11 @@ class FolderConfigSettings : SimplePersistentStateComponent<FolderConfigSettings
     fun clear() = state.configs.clear()
 
     fun addAll(folderConfigs: List<FolderConfig>) = folderConfigs.forEach { addFolderConfig(it) }
+
+    fun getAllForProject(project: Project): List<FolderConfig> =
+        project.getContentRootPaths()
+            .mapNotNull { getFolderConfig(it.toAbsolutePath().toString()) }
+            .stream()
+            .sorted()
+            .collect(Collectors.toList()).toList()
 }

--- a/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
+++ b/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
@@ -19,6 +19,7 @@ import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectLocator
 import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.roots.ui.configuration.ProjectSettingsService
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.util.io.toNioPathOrNull
 import com.intellij.openapi.vfs.VfsUtilCore
@@ -304,6 +305,7 @@ class SnykLanguageClient :
         if (disposed) return
         if (pluginSettings().token == param.token) return
         pluginSettings().token = param.token
+        ApplicationManager.getApplication().saveSettings()
 
         if (pluginSettings().token?.isNotEmpty() == true && pluginSettings().scanOnSave) {
             val wrapper = LanguageServerWrapper.getInstance()

--- a/src/test/kotlin/io/snyk/plugin/ui/BranchChooserComboBoxDialogTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/BranchChooserComboBoxDialogTest.kt
@@ -4,16 +4,12 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.ui.ComboBox
 import com.intellij.testFramework.LightPlatform4TestCase
 import com.intellij.testFramework.PlatformTestUtil
-import com.intellij.testFramework.TestFrameworkUtil
-import com.intellij.ui.charts.times
 import io.mockk.CapturingSlot
 import io.mockk.mockk
 import io.mockk.unmockkAll
 import io.mockk.verify
-import io.mockk.verifyOrder
 import org.eclipse.lsp4j.DidChangeConfigurationParams
 import org.eclipse.lsp4j.services.LanguageServer
-import org.jetbrains.kotlin.utils.addToStdlib.cast
 import org.junit.Test
 import snyk.common.lsp.FolderConfig
 import snyk.common.lsp.FolderConfigSettings

--- a/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLSTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLSTest.kt
@@ -164,7 +164,7 @@ class SnykToolWindowSnykScanListenerLSTest : BasePlatformTestCase() {
             )
 
         TestCase.assertEquals(3, rootTreeNode.childCount)
-        cut.addInfoTreeNodes(rootTreeNode, mockScanIssues(), 1, 1)
+        cut.addInfoTreeNodes(rootTreeNode, mockScanIssues(), 1)
         TestCase.assertEquals(3, rootTreeNode.childCount)
     }
 
@@ -192,7 +192,7 @@ class SnykToolWindowSnykScanListenerLSTest : BasePlatformTestCase() {
             )
 
         TestCase.assertEquals(3, rootTreeNode.childCount)
-        cut.addInfoTreeNodes(rootTreeNode, mockScanIssues(), 1, 1)
+        cut.addInfoTreeNodes(rootTreeNode, mockScanIssues(), 1)
         TestCase.assertEquals(5, rootTreeNode.childCount)
         TestCase.assertEquals(rootTreeNode.children().toList()[0].toString(), " Open Source")
         TestCase.assertEquals(rootTreeNode.children().toList()[1].toString(), " Code Security")
@@ -232,7 +232,7 @@ class SnykToolWindowSnykScanListenerLSTest : BasePlatformTestCase() {
             )
 
         TestCase.assertEquals(3, rootTreeNode.childCount)
-        cut.addInfoTreeNodes(rootTreeNode, mockScanIssues(true), 1, 1)
+        cut.addInfoTreeNodes(rootTreeNode, mockScanIssues(true), 1)
         TestCase.assertEquals(6, rootTreeNode.childCount)
     }
 
@@ -261,7 +261,7 @@ class SnykToolWindowSnykScanListenerLSTest : BasePlatformTestCase() {
             )
 
         TestCase.assertEquals(3, rootTreeNode.childCount)
-        cut.addInfoTreeNodes(rootTreeNode, mockScanIssues(false), 1, 1)
+        cut.addInfoTreeNodes(rootTreeNode, mockScanIssues(false), 1)
         TestCase.assertEquals(6, rootTreeNode.childCount)
     }
 }

--- a/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLSTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLSTest.kt
@@ -60,59 +60,57 @@ class SnykToolWindowSnykScanListenerLSTest : BasePlatformTestCase() {
         isIgnored: Boolean? = false,
         hasAIFix: Boolean? = false,
     ): List<ScanIssue> {
-        val issue =
-            ScanIssue(
-                id = "id",
-                title = "title",
-                severity = Severity.CRITICAL.toString(),
-                filePath = getTestDataPath(),
-                range = Range(),
-                additionalData =
-                    IssueData(
-                        message = "Test message",
-                        leadURL = "",
-                        rule = "",
-                        repoDatasetSize = 1,
-                        exampleCommitFixes = listOf(),
-                        cwe = emptyList(),
-                        text = "",
-                        markers = null,
-                        cols = null,
-                        rows = null,
-                        isSecurityType = true,
-                        priorityScore = 0,
-                        hasAIFix = hasAIFix!!,
-                        dataFlow = listOf(DataFlow(0, getTestDataPath(), Range(Position(1, 1), Position(1, 1)), "")),
-                        license = null,
-                        identifiers = null,
-                        description = "",
-                        language = "",
-                        packageManager = "",
-                        packageName = "",
-                        name = "",
-                        version = "",
-                        exploit = null,
-                        CVSSv3 = null,
-                        cvssScore = null,
-                        fixedIn = null,
-                        from = listOf(),
-                        upgradePath = listOf(),
-                        isPatchable = false,
-                        isUpgradable = false,
-                        projectName = "",
-                        displayTargetFile = null,
-                        matchingIssues = listOf(),
-                        lesson = null,
-                        details = "",
-                        ruleId = "",
-                    ),
-                isIgnored = isIgnored,
-                ignoreDetails = null,
-            )
+        val issue = ScanIssue(
+            id = "id",
+            title = "title",
+            severity = Severity.CRITICAL.toString(),
+            filePath = getTestDataPath(),
+            range = Range(),
+            additionalData = IssueData(
+                message = "Test message",
+                leadURL = "",
+                rule = "",
+                repoDatasetSize = 1,
+                exampleCommitFixes = listOf(),
+                cwe = emptyList(),
+                text = "",
+                markers = null,
+                cols = null,
+                rows = null,
+                isSecurityType = true,
+                priorityScore = 0,
+                hasAIFix = hasAIFix!!,
+                dataFlow = listOf(DataFlow(0, getTestDataPath(), Range(Position(1, 1), Position(1, 1)), "")),
+                license = null,
+                identifiers = null,
+                description = "",
+                language = "",
+                packageManager = "",
+                packageName = "",
+                name = "",
+                version = "",
+                exploit = null,
+                CVSSv3 = null,
+                cvssScore = null,
+                fixedIn = null,
+                from = listOf(),
+                upgradePath = listOf(),
+                isPatchable = false,
+                isUpgradable = false,
+                projectName = "",
+                displayTargetFile = null,
+                matchingIssues = listOf(),
+                lesson = null,
+                details = "",
+                ruleId = "",
+            ),
+            isIgnored = isIgnored,
+            ignoreDetails = null,
+        )
         return listOf(issue)
     }
 
-    fun `testAddInfoTreeNodes does not add new tree nodes for non-code security`() {
+    fun `testAddInfoTreeNodes adds new tree nodes`() {
         pluginSettings().isGlobalIgnoresFeatureEnabled = true
 
         // setup the rootTreeNode from scratch
@@ -120,76 +118,18 @@ class SnykToolWindowSnykScanListenerLSTest : BasePlatformTestCase() {
         rootTreeNode.add(rootOssIssuesTreeNode)
         rootTreeNode.add(rootSecurityIssuesTreeNode)
         rootTreeNode.add(rootQualityIssuesTreeNode)
-        vulnerabilitiesTree =
-            Tree(rootTreeNode).apply {
-                this.isRootVisible = false
-            }
+        vulnerabilitiesTree = Tree(rootTreeNode).apply {
+            this.isRootVisible = false
+        }
 
-        cut =
-            SnykToolWindowSnykScanListenerLS(
-                project,
-                snykToolWindowPanel,
-                vulnerabilitiesTree,
-                rootSecurityIssuesTreeNode,
-                rootQualityIssuesTreeNode,
-                rootOssIssuesTreeNode,
-            )
-
-        TestCase.assertEquals(3, rootTreeNode.childCount)
-        cut.addInfoTreeNodes(rootTreeNode, mockScanIssues())
-        TestCase.assertEquals(3, rootTreeNode.childCount)
-    }
-
-    fun `testAddInfoTreeNodes does not add new tree nodes for code security if ignores are not enabled`() {
-        pluginSettings().isGlobalIgnoresFeatureEnabled = false
-
-        // setup the rootTreeNode from scratch
-        rootTreeNode = DefaultMutableTreeNode("")
-        rootTreeNode.add(rootOssIssuesTreeNode)
-        rootTreeNode.add(rootSecurityIssuesTreeNode)
-        rootTreeNode.add(rootQualityIssuesTreeNode)
-        vulnerabilitiesTree =
-            Tree(rootTreeNode).apply {
-                this.isRootVisible = false
-            }
-
-        cut =
-            SnykToolWindowSnykScanListenerLS(
-                project,
-                snykToolWindowPanel,
-                vulnerabilitiesTree,
-                rootSecurityIssuesTreeNode,
-                rootQualityIssuesTreeNode,
-                rootOssIssuesTreeNode,
-            )
-
-        TestCase.assertEquals(3, rootTreeNode.childCount)
-        cut.addInfoTreeNodes(rootTreeNode, mockScanIssues(), 1)
-        TestCase.assertEquals(3, rootTreeNode.childCount)
-    }
-
-    fun `testAddInfoTreeNodes adds new tree nodes for code security if ignores are enabled`() {
-        pluginSettings().isGlobalIgnoresFeatureEnabled = true
-
-        // setup the rootTreeNode from scratch
-        rootTreeNode = DefaultMutableTreeNode("")
-        rootTreeNode.add(rootOssIssuesTreeNode)
-        rootTreeNode.add(rootSecurityIssuesTreeNode)
-        rootTreeNode.add(rootQualityIssuesTreeNode)
-        vulnerabilitiesTree =
-            Tree(rootTreeNode).apply {
-                this.isRootVisible = false
-            }
-
-        cut =
-            SnykToolWindowSnykScanListenerLS(
-                project,
-                snykToolWindowPanel,
-                vulnerabilitiesTree,
-                rootSecurityIssuesTreeNode,
-                rootQualityIssuesTreeNode,
-                rootOssIssuesTreeNode,
-            )
+        cut = SnykToolWindowSnykScanListenerLS(
+            project,
+            snykToolWindowPanel,
+            vulnerabilitiesTree,
+            rootSecurityIssuesTreeNode,
+            rootQualityIssuesTreeNode,
+            rootOssIssuesTreeNode,
+        )
 
         TestCase.assertEquals(3, rootTreeNode.childCount)
         cut.addInfoTreeNodes(rootTreeNode, mockScanIssues(), 1)
@@ -203,7 +143,7 @@ class SnykToolWindowSnykScanListenerLSTest : BasePlatformTestCase() {
         )
         TestCase.assertEquals(
             rootTreeNode.children().toList()[4].toString(),
-            "⚡ 1 vulnerabilities can be fixed by Snyk DeepCode AI",
+            "⚡ 1 vulnerabilities can be fixed automatically",
         )
     }
 
@@ -216,20 +156,18 @@ class SnykToolWindowSnykScanListenerLSTest : BasePlatformTestCase() {
         rootTreeNode.add(rootOssIssuesTreeNode)
         rootTreeNode.add(rootSecurityIssuesTreeNode)
         rootTreeNode.add(rootQualityIssuesTreeNode)
-        vulnerabilitiesTree =
-            Tree(rootTreeNode).apply {
-                this.isRootVisible = false
-            }
+        vulnerabilitiesTree = Tree(rootTreeNode).apply {
+            this.isRootVisible = false
+        }
 
-        cut =
-            SnykToolWindowSnykScanListenerLS(
-                project,
-                snykToolWindowPanel,
-                vulnerabilitiesTree,
-                rootSecurityIssuesTreeNode,
-                rootQualityIssuesTreeNode,
-                rootOssIssuesTreeNode,
-            )
+        cut = SnykToolWindowSnykScanListenerLS(
+            project,
+            snykToolWindowPanel,
+            vulnerabilitiesTree,
+            rootSecurityIssuesTreeNode,
+            rootQualityIssuesTreeNode,
+            rootOssIssuesTreeNode,
+        )
 
         TestCase.assertEquals(3, rootTreeNode.childCount)
         cut.addInfoTreeNodes(rootTreeNode, mockScanIssues(true), 1)
@@ -245,20 +183,18 @@ class SnykToolWindowSnykScanListenerLSTest : BasePlatformTestCase() {
         rootTreeNode.add(rootOssIssuesTreeNode)
         rootTreeNode.add(rootSecurityIssuesTreeNode)
         rootTreeNode.add(rootQualityIssuesTreeNode)
-        vulnerabilitiesTree =
-            Tree(rootTreeNode).apply {
-                this.isRootVisible = false
-            }
+        vulnerabilitiesTree = Tree(rootTreeNode).apply {
+            this.isRootVisible = false
+        }
 
-        cut =
-            SnykToolWindowSnykScanListenerLS(
-                project,
-                snykToolWindowPanel,
-                vulnerabilitiesTree,
-                rootSecurityIssuesTreeNode,
-                rootQualityIssuesTreeNode,
-                rootOssIssuesTreeNode,
-            )
+        cut = SnykToolWindowSnykScanListenerLS(
+            project,
+            snykToolWindowPanel,
+            vulnerabilitiesTree,
+            rootSecurityIssuesTreeNode,
+            rootQualityIssuesTreeNode,
+            rootOssIssuesTreeNode,
+        )
 
         TestCase.assertEquals(3, rootTreeNode.childCount)
         cut.addInfoTreeNodes(rootTreeNode, mockScanIssues(false), 1)

--- a/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLSTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLSTest.kt
@@ -17,7 +17,6 @@ import io.snyk.plugin.ui.toolwindow.nodes.root.RootSecurityIssuesTreeNode
 import junit.framework.TestCase
 import org.eclipse.lsp4j.Position
 import org.eclipse.lsp4j.Range
-import org.jetbrains.kotlin.idea.gradleTooling.get
 import snyk.common.annotator.SnykCodeAnnotator
 import snyk.common.lsp.DataFlow
 import snyk.common.lsp.FolderConfig

--- a/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLSTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLSTest.kt
@@ -53,7 +53,12 @@ class SnykToolWindowSnykScanListenerLSTest : BasePlatformTestCase() {
 
         file = myFixture.copyFileToProject(fileName)
         psiFile = WriteAction.computeAndWait<PsiFile, Throwable> { psiManager.findFile(file)!! }
-
+        service<FolderConfigSettings>()
+            .addFolderConfig(
+                FolderConfig(
+                    project.getContentRootPaths().first().toAbsolutePath().toString(), "main"
+                )
+            )
         snykToolWindowPanel = SnykToolWindowPanel(project)
         rootOssIssuesTreeNode = RootOssTreeNode(project)
         rootSecurityIssuesTreeNode = RootSecurityIssuesTreeNode(project)
@@ -137,16 +142,16 @@ class SnykToolWindowSnykScanListenerLSTest : BasePlatformTestCase() {
 
         TestCase.assertEquals(3, rootTreeNode.childCount)
         cut.addInfoTreeNodes(rootTreeNode, mockScanIssues(), 1)
-        TestCase.assertEquals(5, rootTreeNode.childCount)
+        TestCase.assertEquals(6, rootTreeNode.childCount)
         TestCase.assertEquals(rootTreeNode.children().toList()[0].toString(), " Open Source")
         TestCase.assertEquals(rootTreeNode.children().toList()[1].toString(), " Code Security")
         TestCase.assertEquals(rootTreeNode.children().toList()[2].toString(), " Code Quality")
         TestCase.assertEquals(
-            rootTreeNode.children().toList()[3].toString(),
+            rootTreeNode.children().toList()[4].toString(),
             "1 vulnerability found by Snyk, 0 ignored",
         )
         TestCase.assertEquals(
-            rootTreeNode.children().toList()[4].toString(),
+            rootTreeNode.children().toList()[5].toString(),
             "⚡ 1 vulnerabilities can be fixed automatically",
         )
     }
@@ -173,12 +178,6 @@ class SnykToolWindowSnykScanListenerLSTest : BasePlatformTestCase() {
         )
 
         TestCase.assertEquals(3, rootTreeNode.childCount)
-        service<FolderConfigSettings>()
-            .addFolderConfig(
-                FolderConfig(
-                    project.getContentRootPaths().first().toAbsolutePath().toString(), "main"
-                )
-            )
 
         cut.addInfoTreeNodes(rootTreeNode, mockScanIssues(), 1)
 
@@ -221,7 +220,7 @@ class SnykToolWindowSnykScanListenerLSTest : BasePlatformTestCase() {
 
         TestCase.assertEquals(3, rootTreeNode.childCount)
         cut.addInfoTreeNodes(rootTreeNode, mockScanIssues(true), 1)
-        TestCase.assertEquals(6, rootTreeNode.childCount)
+        TestCase.assertEquals(7, rootTreeNode.childCount)
     }
 
     fun `testAddInfoTreeNodes adds new tree nodes for code security if all open issues are hidden`() {
@@ -248,6 +247,6 @@ class SnykToolWindowSnykScanListenerLSTest : BasePlatformTestCase() {
 
         TestCase.assertEquals(3, rootTreeNode.childCount)
         cut.addInfoTreeNodes(rootTreeNode, mockScanIssues(false), 1)
-        TestCase.assertEquals(6, rootTreeNode.childCount)
+        TestCase.assertEquals(7, rootTreeNode.childCount)
     }
 }

--- a/src/test/kotlin/snyk/container/ContainerBulkFileListenerTest.kt
+++ b/src/test/kotlin/snyk/container/ContainerBulkFileListenerTest.kt
@@ -21,6 +21,7 @@ import io.snyk.plugin.getKubernetesImageCache
 import io.snyk.plugin.getSnykCachedResults
 import io.snyk.plugin.resetSettings
 import io.snyk.plugin.ui.toolwindow.SnykToolWindowPanel
+import org.awaitility.Awaitility
 import org.awaitility.Awaitility.await
 import org.eclipse.lsp4j.services.LanguageServer
 import snyk.common.lsp.LanguageServerWrapper
@@ -72,11 +73,14 @@ class ContainerBulkFileListenerTest : BasePlatformTestCase() {
         val path = createNewFileInProjectRoot().toPath()
         Files.write(path, "\n".toByteArray(Charsets.UTF_8))
         VirtualFileManager.getInstance().syncRefresh()
-        val virtualFile = VirtualFileManager.getInstance().findFileByNioPath(path)
-        require(virtualFile != null)
+        var virtualFile: VirtualFile? = null
+        await().atMost(2, TimeUnit.SECONDS).until {
+            virtualFile = VirtualFileManager.getInstance().findFileByNioPath(path)
+            virtualFile?.isValid ?: false
+        }
 
         ApplicationManager.getApplication().runWriteAction {
-            val file = PsiManager.getInstance(project).findFile(virtualFile)
+            val file = PsiManager.getInstance(project).findFile(virtualFile!!)
             require(file != null)
             PsiDocumentManager.getInstance(project).getDocument(file)
                 ?.setText(TestYamls.podYaml())
@@ -93,7 +97,7 @@ class ContainerBulkFileListenerTest : BasePlatformTestCase() {
         assertEquals(1, kubernetesWorkloadImages.size)
         assertEquals(path, kubernetesWorkloadImages.first().virtualFile.toNioPath())
         assertEquals("nginx:1.16.0", kubernetesWorkloadImages.first().image)
-        virtualFile.toNioPath().delete(true)
+        virtualFile!!.toNioPath().delete(true)
     }
 
     fun `test Container should delete images from cache when yaml file is deleted`() {

--- a/src/test/kotlin/snyk/container/ContainerBulkFileListenerTest.kt
+++ b/src/test/kotlin/snyk/container/ContainerBulkFileListenerTest.kt
@@ -14,14 +14,12 @@ import com.intellij.testFramework.PlatformTestUtil
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.intellij.util.io.createDirectories
 import com.intellij.util.io.delete
-import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.unmockkAll
 import io.snyk.plugin.getKubernetesImageCache
 import io.snyk.plugin.getSnykCachedResults
 import io.snyk.plugin.resetSettings
 import io.snyk.plugin.ui.toolwindow.SnykToolWindowPanel
-import org.awaitility.Awaitility
 import org.awaitility.Awaitility.await
 import org.eclipse.lsp4j.services.LanguageServer
 import snyk.common.lsp.LanguageServerWrapper


### PR DESCRIPTION
### Description

Adds a tree node for each content root in each scan type that allows selection of a reference branch, if delta findings is enabled. 

Open Todo: wait for the setting to be available, to check against the real setting instead of setting delta findings to true in the UI.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

![image](https://github.com/user-attachments/assets/59d032a5-b51a-4f7b-9050-27b31e00a147)
![image](https://github.com/user-attachments/assets/c3eff24b-7dc8-42eb-8d37-6ca882a4be6f)
![image](https://github.com/user-attachments/assets/222e531e-774b-4ca5-82fc-1c4bd20ee109)
![image](https://github.com/user-attachments/assets/368a7605-cbd6-46cc-99d9-e9049af1ca41)

