### PR TITLE
fix: send config before adding a workspace folder [IDE-668]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Add "plugin installed" analytics event (sent after authentication)
 - Added a description of custom endpoints to settings dialog.
 
+### Fixed
+- folder-specific configs are availabe on opening projects, not only on restart of the IDE
+
 ## [2.10.0]
 ### Changed
 - save git folder config in settings

--- a/src/main/kotlin/io/snyk/plugin/ui/SnykSettingsDialog.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/SnykSettingsDialog.kt
@@ -631,8 +631,7 @@ class SnykSettingsDialog(
 
         val netNewIssuesText =
             JLabel(
-                "Specifies whether to see only net new issues or all issues. " +
-                    "Only applies to Code Security and Code Quality."
+                "Specifies whether to see only net new issues or all issues. This setting does not apply for Snyk Container."
             ).apply { font = FontUtil.minusOne(this.font) }
 
         netNewIssuesPanel.add(

--- a/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
@@ -576,6 +576,7 @@ class LanguageServerWrapper(
         if (disposed || project.isDisposed) return
         ensureLanguageServerInitialized()
         ensureLanguageServerProtocolVersion(project)
+        updateConfiguration()
         val added = getWorkspaceFolders(project)
         updateWorkspaceFolders(added, emptySet())
     }


### PR DESCRIPTION
### Description

This sends the current configuration, including folder & project specific configs to language server before adding a project/folder to the configuration. That way, this config is considered in scans.

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
