### PR TITLE
fix: allow spaces in folder and files names [IDE-684]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - limit warn / error messages to 500 characters
 - use dumb aware to limit scans during startup
 - add no_proxy environment variable, if proxy exceptions are defined
+- be able to process findings in folder and file names that contain URL encoding
 
 ## [2.9.1]
 ### Fixed

--- a/src/main/kotlin/io/snyk/plugin/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/Utils.kt
@@ -62,6 +62,7 @@ import java.io.File
 import java.io.FileNotFoundException
 import java.net.URI
 import java.nio.file.Path
+import java.nio.file.Paths
 import java.util.Objects.nonNull
 import java.util.SortedSet
 import java.util.concurrent.TimeUnit
@@ -390,7 +391,7 @@ fun String.toVirtualFile(): VirtualFile {
     return if (!this.startsWith("file://")) {
         StandardFileSystems.local().refreshAndFindFileByPath(this) ?: throw FileNotFoundException(this)
     } else {
-        VirtualFileManager.getInstance().refreshAndFindFileByUrl(this.toVirtualFileURL())
+        VirtualFileManager.getInstance().refreshAndFindFileByNioPath(convertUriToPath(this.toVirtualFileURL()))
             ?: throw FileNotFoundException(this)
     }
 }
@@ -409,6 +410,12 @@ fun String.toVirtualFileURL(): String {
         return this.replaceFirst("/", "")
     }
     return this
+}
+
+fun convertUriToPath(encodedUri: String): Path {
+    val uri = URI(encodedUri)
+    val path = Paths.get(uri)
+    return path
 }
 
 fun String.isWindowsURI() = SystemUtils.IS_OS_WINDOWS && this.startsWith("file://")

--- a/src/main/kotlin/snyk/common/lsp/LanguageServerBulkFileListener.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerBulkFileListener.kt
@@ -123,7 +123,7 @@ class LanguageServerBulkFileListener : SnykBulkFileListener() {
 
         VirtualFileManager.getInstance().asyncRefresh()
         invokeLater {
-            if (SnykPluginDisposable.getInstance(project).isDisposed() || project.isDisposed) return@invokeLater
+            if (project.isDisposed || SnykPluginDisposable.getInstance(project).isDisposed()) return@invokeLater
             DaemonCodeAnalyzer.getInstance(project).restart()
         }
     }


### PR DESCRIPTION
### Description

Spaces in folder or file names could not be found by IntelliJ SDK, as the findbyURL method does not decode HTML encoded spaces. This PR changes this to use the findByNIOPath method to get the virtual file and converts the URI instead.

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
