### PR TITLE
fix: add iac ignore button [IDE-683]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,9 @@
 - If $/snyk.hasAuthenticated transmits an API URL, this is saved in the settings.
 - Add "plugin installed" analytics event (sent after authentication)
 - Added a description of custom endpoints to settings dialog.
-
+- Add option to ignore IaC issues
 ### Fixed
 - folder-specific configs are availabe on opening projects, not only on restart of the IDE
-
 ## [2.10.0]
 ### Changed
 - save git folder config in settings

--- a/src/main/kotlin/io/snyk/plugin/cli/ConsoleCommandRunner.kt
+++ b/src/main/kotlin/io/snyk/plugin/cli/ConsoleCommandRunner.kt
@@ -89,5 +89,6 @@ open class ConsoleCommandRunner {
 
     companion object {
         const val PROCESS_CANCELLED_BY_USER = "PROCESS_CANCELLED_BY_USER"
+        const val SAVING_POLICY_FILE = "Saving .snyk policy file...\n"
     }
 }

--- a/src/main/kotlin/io/snyk/plugin/services/CliAdapter.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/CliAdapter.kt
@@ -73,6 +73,9 @@ abstract class CliAdapter<CliIssues, R : CliResult<CliIssues>>(val project: Proj
             rawStr == ConsoleCommandRunner.PROCESS_CANCELLED_BY_USER -> {
                 getProductResult(null)
             }
+            rawStr == ConsoleCommandRunner.SAVING_POLICY_FILE -> {
+                getProductResult(null)
+            }
             rawStr.isEmpty() -> {
                 getErrorResult(CLI_PRODUCE_NO_OUTPUT)
             }

--- a/src/main/kotlin/io/snyk/plugin/ui/jcef/IgnoreInFileHandler.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/jcef/IgnoreInFileHandler.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.ui.jcef.JBCefBrowserBase
 import com.intellij.ui.jcef.JBCefJSQuery
+import io.snyk.plugin.getContentRootPaths
 import io.snyk.plugin.runInBackground
 import io.snyk.plugin.ui.SnykBalloonNotificationHelper
 import org.cef.browser.CefBrowser
@@ -33,7 +34,7 @@ class IgnoreInFileHandler(
             val issueId = params[0] // ID of issue that needs to be ignored
             val filePath = params[1]
             // Computed path that will be used in the snyk ignore command for the --path arg
-            val computedPath = filePath.removePrefix("${project.basePath}${File.separator}")
+            val computedPath = filePath.removePrefix("${project.getContentRootPaths().firstOrNull()}${File.separator}")
             // Avoid blocking the UI thread
             runInBackground("Snyk: applying ignore...") {
                 val result = try {

--- a/src/main/kotlin/io/snyk/plugin/ui/jcef/IgnoreInFileHandler.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/jcef/IgnoreInFileHandler.kt
@@ -1,0 +1,96 @@
+package io.snyk.plugin.ui.jcef
+
+import com.intellij.openapi.diagnostic.LogLevel
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
+import com.intellij.ui.jcef.JBCefBrowserBase
+import com.intellij.ui.jcef.JBCefJSQuery
+import io.snyk.plugin.runInBackground
+import io.snyk.plugin.ui.SnykBalloonNotificationHelper
+import org.cef.browser.CefBrowser
+import org.cef.browser.CefFrame
+import org.cef.handler.CefLoadHandlerAdapter
+import snyk.common.IgnoreService
+import snyk.common.lsp.LanguageServerWrapper
+import java.io.File
+import java.io.IOException
+
+class IgnoreInFileHandler(
+    private val project: Project,
+    ) {
+    val logger = Logger.getInstance(this::class.java).apply {
+        // tie log level to language server log level
+        val languageServerWrapper = LanguageServerWrapper.getInstance()
+        if (languageServerWrapper.logger.isDebugEnabled) this.setLevel(LogLevel.DEBUG)
+        if (languageServerWrapper.logger.isTraceEnabled) this.setLevel(LogLevel.TRACE)
+    }
+
+    fun generateIgnoreInFileCommand(jbCefBrowser: JBCefBrowserBase): CefLoadHandlerAdapter {
+        val applyIgnoreInFileQuery = JBCefJSQuery.create(jbCefBrowser)
+
+        applyIgnoreInFileQuery.addHandler { value ->
+            val params = value.split("|@", limit = 2)
+            val issueId = params[0] // ID of issue that needs to be ignored
+            val filePath = params[1]
+            // Computed path that will be used in the snyk ignore command for the --path arg
+            val computedPath = filePath.removePrefix("${project.basePath}${File.separator}")
+            // Avoid blocking the UI thread
+            runInBackground("Snyk: applying ignore...") {
+                val result = try {
+                    applyIgnoreInFileAndSave(issueId, computedPath)
+                } catch (e: IOException) {
+                    logger.error("Error ignoring in file: $filePath. e:$e")
+                    Result.failure(e)
+                } catch (e: Exception) {
+                    logger.error("Unexpected error applying ignore. e:$e")
+                    Result.failure(e)
+                }
+
+                if (result.isSuccess) {
+                    val script = """
+                            window.receiveIgnoreInFileResponse(true);
+                        """.trimIndent()
+                    jbCefBrowser.cefBrowser.executeJavaScript(script, jbCefBrowser.cefBrowser.url, 0)
+                } else {
+                    val errorMessage = "Error ignoring in file: ${result.exceptionOrNull()?.message}"
+                    SnykBalloonNotificationHelper.showError(errorMessage, project)
+                    val errorScript = """
+                            window.receiveIgnoreInFileResponse(false, "$errorMessage");
+                        """.trimIndent()
+                    jbCefBrowser.cefBrowser.executeJavaScript(errorScript, jbCefBrowser.cefBrowser.url, 0)
+                }
+            }
+
+            return@addHandler JBCefJSQuery.Response("success")
+        }
+
+        return object : CefLoadHandlerAdapter() {
+            override fun onLoadEnd(browser: CefBrowser, frame: CefFrame, httpStatusCode: Int) {
+                if (frame.isMain) {
+                    val script = """
+                    (function() {
+                        if (window.applyIgnoreInFileQuery) {
+                            return;
+                        }
+                        window.applyIgnoreInFileQuery = function(value) { ${applyIgnoreInFileQuery.inject("value")} };
+                    })();
+                    """.trimIndent()
+                    browser.executeJavaScript(script, browser.url, 0)
+                }
+            }
+        }
+    }
+
+    fun applyIgnoreInFileAndSave(issueId: String, filePath: String): Result<Unit> {
+        val ignoreService = IgnoreService(project);
+        if (issueId != "" && filePath != "") {
+            ignoreService.ignoreInstance(issueId, filePath)
+        } else {
+            logger.error("[applyIgnoreInFileAndSave] Failed to find document for: $filePath")
+            val errorMessage = "Failed to find document for: $filePath"
+            SnykBalloonNotificationHelper.showError(errorMessage, project)
+            return Result.failure(IOException(errorMessage))
+        }
+        return Result.success(Unit)
+    }
+}

--- a/src/main/kotlin/io/snyk/plugin/ui/jcef/IgnoreInFileHandler.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/jcef/IgnoreInFileHandler.kt
@@ -13,8 +13,9 @@ import org.cef.browser.CefFrame
 import org.cef.handler.CefLoadHandlerAdapter
 import snyk.common.IgnoreService
 import snyk.common.lsp.LanguageServerWrapper
-import java.io.File
 import java.io.IOException
+import kotlin.io.path.Path
+import kotlin.io.path.relativeTo
 
 class IgnoreInFileHandler(
     private val project: Project,
@@ -34,7 +35,7 @@ class IgnoreInFileHandler(
             val issueId = params[0] // ID of issue that needs to be ignored
             val filePath = params[1]
             // Computed path that will be used in the snyk ignore command for the --path arg
-            val computedPath = filePath.removePrefix("${project.getContentRootPaths().firstOrNull()}${File.separator}")
+            val computedPath = Path(filePath).relativeTo(project.getContentRootPaths().firstOrNull()!!).toString();
             // Avoid blocking the UI thread
             runInBackground("Snyk: applying ignore...") {
                 val result = try {
@@ -83,7 +84,7 @@ class IgnoreInFileHandler(
     }
 
     fun applyIgnoreInFileAndSave(issueId: String, filePath: String): Result<Unit> {
-        val ignoreService = IgnoreService(project);
+        val ignoreService = IgnoreService(project)
         if (issueId != "" && filePath != "") {
             ignoreService.ignoreInstance(issueId, filePath)
         } else {

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/JCEFDescriptionPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/JCEFDescriptionPanel.kt
@@ -384,6 +384,8 @@ class SuggestionDescriptionPanelFromLS(
 
               const diffNumElem = document.getElementById("diff-number");
               const diffNum2Elem = document.getElementById("diff-number2");
+              const ignoreContainer = document.getElementById("ignore-container");
+
 
               let diffSelectedIndex = 0;
               let fixes = [];
@@ -394,6 +396,8 @@ class SuggestionDescriptionPanelFromLS(
 
               nextDiffElem?.addEventListener("click", nextDiff);
               previousDiffElem?.addEventListener("click", previousDiff);
+
+              toggleElement(ignoreContainer, "show");
 
               // This function will be called once the response is received from the Language Server
               window.receiveAIFixResponse = function (fixesResponse) {

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/JCEFDescriptionPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/JCEFDescriptionPanel.kt
@@ -183,7 +183,7 @@ class SuggestionDescriptionPanelFromLS(
 
         html = html.replace("\${ideStyle}", "<style nonce=\${nonce}>$ideStyle</style>")
         html = html.replace("\${headerEnd}", "")
-        html = html.replace("\${ideScript}", "<script nonce=\${nonce}>$ideScript</script>")
+        html = html.replace("\${ideScript}", ideScript)
 
 
         html = html.replace("\${nonce}", nonce)
@@ -233,7 +233,6 @@ class SuggestionDescriptionPanelFromLS(
 
     private fun getCustomScript(): String {
         return """
-            (function () {
               // Utility function to show/hide an element based on a toggle value
               function toggleElement(element, action) {
                 if (!element) return;
@@ -365,20 +364,10 @@ class SuggestionDescriptionPanelFromLS(
                  console.log('Applying fix', patch);
               }
 
-              function applyIgnoreInFile() {
-                console.log('Applying ignore', issue);
-                if (!issue) return;
-
-                window.applyIgnoreInFileQuery(issue + '|@' + filePath + ' > ' + resourcePath);
-                toggleElement(ignoreInFileBtn, "hide");
-                console.log('Applying ignore');
-              }
 
               // DOM element references
               const generateAiFixBtn = document.getElementById("generate-ai-fix");
               const applyFixBtn = document.getElementById('apply-fix')
-              const ignoreContainer = document.getElementById("ignore-container");
-              const ignoreInFileBtn = document.getElementById('ignore-file-issue')
               const retryGenerateFixBtn = document.getElementById('retry-generate-fix')
 
               const fixLoadingIndicatorElem = document.getElementById("fix-loading-indicator");
@@ -398,19 +387,14 @@ class SuggestionDescriptionPanelFromLS(
 
               let diffSelectedIndex = 0;
               let fixes = [];
-              let issue = ignoreInFileBtn.getAttribute('issue')
-              let resourcePath =  ignoreInFileBtn.getAttribute('resourcePath')
-              let filePath =  ignoreInFileBtn.getAttribute('filePath')
               // Event listener for Generate AI fix button
               generateAiFixBtn?.addEventListener("click", generateAIFix);
               applyFixBtn?.addEventListener('click', applyFix);
               retryGenerateFixBtn?.addEventListener('click', reGenerateAIFix);
 
-              ignoreInFileBtn?.addEventListener("click", applyIgnoreInFile);
               nextDiffElem?.addEventListener("click", nextDiff);
               previousDiffElem?.addEventListener("click", previousDiff);
 
-              toggleElement(ignoreContainer, "show");
               // This function will be called once the response is received from the Language Server
               window.receiveAIFixResponse = function (fixesResponse) {
                 fixes = [...fixesResponse];
@@ -421,17 +405,6 @@ class SuggestionDescriptionPanelFromLS(
                 showAIFixes(fixes);
               };
 
-              window.receiveIgnoreInFileResponse = function (success){
-                console.log('[[receiveIgnoreInFileResponse]]', success);
-                if(success){
-                    ignoreInFileBtn.disabled = true;
-                    console.log('Ignored in file', success);
-                    document.getElementById('ignore-file-issue').disabled = true;
-                }else{
-                    toggleElement(ignoreInFileBtn, "show");
-                    console.error('Failed to apply fix', success);
-                }
-              }
               window.receiveApplyFixResponse = function (success) {
               console.log('[[receiveApplyFixResponse]]', success);
                 if (success) {
@@ -442,7 +415,6 @@ class SuggestionDescriptionPanelFromLS(
                     console.error('Failed to apply fix', success);
                 }
               };
-            })();
         """.trimIndent()
     }
 }

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/JCEFDescriptionPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/JCEFDescriptionPanel.kt
@@ -175,10 +175,10 @@ class SuggestionDescriptionPanelFromLS(
 
         val editorColorsManager = EditorColorsManager.getInstance()
         val editorUiTheme = editorColorsManager.schemeForCurrentUITheme
-        val lsNonce = extractLsNonceIfPresent(html);
+        val lsNonce = extractLsNonceIfPresent(html)
         var nonce = getNonce()
         if (lsNonce != "") {
-            nonce = lsNonce;
+            nonce = lsNonce
         }
 
         html = html.replace("\${ideStyle}", "<style nonce=\${nonce}>$ideStyle</style>")
@@ -216,13 +216,13 @@ class SuggestionDescriptionPanelFromLS(
     private fun extractLsNonceIfPresent(html: String): String{
         // When the nonce is injected by the IDE, it is of format nonce-${nonce}
         if (!html.contains("\${nonce}") && html.contains("nonce-")){
-            val nonceStartPosition = html.indexOf("nonce-");
+            val nonceStartPosition = html.indexOf("nonce-")
             // Length of LS nonce
-            val startIndex = nonceStartPosition + "nonce-".length;
-            val endIndex = startIndex + 24;
-            return html.substring(startIndex, endIndex ).trim();
+            val startIndex = nonceStartPosition + "nonce-".length
+            val endIndex = startIndex + 24
+            return html.substring(startIndex, endIndex ).trim()
         }
-        return "";
+        return ""
     }
     private fun getNonce(): String {
         val allowedChars = ('A'..'Z') + ('a'..'z') + ('0'..'9')
@@ -369,7 +369,7 @@ class SuggestionDescriptionPanelFromLS(
                 console.log('Applying ignore', issue);
                 if (!issue) return;
 
-                window.applyIgnoreInFileQuery(issue + '|@' + filePath + ' > ' + path);
+                window.applyIgnoreInFileQuery(issue + '|@' + filePath + ' > ' + resourcePath);
                 toggleElement(ignoreInFileBtn, "hide");
                 console.log('Applying ignore');
               }
@@ -399,7 +399,7 @@ class SuggestionDescriptionPanelFromLS(
               let diffSelectedIndex = 0;
               let fixes = [];
               let issue = ignoreInFileBtn.getAttribute('issue')
-              let path =  ignoreInFileBtn.getAttribute('path')
+              let resourcePath =  ignoreInFileBtn.getAttribute('resourcePath')
               let filePath =  ignoreInFileBtn.getAttribute('filePath')
               // Event listener for Generate AI fix button
               generateAiFixBtn?.addEventListener("click", generateAIFix);

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/JCEFDescriptionPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/JCEFDescriptionPanel.kt
@@ -183,7 +183,7 @@ class SuggestionDescriptionPanelFromLS(
 
         html = html.replace("\${ideStyle}", "<style nonce=\${nonce}>$ideStyle</style>")
         html = html.replace("\${headerEnd}", "")
-        html = html.replace("\${ideScript}", ideScript)
+        html = html.replace("\${ideScript}", "<script nonce=\${nonce}>$ideScript</script>")
 
 
         html = html.replace("\${nonce}", nonce)

--- a/src/test/kotlin/io/snyk/plugin/ui/jcef/IgnoreInFileHandlerTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/jcef/IgnoreInFileHandlerTest.kt
@@ -1,0 +1,59 @@
+package io.snyk.plugin.ui.jcef
+
+import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiFile
+import com.intellij.testFramework.PlatformTestUtil
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import io.mockk.verify
+import io.snyk.plugin.resetSettings
+import org.eclipse.lsp4j.ExecuteCommandParams
+import org.eclipse.lsp4j.services.LanguageServer
+import snyk.common.IgnoreService
+import snyk.common.annotator.SnykCodeAnnotator
+import snyk.common.annotator.SnykIaCAnnotator
+import snyk.common.lsp.LanguageServerWrapper
+import snyk.common.lsp.commands.COMMAND_EXECUTE_CLI
+import java.io.File
+import java.nio.file.Paths
+import java.util.concurrent.CompletableFuture
+import java.util.function.BooleanSupplier
+
+class IgnoreInFileHandlerTest : BasePlatformTestCase() {
+    private lateinit var ignorer: IgnoreInFileHandler
+    private val fileName = "fargate.json"
+    val lsMock = mockk<LanguageServer>()
+
+    override fun getTestDataPath(): String {
+        val resource = SnykIaCAnnotator::class.java.getResource("/iac-test-results")
+        requireNotNull(resource) { "Make sure that the resource $resource exists!" }
+        return Paths.get(resource.toURI()).toString()
+    }
+
+    override fun setUp() {
+        super.setUp()
+        unmockkAll()
+        resetSettings(project)
+        val languageServerWrapper = LanguageServerWrapper.getInstance()
+        languageServerWrapper.languageServer = lsMock
+        languageServerWrapper.isInitialized = true
+        ignorer = IgnoreInFileHandler(project)
+    }
+
+    fun `test issue should be ignored in file`() {
+        every { lsMock.workspaceService.executeCommand(any()) } returns CompletableFuture.completedFuture(null)
+        val filePath = this.getTestDataPath()+ File.separator + fileName;
+        ignorer.applyIgnoreInFileAndSave("SNYK-CC-TF-61", filePath )
+        val projectBasePath = project.basePath ?: "";
+
+        // Expected args for executeCommandParams
+        val args: List<String> = arrayListOf(projectBasePath, "ignore", "--id=SNYK-CC-TF-61", "--path=${filePath}")
+
+        val executeCommandParams = ExecuteCommandParams (COMMAND_EXECUTE_CLI, args);
+        verify { lsMock.workspaceService.executeCommand(executeCommandParams) }
+    }
+}


### PR DESCRIPTION
### Description

This provides the logic to ignore an IaC finding for a specific file in the IntelliJ plugin, the ignore button is implicitly hidden and set to show in IntelliJ only.

The **HTML** panel that comes from the **Language Server** receives dynamic attributes with injected values such as the `path` and `Issue.ID`, these are extracted in a custom JS script and called through a callback when clicking **ignore button** , this triggers the `IgnoreHandler` .
In the `IgnoreHandler` the `IgnoreService` is called which calls calls the **CLI** through the **LS Wrapper** to execute the `snyk ignore` command on the specified params.

This path and issue id comes injected in the HTML template which comes from Snyk LS.
### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
