### PR TITLE
feat: add option to enable/disable gutter icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - switch downloads to downloads.snyk.io
 - allow annotations during IntelliJ indexing
 - add gutter icons for Snyk issues
+- add option to switch gutter icons on/off in Snyk Settings (the IntelliJ setting only works for parsed languages)
 - add color and highlighting setting for Snyk issues
 - add dialog to choose reference branch when delta scanning
 - always display info nodes

--- a/src/main/kotlin/snyk/common/annotator/SnykAnnotator.kt
+++ b/src/main/kotlin/snyk/common/annotator/SnykAnnotator.kt
@@ -1,6 +1,9 @@
 package snyk.common.annotator
 
+import com.intellij.codeInsight.daemon.LineMarkerProviders
+import com.intellij.codeInsight.daemon.LineMarkerSettings
 import com.intellij.codeInsight.intention.IntentionAction
+import com.intellij.lang.Language.ANY
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.ExternalAnnotator
 import com.intellij.lang.annotation.HighlightSeverity
@@ -8,7 +11,6 @@ import com.intellij.openapi.Disposable
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.application.invokeLater
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.editor.markup.GutterIconRenderer
@@ -40,6 +42,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 import javax.swing.Icon
 
+
 private const val CODEACTION_TIMEOUT = 5000L
 
 abstract class SnykAnnotator(private val product: ProductType) :
@@ -63,7 +66,7 @@ abstract class SnykAnnotator(private val product: ProductType) :
         val annotationMessage: String,
         val range: TextRange,
         val intention: IntentionAction,
-        val renderGutterIcon: Boolean = false
+        var gutterIconRenderer: GutterIconRenderer? = null
     )
 
     // overrides needed for the Annotator to invoke apply(). We don't do anything here
@@ -74,15 +77,19 @@ abstract class SnykAnnotator(private val product: ProductType) :
             .sortedBy { it.title })
     }
 
