### PR TITLE
fix: update root node branch name on changing base branch [IDE-841]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 - folder-specific configs are availabe on opening projects, not only on restart of the IDE
 - display open source issues in Rider. Previously, as the project.assets.json is in a derived folder, it was filtered.
+- correctly display and update base branch name for Net New Issues
 ## [2.10.0]
 ### Changed
 - save git folder config in settings

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
@@ -552,8 +552,21 @@ class SnykToolWindowPanel(
 
         val newContainerTreeNodeText = getNewContainerTreeNodeText(settings, containerResultsCount, addHMLPostfix)
         newContainerTreeNodeText?.let { rootContainerIssuesTreeNode.userObject = it }
+
+        val newRootTreeNodeText = getNewRootTreeNodeText()
+        newRootTreeNodeText.let { rootTreeNode.info = it }
     }
 
+    private fun getNewRootTreeNodeText() : String {
+        val folderConfig = service<FolderConfigSettings>().getFolderConfig(project.basePath.toString())
+            if (folderConfig?.let {
+                getRootNodeText(
+                    it.folderPath,
+                    it.baseBranch
+                )
+            } != null)  return folderConfig.let { getRootNodeText(it.folderPath, it.baseBranch) }
+            return "Choose branch on ${project.basePath}"
+    }
     private fun getNewContainerTreeNodeText(
         settings: SnykApplicationSettingsStateService,
         containerResultsCount: Int?,


### PR DESCRIPTION
### Description

Root Node base branch text was only initialized never updated, this PR updates it whenever the other RootTreeNodes update.
Note: The state is and was already saved as intended in the folder config.
### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
