### PR TITLE
fix: whitelist project.assets.json in obj directory for oss scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add option to ignore IaC issues
 ### Fixed
 - folder-specific configs are availabe on opening projects, not only on restart of the IDE
+- display open source issues in Rider. Previously, as the project.assets.json is in a derived folder, it was filtered.
 ## [2.10.0]
 ### Changed
 - save git folder config in settings

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,6 +44,9 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-databind:2.15.0")
     implementation("org.json:json:20231013")
     implementation("org.slf4j:slf4j-api:2.0.5")
+    implementation("org.apache.commons:commons-text:1.12.0")
+    implementation("org.apache.commons:commons-lang3:3.17.0")
+
     implementation("ly.iterative.itly:plugin-iteratively:1.2.11") {
         exclude(group = "com.fasterxml.jackson.core")
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ platformDownloadSources=true
 # plugin dependencies (comma-separated)
 # example: platformPlugins = com.intellij.java, org.jetbrains.plugins.yaml
 # see https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
-platformPlugins=org.intellij.plugins.hcl:233.11799.172,org.jetbrains.plugins.yaml,org.jetbrains.kotlin,com.intellij.java,org.intellij.groovy
+platformPlugins=org.jetbrains.plugins.yaml
 # list of versions for which to check the plugin for api compatibility
 pluginVerifierIdeVersions=2023.3,2024.1,2024.2
 localIdeDirectory=

--- a/src/main/kotlin/io/snyk/plugin/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/Utils.kt
@@ -455,11 +455,18 @@ fun VirtualFile.isInContent(project: Project): Boolean {
     val vf = this
     return ReadAction.compute<Boolean, RuntimeException> {
         if (project.isDisposed) return@compute false
-        ProjectFileIndex.getInstance(project).isInContent(vf)
+        ProjectFileIndex.getInstance(project).isInContent(vf) || isWhitelistedForInclusion()
     }
 }
 
-inline fun runInBackground(title: String, project: Project? = null, cancellable: Boolean = true, crossinline task: (indicator: ProgressIndicator) -> Unit) {
+fun VirtualFile.isWhitelistedForInclusion() = this.name == "project.assets.json" && this.parent.name == "obj"
+
+inline fun runInBackground(
+    title: String,
+    project: Project? = null,
+    cancellable: Boolean = true,
+    crossinline task: (indicator: ProgressIndicator) -> Unit
+) {
     ProgressManager.getInstance().run(object : Task.Backgroundable(project, title, cancellable) {
         override fun run(indicator: ProgressIndicator) {
             task(indicator)

--- a/src/main/kotlin/snyk/common/lsp/LanguageServerBulkFileListener.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerBulkFileListener.kt
@@ -10,9 +10,11 @@ import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.openapi.vfs.readText
+import com.intellij.util.TestRuntimeUtil
 import io.snyk.plugin.SnykBulkFileListener
 import io.snyk.plugin.SnykFile
 import io.snyk.plugin.getSnykCachedResults
+import io.snyk.plugin.isInContent
 import io.snyk.plugin.toLanguageServerURL
 import io.snyk.plugin.toSnykFileSet
 import io.snyk.plugin.ui.toolwindow.SnykPluginDisposable
@@ -20,13 +22,12 @@ import org.eclipse.lsp4j.DidSaveTextDocumentParams
 import org.eclipse.lsp4j.TextDocumentIdentifier
 import org.jetbrains.annotations.TestOnly
 import org.jetbrains.concurrency.runAsync
-import org.jetbrains.kotlin.idea.util.application.isUnitTestMode
 import java.io.File
 import java.time.Duration
 
 class LanguageServerBulkFileListener : SnykBulkFileListener() {
     @TestOnly
-    var disabled = isUnitTestMode()
+    var disabled = TestRuntimeUtil.isRunningUnderUnitTest
 
     override fun before(
         project: Project,
@@ -90,7 +91,7 @@ class LanguageServerBulkFileListener : SnykBulkFileListener() {
                 shouldProcess = false
             } else {
                 debounceFileCache.put(file.path, true)
-                if (index.isInContent(file) && !isInBlacklistedParentDir(file)) {
+                if (file.isInContent(project) && !isInBlacklistedParentDir(file)) {
                     shouldProcess = true
                 } else {
                     shouldProcess = false


### PR DESCRIPTION
### Description

Fixes dotnet scanning in Rider, when obj directory is excluded from source.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