-    override fun doAnnotate(initial: Pair<PsiFile, List<ScanIssue>>): List<SnykAnnotation> {
+    override fun doAnnotate(initialInfo: Pair<PsiFile, List<ScanIssue>>): List<SnykAnnotation> {
         if (disposed) return emptyList()
-        AnnotatorCommon.prepareAnnotate(initial.first)
+        AnnotatorCommon.prepareAnnotate(initialInfo.first)
         if (!LanguageServerWrapper.getInstance().isInitialized) return emptyList()
+
+        val lineMarkerProviderDescriptor: SnykLineMarkerProvider = getLineMarkerProvider()
+        val gutterIconEnabled = LineMarkerSettings.getSettings().isEnabled(lineMarkerProviderDescriptor)
 
         val annotations = mutableListOf<SnykAnnotation>()
         val gutterIcons: MutableSet<TextRange> = mutableSetOf()
-        initial.second.sortedByDescending { it.getSeverityAsEnum() }.forEach { issue ->
-            val textRange = textRange(initial.first, issue.range)
+
+        initialInfo.second.sortedByDescending { it.getSeverityAsEnum() }.forEach { issue ->
+            val textRange = textRange(initialInfo.first, issue.range)
             val highlightSeverity = issue.getSeverityAsEnum().getHighlightSeverity()
             val annotationMessage = issue.annotationMessage()
             if (textRange == null) {
@@ -95,47 +102,28 @@ abstract class SnykAnnotator(private val product: ProductType) :
                     highlightSeverity,
                     annotationMessage,
                     textRange,
-                    ShowDetailsIntentionAction(annotationMessage, issue),
-                    renderGutterIcon = !gutterIcons.contains(textRange)
+                    ShowDetailsIntentionAction(annotationMessage, issue)
                 )
+
+                val gutterIconRenderer =
+                    if (!gutterIcons.contains(textRange) && gutterIconEnabled) {
+                        SnykShowDetailsGutterRenderer(detailAnnotation)
+                    } else {
+                        null
+                    }
+
+                detailAnnotation.gutterIconRenderer = gutterIconRenderer
                 annotations.add(detailAnnotation)
                 gutterIcons.add(textRange)
 
-                val params =
-                    CodeActionParams(
-                        TextDocumentIdentifier(initial.first.virtualFile.toLanguageServerURL()),
-                        issue.range,
-                        CodeActionContext(emptyList()),
+                annotations.addAll(
+                    getAnnotationsForCodeActions(
+                        initialInfo,
+                        issue,
+                        highlightSeverity,
+                        textRange
                     )
-                val languageServer = LanguageServerWrapper.getInstance().languageServer
-                val codeActions =
-                    try {
-                        languageServer.textDocumentService
-                            .codeAction(params).get(CODEACTION_TIMEOUT, TimeUnit.MILLISECONDS) ?: emptyList()
-                    } catch (ignored: TimeoutException) {
-                        logger.info("Timeout fetching code actions for issue: $issue")
-                        emptyList()
-                    }
-
-                codeActions
-                    .filter { a ->
-                        val diagnosticCode = a.right.diagnostics?.get(0)?.code?.left
-                        val ruleId = issue.ruleId()
-                        diagnosticCode == ruleId
-                    }
-                    .sortedBy { it.right.title }.forEach { action ->
-                        val codeAction = action.right
-                        val title = codeAction.title
-                        val codeActionAnnotation = SnykAnnotation(
-                            issue,
-                            highlightSeverity,
-                            title,
-                            textRange,
-                            CodeActionIntention(issue, codeAction, product)
-                        )
-                        annotations.add(codeActionAnnotation)
-                    }
-
+                )
             }
         }
         return annotations
@@ -155,12 +143,66 @@ abstract class SnykAnnotator(private val product: ProductType) :
                         .range(annotation.range)
                         .textAttributes(getTextAttributeKeyBySeverity(annotation.issue.getSeverityAsEnum()))
                         .withFix(annotation.intention)
-                    if (annotation.renderGutterIcon) {
+                    if (annotation.gutterIconRenderer != null) {
                         annoBuilder.gutterIconRenderer(SnykShowDetailsGutterRenderer(annotation))
                     }
                     annoBuilder.create()
                 }
             }
+    }
+
+    private fun getAnnotationsForCodeActions(
+        initial: Pair<PsiFile, List<ScanIssue>>,
+        issue: ScanIssue,
+        highlightSeverity: HighlightSeverity,
+        textRange: TextRange,
+    ): MutableList<SnykAnnotation> {
+        val addedAnnotationsList = mutableListOf<SnykAnnotation>()
+        val params =
+            CodeActionParams(
+                TextDocumentIdentifier(initial.first.virtualFile.toLanguageServerURL()),
+                issue.range,
+                CodeActionContext(emptyList()),
+            )
+        val languageServer = LanguageServerWrapper.getInstance().languageServer
+        val codeActions =
+            try {
+                languageServer.textDocumentService
+                    .codeAction(params).get(CODEACTION_TIMEOUT, TimeUnit.MILLISECONDS) ?: emptyList()
+            } catch (ignored: TimeoutException) {
+                logger.info("Timeout fetching code actions for issue: $issue")
+                emptyList()
+            }
+
+        codeActions
+            .filter { a ->
+                val diagnosticCode = a.right.diagnostics?.get(0)?.code?.left
+                val ruleId = issue.ruleId()
+                diagnosticCode == ruleId
+            }
+            .sortedBy { it.right.title }.forEach { action ->
+                val codeAction = action.right
+                val title = codeAction.title
+                val codeActionAnnotation = SnykAnnotation(
+                    issue,
+                    highlightSeverity,
+                    title,
+                    textRange,
+                    CodeActionIntention(issue, codeAction, product)
+                )
+                addedAnnotationsList.add(codeActionAnnotation)
+            }
+        return addedAnnotationsList
+    }
+
+    private fun getLineMarkerProvider(): SnykLineMarkerProvider {
+        val lineMarkerProviderDescriptor: SnykLineMarkerProvider =
+            LineMarkerProviders.getInstance().allForLanguage(ANY)
+                .stream()
+                .filter { p -> p is SnykLineMarkerProvider }
+                .findFirst()
+                .orElse(null) as SnykLineMarkerProvider
+        return lineMarkerProviderDescriptor
     }
 
     private fun getTextAttributeKeyBySeverity(severity: Severity): TextAttributesKey {

--- a/src/main/kotlin/snyk/common/annotator/SnykAnnotator.kt
+++ b/src/main/kotlin/snyk/common/annotator/SnykAnnotator.kt
@@ -73,8 +73,7 @@ abstract class SnykAnnotator(private val product: ProductType) :
     override fun collectInformation(file: PsiFile): Pair<PsiFile, List<ScanIssue>> {
         return Pair(file, getIssuesForFile(file)
             .filter { AnnotatorCommon.isSeverityToShow(it.getSeverityAsEnum()) }
-            .distinctBy { it.id }
-            .sortedBy { it.title })
+            .distinctBy { it.id })
     }
 
     override fun doAnnotate(initialInfo: Pair<PsiFile, List<ScanIssue>>): List<SnykAnnotation> {
@@ -106,7 +105,8 @@ abstract class SnykAnnotator(private val product: ProductType) :
                 )
 
                 val gutterIconRenderer =
-                    if (!gutterIcons.contains(textRange) && gutterIconEnabled) {
+                    if (gutterIconEnabled && !gutterIcons.contains(textRange)) {
+                        gutterIcons.add(textRange)
                         SnykShowDetailsGutterRenderer(detailAnnotation)
                     } else {
                         null
@@ -114,7 +114,6 @@ abstract class SnykAnnotator(private val product: ProductType) :
 
                 detailAnnotation.gutterIconRenderer = gutterIconRenderer
                 annotations.add(detailAnnotation)
-                gutterIcons.add(textRange)
 
                 annotations.addAll(
                     getAnnotationsForCodeActions(
@@ -136,7 +135,7 @@ abstract class SnykAnnotator(private val product: ProductType) :
     ) {
         if (disposed) return
         if (!LanguageServerWrapper.getInstance().isInitialized) return
-        annotationResult.sortedByDescending { it.issue.getSeverityAsEnum() }
+        annotationResult
             .forEach { annotation ->
                 if (!annotation.range.isEmpty) {
                     val annoBuilder = holder.newAnnotation(annotation.annotationSeverity, annotation.annotationMessage)
@@ -306,6 +305,4 @@ class SnykShowDetailsGutterRenderer(val annotation: SnykAnnotation) : GutterIcon
     override fun isDumbAware(): Boolean {
         return true
     }
-
-
 }

--- a/src/main/kotlin/snyk/common/annotator/SnykLineMarkerProvider.kt
+++ b/src/main/kotlin/snyk/common/annotator/SnykLineMarkerProvider.kt
@@ -1,0 +1,23 @@
+package snyk.common.annotator
+
+import com.intellij.codeInsight.daemon.LineMarkerInfo
+import com.intellij.codeInsight.daemon.LineMarkerProviderDescriptor
+import com.intellij.psi.PsiElement
+import icons.SnykIcons
+import javax.swing.Icon
+
+// we only define a line marker provider so we can use the gutter icon settings to switch
+// rendering of gutter icons on and off
+class SnykLineMarkerProvider : LineMarkerProviderDescriptor() {
+    override fun getName(): String {
+        return "Snyk Security"
+    }
+
+    override fun getIcon(): Icon {
+        return SnykIcons.TOOL_WINDOW
+    }
+
+    override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? {
+        return null
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -19,6 +19,9 @@
   <depends optional="true" config-file="optional/withXML.xml">com.intellij.modules.xml</depends>
 
   <extensions defaultExtensionNs="com.intellij">
+      <codeInsight.lineMarkerProvider
+        language=""
+        implementationClass="snyk.common.annotator.SnykLineMarkerProvider"/>
     <colorSettingsPage implementation="snyk.common.annotator.SnykAnnotationColorSettingsPage"/>
     <toolWindow id="Snyk"
                 anchor="bottom"


### PR DESCRIPTION
### Description

This adds an option to enable/disable Snyk gutter icons in the IntelliJ Gutter Icons Editor settings page.

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

![image](https://github.com/user-attachments/assets/bd4efe1e-550d-48d4-a76b-a582c4f719ae)