### PR TITLE
chore: update IntelliJ plugin to support 2025.1, fix workspaceFolder config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Snyk Security Changelog
 
+## [2.12.0]
+### Changed
+- support 2025.1
+
 ## [2.11.0]
 ### Changed
 - If $/snyk.hasAuthenticated transmits an API URL, this is saved in the settings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Snyk Security Changelog
 
-## [2.12.0]
+## [2.11.1]
 ### Changed
 - support 2025.1
+
+### Fixed
+- workspace folder configuration on language server (re-)start
 
 ## [2.11.0]
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginName=Snyk Security
 # for insight into build numbers and IntelliJ Platform versions
 # see https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild=233
-pluginUntilBuild=243.*
+pluginUntilBuild=
 platformVersion=2023.3
 platformDownloadSources=true
 
@@ -13,7 +13,7 @@ platformDownloadSources=true
 # see https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 platformPlugins=org.jetbrains.plugins.yaml
 # list of versions for which to check the plugin for api compatibility
-pluginVerifierIdeVersions=2023.3,2024.1,2024.2
+pluginVerifierIdeVersions=2023.3,2024.1,2024.2,2024.3,2025.1
 localIdeDirectory=
 # opt-out flag for bundling Kotlin standard library
 # see https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library

--- a/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
@@ -68,7 +68,6 @@ import snyk.pluginInfo
 import snyk.trust.WorkspaceTrustService
 import snyk.trust.confirmScanningAndSetWorkspaceTrustedStateIfNeeded
 import java.io.FileNotFoundException
-import java.net.URI
 import java.nio.file.Paths
 import java.util.Collections
 import java.util.concurrent.ExecutorService
@@ -185,6 +184,7 @@ class LanguageServerWrapper(
             }
 
             if (!(listenerFuture.isDone || listenerFuture.isCancelled)) {
+                configuredWorkspaceFolders.clear()
                 sendInitializeMessage()
                 isInitialized = true
                 // listen for downloads / restarts
@@ -233,6 +233,7 @@ class LanguageServerWrapper(
             }
             lsp4jLogger.level = previousLSP4jLogLevel
             messageProducerLogger.level = previousMessageProducerLevel
+            configuredWorkspaceFolders.clear()
         }
     }
 


### PR DESCRIPTION
### Description

- Updates the `until` build property to unlimited, supporting by default new plugins.
- Fixes a bug with workspaceFolder config on shutdown/initialize

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
