### PR TITLE
fix: cut max message length, ensure ls init

### DIFF
--- a/.snyk.env.darwin
+++ b/.snyk.env.darwin
@@ -1,2 +1,0 @@
-JAVA_HOME=$HOME/Library/Java/JavaVirtualMachines/corretto-19.0.2/Contents/Home
-PATH=$JAVA_HOME/bin

--- a/.snyk.env.darwin
+++ b/.snyk.env.darwin
@@ -1,0 +1,2 @@
+JAVA_HOME=$HOME/Library/Java/JavaVirtualMachines/corretto-19.0.2/Contents/Home
+PATH=$JAVA_HOME/bin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@
 - if the language server listener is shut down, set initialized to false
 - log error stream of language server to idea.log
 - show error / warn messages if the project is null (e.g. for offline handling)
+- limit warn / error messages to 500 characters
+- use dumb aware to limit scans during startup
 - add no_proxy environment variable, if proxy exceptions are defined
 
 ## [2.9.1]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,49 +1,7 @@
 # Contribution guide (draft)
 
-__As of state for June 2022__
-
-### Architectural Overview
-There are two projects' packages structures in source tree right now:
-- `io.snyk.plugin` - Old one (legacy). Grouping classes/components by it's IntelliJ framework role, i.e. `.events`, `.services`, etc. mixed with our own components groups: `.net`, `.cli`, etc.
-- `snyk` - New one. Grouping by Snyk Product (`.advisor`, `.iac`, etc) or service (`.common`, `.net`, etc)
-
-**todo:** Unify project packages structure to either `io.snyk.plugin` or `snyk`
-
-Ideally all communication between components/services should happen through events' mechanism (see `SnykScanListener` and it's usages/implementations as example).
-
-**todo:** But that's not always true presently. :(
-
-All communication through network should go through `HttpClient`/`ApiClient` from `.net` package to reuse Client whenever possible (mostly to reuse Interceptors, SSL Certificate handlers, timeouts, etc.)
-
-**todo:** Unify `.net` packages from `io.snyk.plugin` and `snyk` roots
-
-Communication with CLI goes through `CliAdapter` (with `ConsoleCommandRunner` call under the hood): i.e. you need to inherit from it for every specific CLI usage/call (see `OssService` as example)
-
-None-CLI product (SnykCode) communicate directly to Code backend using `java-code-sdk` library. Implementation of required classes are inside `io.snyk.plugin.snykcode` package
-
-**todo:** Unify `.snykcode` network related classes with `.net` package classes.
-
-`ProductType` holds textual representation for each supported product and should be the source of truth and the only place for such texts.
-
-All cached scan results (except SnykCode?) should be holding in `SnykCachedResults` service and requested/updated there when needed.
-
-All project-files-on-disk update (changed, deleted, created, moved, copied) events happened through correspondent implementations of `SnykBulkFileListener` class (see existing implementations for examples of using)
-
-All (most) of the setup needed to be done on plugin start or new Project opening happened at `SnykPostStartupActivity`
-
-All application-wide persisted settings should be held in `SnykApplicationSettingsStateService` and Project-wide settings at correspondent `SnykProjectSettingsStateService`
-
-Any new scan/re-scan should be executed through `SnykTaskQueueService`
-
-Scan related options/settings are held inside `SnykApplicationSettingsStateService` while for the representation of scan results in the Tree we have also _filters_ (by Severity or Product) which should operate on top of the _settings_.
-
-For UI (especially on top level) we're trying to use Idea built-in panels and factory classes/methods like `SimpleToolWindowPanel` or `JPanel`/`JBPanel` with `BorderLayout` as it seems to be more "native" for Idea. For more complicated custom panels we use `JPanel` with `GridConstraints` (see `io.snyk.plugin.ui.UIUtils` for the clue)
-
-Beware of needed wrapping of any UI related code inside of `ApplicationManager.getApplication().invokeLater{}` if you call it from any background thread.
-
-All our instances of Idea's `@Service` classes should be called through correspondent wrapper `get<xxx>Service()` in `io.snyk.plugin.Utils` as some checks need to be done (especially for project's services). Also, Jetbrains changed already in the past recommended way to invoke such services, so would be nice to have such invocations centralised for possible future changes.
-
-Before creating PR (if any user related changes been made) please don't forget to update CHANGELOG.md (follow existing structure) to be reflected in released plugin's Change Notes.
+### Dependencies (macOS)
+- install a JDK into the path specified in `.snyk.env.darwin`. Else the snyk scan may fail 
 
 ### Build and deploy
 

--- a/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
@@ -522,7 +522,7 @@ class LanguageServerWrapper(
 
     fun addContentRoots(project: Project) {
         if (disposed || project.isDisposed) return
-        assert(isInitialized)
+        ensureLanguageServerInitialized()
         ensureLanguageServerProtocolVersion(project)
         val added = getWorkspaceFolders(project)
         updateWorkspaceFolders(added, emptySet())

--- a/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
+++ b/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
@@ -299,20 +299,33 @@ class SnykLanguageClient :
         val project = ProjectUtil.getActiveProject()
         when (messageParams?.type) {
             MessageType.Error -> {
-                SnykBalloonNotificationHelper.showError(messageParams.message, project)
+                val m = cutMessage(messageParams)
+                SnykBalloonNotificationHelper.showError(m, project)
             }
 
-            MessageType.Warning -> SnykBalloonNotificationHelper.showWarn(messageParams.message, project)
+            MessageType.Warning -> {
+                val m = cutMessage(messageParams)
+                SnykBalloonNotificationHelper.showWarn(m, project)
+            }
+
             MessageType.Info -> {
                 val notification = SnykBalloonNotificationHelper.showInfo(messageParams.message, project)
                 ApplicationManager.getApplication().executeOnPooledThread {
-                    Thread.sleep(10000)
+                    Thread.sleep(30000)
                     notification.expire()
                 }
             }
 
             MessageType.Log -> logger.info(messageParams.message)
             null -> {}
+        }
+    }
+
+    private fun cutMessage(messageParams: MessageParams) : String {
+        return if (messageParams.message.length > 500) {
+            messageParams.message.substring(0, 500) + "..."
+        } else {
+            messageParams.message
         }
     }
 


### PR DESCRIPTION
### Description

- cuts max message length
- ensures ls is initialized when adding content root
- adds default java home/path extension via config file


### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
