### PR TITLE
fix: improve download and restart logic

### DIFF
--- a/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
@@ -157,6 +157,7 @@ class SnykTaskQueueService(val project: Project) {
         })
     }
 
+    // FIXME this is currently not project, but app specific
     fun stopScan() {
         val languageServerWrapper = LanguageServerWrapper.getInstance()
 

--- a/src/main/kotlin/io/snyk/plugin/services/download/CliDownloader.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/download/CliDownloader.kt
@@ -1,9 +1,11 @@
 package io.snyk.plugin.services.download
 
+import com.intellij.ide.impl.ProjectUtil
 import com.intellij.openapi.progress.ProgressIndicator
 import io.snyk.plugin.cli.Platform
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.services.download.HttpRequestHelper.createRequest
+import io.snyk.plugin.ui.SnykBalloonNotificationHelper
 import snyk.common.lsp.LanguageServerWrapper
 import java.io.File
 import java.io.IOException
@@ -77,7 +79,12 @@ class CliDownloader {
                 )
             } catch (ignored: AtomicMoveNotSupportedException) {
                 // fallback to renameTo because of e
-                downloadFile.renameTo(cliFile)
+                val success = downloadFile.renameTo(cliFile)
+                if (!success) {
+                    val message =
+                        "CLI could not be updated. Please check if another process is using the CLI binary at ${pluginSettings().cliPath}"
+                    SnykBalloonNotificationHelper.showWarn(message, ProjectUtil.getActiveProject())
+                }
             } finally {
                 languageServerWrapper.isInitializing.unlock()
             }

--- a/src/main/kotlin/io/snyk/plugin/services/download/CliDownloaderService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/download/CliDownloaderService.kt
@@ -15,7 +15,6 @@ import java.io.IOException
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 import java.util.Date
-import java.util.concurrent.TimeUnit
 
 @Service
 class SnykCliDownloaderService {
@@ -71,14 +70,6 @@ class SnykCliDownloaderService {
 
             val languageServerWrapper = LanguageServerWrapper.getInstance()
             try {
-                if (languageServerWrapper.isInitialized) {
-                    try {
-                        languageServerWrapper.shutdown()
-                    } catch (e: RuntimeException) {
-                        logger<SnykCliDownloaderService>()
-                            .warn("Language server shutdown for download took too long, couldn't shutdown", e)
-                    }
-                }
                 downloader.downloadFile(cliFile, latestRelease, indicator)
                 pluginSettings().cliVersion = latestRelease
                 pluginSettings().lastCheckDate = Date()

--- a/src/main/kotlin/snyk/common/lsp/LanguageServerRestartListener.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerRestartListener.kt
@@ -1,0 +1,36 @@
+package snyk.common.lsp
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.util.Disposer
+import io.snyk.plugin.events.SnykCliDownloadListener
+import io.snyk.plugin.ui.toolwindow.SnykPluginDisposable
+
+@Service(Service.Level.APP)
+class LanguageServerRestartListener : Disposable {
+    private var disposed = false
+
+    fun isDisposed() = disposed
+    override fun dispose() {
+        this.disposed = true
+    }
+
+    companion object {
+        @JvmStatic
+        fun getInstance(): LanguageServerRestartListener = service()
+    }
+
+    init {
+        Disposer.register(SnykPluginDisposable.getInstance(), this)
+        ApplicationManager.getApplication().messageBus.connect()
+            .subscribe(SnykCliDownloadListener.CLI_DOWNLOAD_TOPIC, object : SnykCliDownloadListener {
+                override fun cliDownloadFinished(succeed: Boolean) {
+                    if (succeed && !disposed) {
+                        LanguageServerWrapper.getInstance().restart()
+                    }
+                }
+            })
+    }
+}

--- a/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
+++ b/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
@@ -59,7 +59,7 @@ class SnykLanguageClient :
     Disposable {
     val logger = Logger.getInstance("Snyk Language Server")
     val gson = Gson()
-    val progressManager = ProgressManager()
+    val progressManager = ProgressManager.getInstance()
 
     private var disposed = false
         get() {

--- a/src/main/kotlin/snyk/common/lsp/progress/ProgressManager.kt
+++ b/src/main/kotlin/snyk/common/lsp/progress/ProgressManager.kt
@@ -18,6 +18,8 @@ package snyk.common.lsp.progress
 
 import com.intellij.ide.impl.ProjectUtil
 import com.intellij.openapi.Disposable
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
 import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.ProgressManager
@@ -35,7 +37,7 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 import java.util.function.Function
 
-
+@Service
 class ProgressManager : Disposable {
     private val progresses: MutableMap<String, Progress> = ConcurrentHashMap<String, Progress>()
     private var disposed = false
@@ -231,5 +233,8 @@ class ProgressManager : Disposable {
                 Function.identity()
             ) { obj: Int -> obj.toString() }
         }
+
+        @JvmStatic
+        fun getInstance(): snyk.common.lsp.progress.ProgressManager = service()
     }
 }

--- a/src/test/kotlin/snyk/common/lsp/SnykLanguageClientTest.kt
+++ b/src/test/kotlin/snyk/common/lsp/SnykLanguageClientTest.kt
@@ -27,6 +27,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Before
 import org.junit.Test
+import snyk.common.lsp.progress.ProgressManager
 import snyk.pluginInfo
 import snyk.trust.WorkspaceTrustService
 import java.nio.file.Files
@@ -54,6 +55,7 @@ class SnykLanguageClientTest {
         every { applicationMock.getService(WorkspaceTrustService::class.java) } returns trustServiceMock
 
         every { applicationMock.getService(ProjectManager::class.java) } returns projectManagerMock
+        every { applicationMock.getService(ProgressManager::class.java) } returns mockk(relaxed = true)
         every { applicationMock.isDisposed } returns false
         every { applicationMock.messageBus } returns mockk(relaxed = true)
 
@@ -84,8 +86,7 @@ class SnykLanguageClientTest {
     }
 
     @Test
-    fun applyEdit() {
-    }
+    fun applyEdit() {}
 
     @Test
     fun `refreshCodeLenses does not run when disposed`() {


### PR DESCRIPTION
### Description
- register download listener
- on successful download:

- stop all scans
- cancel all progresses
- shutdown
- sleep for a second
- restart Language Server
- connect all workspace folders to newly started LS

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
