### PR TITLE
fix: don't double scan on startup, handle feature flags better

### DIFF
--- a/src/main/kotlin/io/snyk/plugin/SnykPostStartupActivity.kt
+++ b/src/main/kotlin/io/snyk/plugin/SnykPostStartupActivity.kt
@@ -79,7 +79,7 @@ class SnykPostStartupActivity : ProjectActivity {
         }
 
         if (!settings.token.isNullOrBlank() && settings.scanOnSave) {
-            getSnykTaskQueueService(project)?.scan()
+            getSnykTaskQueueService(project)?.scheduleContainerScan()
         }
 
         ExtensionPointsUtil.controllerManager.extensionList.forEach {

--- a/src/main/kotlin/io/snyk/plugin/SnykProjectManagerListener.kt
+++ b/src/main/kotlin/io/snyk/plugin/SnykProjectManagerListener.kt
@@ -17,7 +17,7 @@ class SnykProjectManagerListener : ProjectManagerListener {
     val threadPool: ExecutorService = Executors.newWorkStealingPool()
 
     override fun projectClosing(project: Project) {
-        val closingTask = object : Backgroundable(project, "Project closing ${project.name}") {
+        val closingTask = object : Backgroundable(project, "Snyk: Project closing ${project.name}") {
             override fun run(indicator: ProgressIndicator) {
                 // limit clean up to TIMEOUT
                 try {

--- a/src/main/kotlin/io/snyk/plugin/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/Utils.kt
@@ -24,7 +24,6 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.roots.ProjectRootManager
-import com.intellij.openapi.util.NlsContexts
 import com.intellij.openapi.util.io.toNioPathOrNull
 import com.intellij.openapi.util.registry.Registry
 import com.intellij.openapi.vfs.StandardFileSystems

--- a/src/main/kotlin/io/snyk/plugin/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/Utils.kt
@@ -18,10 +18,13 @@ import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.openapi.util.NlsContexts
 import com.intellij.openapi.util.io.toNioPathOrNull
 import com.intellij.openapi.util.registry.Registry
 import com.intellij.openapi.vfs.StandardFileSystems
@@ -454,4 +457,12 @@ fun Project.getContentRootVirtualFiles(): Set<VirtualFile> {
 fun VirtualFile.isInContent(project: Project): Boolean {
     val vf = this
     return ReadAction.compute<Boolean, RuntimeException> { ProjectFileIndex.getInstance(project).isInContent(vf) }
+}
+
+inline fun runInBackground(title: String, project: Project? = null, cancellable: Boolean = true, crossinline task: (indicator: ProgressIndicator) -> Unit) {
+    ProgressManager.getInstance().run(object : Task.Backgroundable(project, title, cancellable) {
+        override fun run(indicator: ProgressIndicator) {
+            task(indicator)
+        }
+    })
 }

--- a/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
@@ -10,12 +10,10 @@ import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import io.snyk.plugin.events.SnykCliDownloadListener
 import io.snyk.plugin.events.SnykScanListener
-import io.snyk.plugin.events.SnykSettingsListener
 import io.snyk.plugin.events.SnykTaskQueueListener
 import io.snyk.plugin.getContainerService
 import io.snyk.plugin.getSnykCachedResults
 import io.snyk.plugin.getSnykCliDownloaderService
-import io.snyk.plugin.getSnykToolWindowPanel
 import io.snyk.plugin.getSyncPublisher
 import io.snyk.plugin.isCliDownloading
 import io.snyk.plugin.isCliInstalled

--- a/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
@@ -55,19 +55,6 @@ class SnykTaskQueueService(val project: Project) {
         // subscribe to the settings changed topic
         val languageServerWrapper = LanguageServerWrapper.getInstance()
         languageServerWrapper.ensureLanguageServerInitialized()
-
-        getSnykToolWindowPanel(project)?.let {
-            project.messageBus.connect(it)
-                .subscribe(
-                    SnykSettingsListener.SNYK_SETTINGS_TOPIC,
-                    object : SnykSettingsListener {
-                        override fun settingsChanged() {
-                            languageServerWrapper.updateConfiguration()
-                        }
-                    }
-                )
-        }
-
         languageServerWrapper.addContentRoots(project)
     }
 

--- a/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.progress.BackgroundTaskQueue
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task
+import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import io.snyk.plugin.events.SnykCliDownloadListener
 import io.snyk.plugin.events.SnykScanListener
@@ -50,10 +51,13 @@ class SnykTaskQueueService(val project: Project) {
     fun getTaskQueue() = taskQueue
 
     fun connectProjectToLanguageServer(project: Project) {
-        // subscribe to the settings changed topic
         val languageServerWrapper = LanguageServerWrapper.getInstance()
         languageServerWrapper.ensureLanguageServerInitialized()
-        languageServerWrapper.addContentRoots(project)
+
+        // wait for modules to be loaded and indexed so we can add all relevant content roots
+        DumbService.getInstance(project).runWhenSmart {
+            languageServerWrapper.addContentRoots(project)
+        }
     }
 
     fun scan() {

--- a/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
@@ -85,9 +85,7 @@ class SnykTaskQueueService(val project: Project) {
 
                 LanguageServerWrapper.getInstance().sendScanCommand(project)
 
-                if (settings.containerScanEnabled) {
-                    scheduleContainerScan()
-                }
+                scheduleContainerScan()
             }
         })
     }
@@ -99,7 +97,8 @@ class SnykTaskQueueService(val project: Project) {
         } while (isCliDownloading())
     }
 
-    private fun scheduleContainerScan() {
+    fun scheduleContainerScan() {
+        if (!settings.containerScanEnabled) return
         taskQueueContainer.run(object : Task.Backgroundable(project, "Snyk Container is scanning...", true) {
             override fun run(indicator: ProgressIndicator) {
                 if (!isCliInstalled()) return

--- a/src/main/kotlin/io/snyk/plugin/settings/SnykProjectSettingsConfigurable.kt
+++ b/src/main/kotlin/io/snyk/plugin/settings/SnykProjectSettingsConfigurable.kt
@@ -111,9 +111,7 @@ class SnykProjectSettingsConfigurable(
         }
 
         runBackgroundableTask("processing config changes", project, true) {
-            LanguageServerWrapper.getInstance().refreshFeatureFlags()
-
-
+            val languageServerWrapper = LanguageServerWrapper.getInstance()
             if (snykSettingsDialog.getCliReleaseChannel().trim() != pluginSettings().cliReleaseChannel) {
                 handleReleaseChannelChanged()
             }
@@ -127,7 +125,8 @@ class SnykProjectSettingsConfigurable(
                 getSnykToolWindowPanel(project)?.getTree()?.isRootVisible = pluginSettings().isDeltaFindingsEnabled()
             }
 
-            LanguageServerWrapper.getInstance().updateConfiguration()
+            languageServerWrapper.refreshFeatureFlags()
+            languageServerWrapper.updateConfiguration()
         }
 
         if (rescanNeeded) {

--- a/src/main/kotlin/io/snyk/plugin/settings/SnykProjectSettingsConfigurable.kt
+++ b/src/main/kotlin/io/snyk/plugin/settings/SnykProjectSettingsConfigurable.kt
@@ -111,8 +111,7 @@ class SnykProjectSettingsConfigurable(
         }
 
         runBackgroundableTask("processing config changes", project, true) {
-            settingsStateService.isGlobalIgnoresFeatureEnabled =
-                LanguageServerWrapper.getInstance().isGlobalIgnoresFeatureEnabled()
+            LanguageServerWrapper.getInstance().refreshFeatureFlags()
 
 
             if (snykSettingsDialog.getCliReleaseChannel().trim() != pluginSettings().cliReleaseChannel) {

--- a/src/main/kotlin/io/snyk/plugin/ui/BranchChooserComboboxDialog.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/BranchChooserComboboxDialog.kt
@@ -7,10 +7,10 @@ import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.openapi.ui.ValidationInfo
 import com.intellij.util.ui.GridBag
 import com.intellij.util.ui.JBUI
-import org.jetbrains.concurrency.runAsync
+import io.snyk.plugin.runInBackground
 import snyk.common.lsp.FolderConfig
-import snyk.common.lsp.settings.FolderConfigSettings
 import snyk.common.lsp.LanguageServerWrapper
+import snyk.common.lsp.settings.FolderConfigSettings
 import java.awt.GridBagConstraints
 import java.awt.GridBagLayout
 import javax.swing.JComponent
@@ -66,7 +66,7 @@ class BranchChooserComboBoxDialog(val project: Project) : DialogWrapper(true) {
             val baseBranch = it.selectedItem!!.toString() // validation makes sure it is not null and not empty
             folderConfigSettings.addFolderConfig(folderConfig.copy(baseBranch = baseBranch))
         }
-        runAsync {
+        runInBackground("Snyk: updating configuration") {
             LanguageServerWrapper.getInstance().updateConfiguration()
         }
     }

--- a/src/main/kotlin/io/snyk/plugin/ui/SnykSettingsDialog.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/SnykSettingsDialog.kt
@@ -47,7 +47,9 @@ import io.snyk.plugin.ui.settings.IssueViewOptionsPanel
 import io.snyk.plugin.ui.settings.ScanTypesPanel
 import io.snyk.plugin.ui.settings.SeveritiesEnablementPanel
 import io.snyk.plugin.ui.toolwindow.SnykPluginDisposable
+import org.jetbrains.concurrency.runAsync
 import snyk.SnykBundle
+import snyk.common.lsp.LanguageServerWrapper
 import snyk.common.lsp.settings.FolderConfigSettings
 import java.awt.GridBagConstraints
 import java.awt.GridBagLayout
@@ -376,41 +378,47 @@ class SnykSettingsDialog(
 
         /** Products and Severities selection ------------------ */
 
-        if (pluginSettings().isGlobalIgnoresFeatureEnabled) {
-            val issueViewPanel = JPanel(UIGridLayoutManager(3, 2, JBUI.emptyInsets(), 30, -1))
-            issueViewPanel.border = IdeBorderFactory.createTitledBorder("Issue view options")
+        val issueViewPanel = JPanel(UIGridLayoutManager(3, 2, JBUI.emptyInsets(), 30, -1))
+        issueViewPanel.isVisible = true
+        issueViewPanel.border = IdeBorderFactory.createTitledBorder("Issue view options")
 
-            val issueViewLabel = JLabel("Show the following issues:")
-            issueViewPanel.add(
-                issueViewLabel,
-                baseGridConstraintsAnchorWest(
-                    row = 0,
-                    indent = 0,
-                ),
-            )
+        val issueViewLabel = JLabel("Show the following issues:")
+        issueViewPanel.add(
+            issueViewLabel,
+            baseGridConstraintsAnchorWest(
+                row = 0,
+                indent = 0,
+            ),
+        )
 
-            rootPanel.add(
-                issueViewPanel,
-                baseGridConstraints(
-                    row = 1,
-                    anchor = UIGridConstraints.ANCHOR_NORTHWEST,
-                    fill = UIGridConstraints.FILL_HORIZONTAL,
-                    hSizePolicy = UIGridConstraints.SIZEPOLICY_CAN_SHRINK or UIGridConstraints.SIZEPOLICY_CAN_GROW,
-                    indent = 0,
-                ),
-            )
+        rootPanel.add(
+            issueViewPanel,
+            baseGridConstraints(
+                row = 1,
+                anchor = UIGridConstraints.ANCHOR_NORTHWEST,
+                fill = UIGridConstraints.FILL_HORIZONTAL,
+                hSizePolicy = UIGridConstraints.SIZEPOLICY_CAN_SHRINK or UIGridConstraints.SIZEPOLICY_CAN_GROW,
+                indent = 0,
+            ),
+        )
 
-            issueViewPanel.add(
-                this.issueViewOptionsPanel,
-                baseGridConstraints(
-                    row = 1,
-                    anchor = UIGridConstraints.ANCHOR_NORTHWEST,
-                    fill = UIGridConstraints.FILL_NONE,
-                    hSizePolicy = UIGridConstraints.SIZEPOLICY_CAN_SHRINK or UIGridConstraints.SIZEPOLICY_CAN_GROW,
-                    vSizePolicy = UIGridConstraints.SIZEPOLICY_CAN_SHRINK or UIGridConstraints.SIZEPOLICY_CAN_GROW,
-                    indent = 0,
-                ),
-            )
+        issueViewPanel.add(
+            this.issueViewOptionsPanel,
+            baseGridConstraints(
+                row = 1,
+                anchor = UIGridConstraints.ANCHOR_NORTHWEST,
+                fill = UIGridConstraints.FILL_NONE,
+                hSizePolicy = UIGridConstraints.SIZEPOLICY_CAN_SHRINK or UIGridConstraints.SIZEPOLICY_CAN_GROW,
+                vSizePolicy = UIGridConstraints.SIZEPOLICY_CAN_SHRINK or UIGridConstraints.SIZEPOLICY_CAN_GROW,
+                indent = 0,
+            ),
+        )
+
+        runAsync {
+            if (!pluginSettings().isGlobalIgnoresFeatureEnabled) {
+                LanguageServerWrapper.getInstance().refreshFeatureFlags()
+            }
+            issueViewPanel.isVisible = pluginSettings().isGlobalIgnoresFeatureEnabled
         }
 
         val productAndSeveritiesPanel = JPanel(UIGridLayoutManager(2, 2, JBUI.emptyInsets(), 30, -1))
@@ -605,7 +613,7 @@ class SnykSettingsDialog(
         val netNewIssuesText =
             JLabel(
                 "Specifies whether to see only net new issues or all issues. " +
-                        "Only applies to Code Security and Code Quality."
+                    "Only applies to Code Security and Code Quality."
             ).apply { font = FontUtil.minusOne(this.font) }
 
         netNewIssuesPanel.add(

--- a/src/main/kotlin/io/snyk/plugin/ui/jcef/ApplyFixHandler.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/jcef/ApplyFixHandler.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.ui.jcef.JBCefBrowserBase
 import com.intellij.ui.jcef.JBCefJSQuery
 import io.snyk.plugin.DiffPatcher
+import io.snyk.plugin.runInBackground
 import io.snyk.plugin.toVirtualFile
 import org.cef.browser.CefBrowser
 import org.cef.browser.CefFrame
@@ -36,7 +37,7 @@ class ApplyFixHandler(private val project: Project) {
             val patch = params[2]      // The patch we received from LS
 
             // Avoid blocking the UI thread
-            runAsync {
+            runInBackground("Snyk: applying fix...") {
                 val result = try {
                     applyPatchAndSave(project, filePath, patch)
                 } catch (e: IOException) { // Catch specific file-related exceptions

--- a/src/main/kotlin/io/snyk/plugin/ui/jcef/ApplyFixHandler.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/jcef/ApplyFixHandler.kt
@@ -10,11 +10,10 @@ import com.intellij.ui.jcef.JBCefJSQuery
 import io.snyk.plugin.DiffPatcher
 import io.snyk.plugin.runInBackground
 import io.snyk.plugin.toVirtualFile
+import io.snyk.plugin.ui.SnykBalloonNotificationHelper
 import org.cef.browser.CefBrowser
 import org.cef.browser.CefFrame
 import org.cef.handler.CefLoadHandlerAdapter
-import org.jetbrains.concurrency.runAsync
-import io.snyk.plugin.ui.SnykBalloonNotificationHelper
 import snyk.common.lsp.LanguageServerWrapper
 import java.io.IOException
 

--- a/src/main/kotlin/io/snyk/plugin/ui/jcef/GenerateAIFixHandler.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/jcef/GenerateAIFixHandler.kt
@@ -3,6 +3,7 @@ package io.snyk.plugin.ui.jcef
 import com.google.gson.Gson
 import com.intellij.ui.jcef.JBCefBrowserBase
 import com.intellij.ui.jcef.JBCefJSQuery
+import io.snyk.plugin.runInBackground
 import org.cef.browser.CefBrowser
 import org.cef.browser.CefFrame
 import org.cef.handler.CefLoadHandlerAdapter
@@ -23,7 +24,7 @@ class GenerateAIFixHandler() {
             val issueID = params[2]
 
 
-            runAsync {
+            runInBackground("Snyk: getting AI fix proposals...") {
                 val responseDiff: List<Fix> =
                     LanguageServerWrapper.getInstance().sendCodeFixDiffsCommand(folderURI, fileURI, issueID)
 

--- a/src/main/kotlin/io/snyk/plugin/ui/jcef/GenerateAIFixHandler.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/jcef/GenerateAIFixHandler.kt
@@ -7,9 +7,8 @@ import io.snyk.plugin.runInBackground
 import org.cef.browser.CefBrowser
 import org.cef.browser.CefFrame
 import org.cef.handler.CefLoadHandlerAdapter
-import org.jetbrains.concurrency.runAsync
-import snyk.common.lsp.LanguageServerWrapper
 import snyk.common.lsp.Fix
+import snyk.common.lsp.LanguageServerWrapper
 
 
 class GenerateAIFixHandler() {

--- a/src/main/kotlin/snyk/common/codevision/LSCodeVisionProvider.kt
+++ b/src/main/kotlin/snyk/common/codevision/LSCodeVisionProvider.kt
@@ -48,14 +48,14 @@ class LSCodeVisionProvider : CodeVisionProvider<Unit>, CodeVisionGroupSettingPro
         if (LanguageServerWrapper.getInstance().isDisposed()) return CodeVisionState.READY_EMPTY
         if (!LanguageServerWrapper.getInstance().isInitialized) return CodeVisionState.READY_EMPTY
         val project = editor.project ?: return CodeVisionState.READY_EMPTY
-        if (!editor.virtualFile.isInContent(project)) return CodeVisionState.READY_EMPTY
-
         val document = editor.document
 
         val file = ReadAction.compute<PsiFile, RuntimeException> {
             PsiDocumentManager.getInstance(project).getPsiFile(document)
         } ?: return CodeVisionState.READY_EMPTY
 
+        val virtualFile = file.virtualFile
+        if (!virtualFile.isInContent(project)) return CodeVisionState.READY_EMPTY
 
         val params = CodeLensParams(TextDocumentIdentifier(file.virtualFile.toLanguageServerURL()))
         val lenses = mutableListOf<Pair<TextRange, CodeVisionEntry>>()

--- a/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
@@ -200,16 +200,6 @@ class LanguageServerWrapper(
 
     private fun lsIsAlive() = ::process.isInitialized && process.isAlive
 
-    private fun determineWorkspaceFolders(): List<WorkspaceFolder> {
-        val workspaceFolders = mutableSetOf<WorkspaceFolder>()
-        ProjectManager.getInstance().openProjects.forEach { project ->
-            if (!project.isDisposed) {
-                workspaceFolders.addAll(getWorkspaceFolders(project))
-            }
-        }
-        return workspaceFolders.toList()
-    }
-
     fun getWorkspaceFolders(project: Project): Set<WorkspaceFolder> {
         if (disposed || project.isDisposed) return emptySet()
         val normalizedRoots = getTrustedContentRoots(project)

--- a/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
@@ -1,14 +1,10 @@
 package snyk.common.lsp
 
 import com.google.gson.Gson
-import com.intellij.ide.impl.ProjectUtil
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
-import com.intellij.openapi.progress.ProgressIndicator
-import com.intellij.openapi.progress.ProgressManager
-import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager

--- a/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
@@ -250,13 +250,11 @@ class LanguageServerWrapper(
 
     fun sendInitializeMessage() {
         if (disposed) return
-        val workspaceFolders = determineWorkspaceFolders()
 
         val params = InitializeParams()
         params.processId = ProcessHandle.current().pid().toInt()
         params.clientInfo = ClientInfo(pluginInfo.integrationEnvironment, pluginInfo.integrationEnvironmentVersion)
         params.initializationOptions = getSettings()
-        params.workspaceFolders = workspaceFolders
         params.capabilities = getCapabilities()
 
         initializeResult = languageServer.initialize(params).get(INITIALIZATION_TIMEOUT, TimeUnit.SECONDS)

--- a/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
@@ -353,18 +353,14 @@ class LanguageServerWrapper(
     }
 
     fun refreshFeatureFlags() {
+        if (notAuthenticated()) return
         runAsync {
-            if (!ensureLanguageServerInitialized()) return@runAsync
             pluginSettings().isGlobalIgnoresFeatureEnabled = isGlobalIgnoresFeatureEnabled()
         }
     }
 
     fun getFeatureFlagStatus(featureFlag: String): Boolean {
         if (notAuthenticated()) return false
-        return getFeatureFlagStatusInternal(featureFlag)
-    }
-
-    private fun getFeatureFlagStatusInternal(featureFlag: String): Boolean {
         try {
             val param = ExecuteCommandParams()
             param.command = COMMAND_GET_FEATURE_FLAG_STATUS

--- a/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
+++ b/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
@@ -225,7 +225,6 @@ class SnykLanguageClient :
         }
     }
 
-
     private fun processSuccessfulScan(
         snykScan: SnykScanParams,
         scanPublisher: SnykScanListenerLS,
@@ -351,6 +350,16 @@ class SnykLanguageClient :
             }
         }
     }
+
+    /**
+     * We don't need this custom notification, as LSP4j already supports LSP 3.17.
+     * This custom notification is sent from the server to give clients that only support
+     * lower LSP protocol versions the chance to retrieve the <pre>data</pre> field of
+     * the diagnostic that contains the issue detail data by implementing a custom
+     * notification listener (e.g. Visual Studio)
+     */
+    @JsonNotification("\$/snyk.publishDiagnostics316")
+    fun publishDiagnostics316(ignored: PublishDiagnosticsParams?) = Unit
 
     companion object {
         // we only allow one message request at a time

--- a/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
+++ b/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
@@ -186,8 +186,6 @@ class SnykLanguageClient :
     fun snykScan(snykScan: SnykScanParams) {
         if (disposed) return
         try {
-            // retrieve global ignores feature flag status after auth
-            LanguageServerWrapper.getInstance().refreshFeatureFlags()
             getScanPublishersFor(snykScan.folderPath).forEach { (_, scanPublisher) ->
                 processSnykScan(snykScan, scanPublisher)
             }
@@ -236,7 +234,10 @@ class SnykLanguageClient :
 
         when (snykScan.product) {
             "oss" -> scanPublisher.scanningOssFinished()
-            "code" -> scanPublisher.scanningSnykCodeFinished()
+            "code" -> {
+                LanguageServerWrapper.getInstance().refreshFeatureFlags()
+                scanPublisher.scanningSnykCodeFinished()
+            }
             "iac" -> scanPublisher.scanningIacFinished()
             "container" -> TODO()
         }
@@ -272,9 +273,6 @@ class SnykLanguageClient :
 
         if (pluginSettings().token?.isNotEmpty() == true && pluginSettings().scanOnSave) {
             val wrapper = LanguageServerWrapper.getInstance()
-            // retrieve global ignores feature flag status after auth
-            LanguageServerWrapper.getInstance().refreshFeatureFlags()
-
             ProjectManager.getInstance().openProjects.forEach {
                 wrapper.sendScanCommand(it)
             }

--- a/src/test/kotlin/snyk/common/lsp/LanguageServerWrapperTest.kt
+++ b/src/test/kotlin/snyk/common/lsp/LanguageServerWrapperTest.kt
@@ -26,7 +26,6 @@ import org.eclipse.lsp4j.InitializeParams
 import org.eclipse.lsp4j.services.LanguageServer
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import snyk.common.lsp.commands.ScanDoneEvent
 import snyk.common.lsp.settings.FolderConfigSettings
@@ -77,6 +76,7 @@ class LanguageServerWrapperTest {
         cut = LanguageServerWrapper("dummy")
         cut.languageServer = lsMock
         cut.isInitialized = true
+        settings.token = "testToken"
     }
 
     @After

--- a/src/test/kotlin/snyk/common/lsp/LanguageServerWrapperTest.kt
+++ b/src/test/kotlin/snyk/common/lsp/LanguageServerWrapperTest.kt
@@ -329,22 +329,4 @@ class LanguageServerWrapperTest {
         assertEquals(settings.organization, actual.organization)
         assertEquals(settings.isDeltaFindingsEnabled().toString(), actual.enableDeltaFindings)
     }
-
-    @Ignore // somehow it doesn't work in the pipeline
-    @Test
-    fun `sendFeatureFlagCommand should return true if feature flag is enabled`() {
-        // Arrange
-        cut.languageClient = mockk(relaxed = true)
-        val featureFlag = "testFeatureFlag"
-        every {
-            lsMock.workspaceService.executeCommand(any<ExecuteCommandParams>())
-        } returns CompletableFuture.completedFuture(mapOf("ok" to true))
-        justRun { applicationMock.invokeLater(any()) }
-
-        // Act
-        val result = cut.getFeatureFlagStatus(featureFlag)
-
-        // Assert
-        assertEquals(true, result)
-    }
 }


### PR DESCRIPTION
### Description

Previously, at startup, two scans were triggered due to LS triggering one automatically during startup and IntelliJ triggering one manually on opening a project.

Now, no scan is manually triggered when opening a project.

In addition to using the feature flag API endpoint, consistentIgnores status is now detected when processing scan results. When an issue is ignored, this can only come from the feature being on, so it's switched on in IntelliJ. This should make sure that whenever ignored issues are transmitted, IntelliJ filters & displays them correctly.

Fixes code vision not displaying.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
