### PR TITLE
feat: add reference folder to branch chooser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [2.11.1]
 ### Changed
-- support 2025.1
+- support 2025.1.
+- allow to select a reference folder instead of a branch for delta scanning and display of only net-new issues.
 
 ### Fixed
 - workspace folder configuration on language server (re-)start

--- a/src/main/kotlin/io/snyk/plugin/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/Utils.kt
@@ -65,6 +65,7 @@ import java.net.URI
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.security.MessageDigest
 import java.util.Objects.nonNull
 import java.util.SortedSet
 import java.util.concurrent.TimeUnit
@@ -464,6 +465,13 @@ fun VirtualFile.isInContent(project: Project): Boolean {
 fun VirtualFile.isExecutable(): Boolean = this.toNioPathOrNull()?.let { Files.isExecutable(it) } == true
 
 fun VirtualFile.isWhitelistedForInclusion() = this.name == "project.assets.json" && this.parent.name == "obj"
+
+fun String.sha256(): String {
+    val bytes = this.toByteArray()
+    val md = MessageDigest.getInstance("SHA-256")
+    val digest = md.digest(bytes)
+    return digest.fold("") { str, it -> str + "%02x".format(it) }
+}
 
 inline fun runInBackground(
     title: String,

--- a/src/main/kotlin/io/snyk/plugin/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/Utils.kt
@@ -29,6 +29,7 @@ import com.intellij.openapi.util.registry.Registry
 import com.intellij.openapi.vfs.StandardFileSystems
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.openapi.vfs.toNioPathOrNull
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.psi.PsiFile
@@ -61,6 +62,7 @@ import snyk.iac.IacScanService
 import java.io.File
 import java.io.FileNotFoundException
 import java.net.URI
+import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.Objects.nonNull
@@ -458,6 +460,8 @@ fun VirtualFile.isInContent(project: Project): Boolean {
         ProjectFileIndex.getInstance(project).isInContent(vf) || isWhitelistedForInclusion()
     }
 }
+
+fun VirtualFile.isExecutable(): Boolean = this.toNioPathOrNull()?.let { Files.isExecutable(it) } == true
 
 fun VirtualFile.isWhitelistedForInclusion() = this.name == "project.assets.json" && this.parent.name == "obj"
 

--- a/src/main/kotlin/io/snyk/plugin/ui/BranchChooserComboboxDialog.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/BranchChooserComboboxDialog.kt
@@ -94,11 +94,13 @@ class BranchChooserComboBoxDialog(val project: Project) : DialogWrapper(true) {
         baseBranches.forEach {
             val folderConfig: FolderConfig = it.key
 
-            val baseBranch = getSelectedItem(it.value)
-            if (!baseBranch.isNullOrBlank()) {
+            val baseBranch = getSelectedItem(it.value) ?: ""
+            val referenceFolder = referenceFolders[folderConfig]!!.text
+            if (baseBranch.isNotBlank()) {
                 folderConfigSettings.addFolderConfig(folderConfig.copy(baseBranch = baseBranch))
-            } else {
-                folderConfigSettings.addFolderConfig(folderConfig.copy(referenceFolderPath = referenceFolders[folderConfig]!!.text))
+            }
+            if (referenceFolder.isNotBlank()){
+                folderConfigSettings.addFolderConfig(folderConfig.copy(referenceFolderPath = referenceFolder))
             }
         }
         runInBackground("Snyk: updating configuration") {

--- a/src/main/kotlin/io/snyk/plugin/ui/BranchChooserComboboxDialog.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/BranchChooserComboboxDialog.kt
@@ -33,7 +33,7 @@ class BranchChooserComboBoxDialog(val project: Project) : DialogWrapper(true) {
     override fun createCenterPanel(): JComponent {
         val folderConfigs = service<FolderConfigSettings>().getAllForProject(project)
         folderConfigs.forEach { folderConfig ->
-            val comboBox = ComboBox(folderConfig.localBranches.sorted().toTypedArray())
+            val comboBox = ComboBox(folderConfig.localBranches?.sorted()?.toTypedArray()?: emptyArray())
             comboBox.selectedItem = folderConfig.baseBranch
             comboBox.name = folderConfig.folderPath
             baseBranches[folderConfig] = comboBox

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
@@ -47,7 +47,7 @@ import io.snyk.plugin.refreshAnnotationsForOpenFiles
 import io.snyk.plugin.services.SnykApplicationSettingsStateService
 import io.snyk.plugin.snykToolWindow
 import io.snyk.plugin.toVirtualFile
-import io.snyk.plugin.ui.BranchChooserComboBoxDialog
+import io.snyk.plugin.ui.ReferenceChooserDialog
 import io.snyk.plugin.ui.SnykBalloonNotificationHelper
 import io.snyk.plugin.ui.expandTreeNodeRecursively
 import io.snyk.plugin.ui.toolwindow.nodes.DescriptionHolderTreeNode
@@ -374,7 +374,7 @@ class SnykToolWindowPanel(
 
             if (lastPathComponent is ChooseBranchNode && capturedNavigateToSourceEnabled && !capturedSmartReloadMode) {
                 invokeLater {
-                    BranchChooserComboBoxDialog(project).show()
+                    ReferenceChooserDialog(project).show()
                 }
             }
 

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
@@ -46,6 +46,7 @@ import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.refreshAnnotationsForOpenFiles
 import io.snyk.plugin.services.SnykApplicationSettingsStateService
 import io.snyk.plugin.snykToolWindow
+import io.snyk.plugin.toVirtualFile
 import io.snyk.plugin.ui.BranchChooserComboBoxDialog
 import io.snyk.plugin.ui.SnykBalloonNotificationHelper
 import io.snyk.plugin.ui.expandTreeNodeRecursively
@@ -73,6 +74,7 @@ import org.jetbrains.annotations.TestOnly
 import org.jetbrains.concurrency.runAsync
 import snyk.common.ProductType
 import snyk.common.SnykError
+import snyk.common.lsp.FolderConfig
 import snyk.common.lsp.LanguageServerWrapper
 import snyk.common.lsp.ScanIssue
 import snyk.common.lsp.SnykScanParams
@@ -120,9 +122,16 @@ class SnykToolWindowPanel(
         }
     }
 
-    private fun getRootNodeText(folderPath: String, baseBranch: String) =
-        "Click to choose base branch for $folderPath [ current: $baseBranch ]"
-
+    private fun getRootNodeText(folderConfig: FolderConfig): String {
+        val detail = if (folderConfig.referenceFolderPath.isNullOrBlank()) {
+            folderConfig.baseBranch
+        } else {
+            folderConfig.referenceFolderPath
+        }
+        return "Click to choose base branch or reference folder for ${
+            folderConfig.folderPath.toVirtualFile().toNioPath().fileName
+        }: [ current: $detail ]"
+    }
 
     /** Flag used to recognize not-user-initiated Description panel reload cases for purposes like:
      *  - disable Itly logging
@@ -140,7 +149,7 @@ class SnykToolWindowPanel(
 
     init {
         val folderConfig = service<FolderConfigSettings>().getFolderConfig(project.basePath.toString())
-        val rootNodeText = folderConfig?.let { getRootNodeText(it.folderPath, it.baseBranch) }
+        val rootNodeText = folderConfig?.let { getRootNodeText(it) }
             ?: "Choose branch on ${project.basePath}"
         rootTreeNode.info = rootNodeText
 
@@ -476,7 +485,7 @@ class SnykToolWindowPanel(
             ),
     ) {
         rootNodesToUpdate.forEach {
-            if (it.childCount>0) it.removeAllChildren()
+            if (it.childCount > 0) it.removeAllChildren()
             (vulnerabilitiesTree.model as DefaultTreeModel).reload(it)
         }
     }
@@ -491,7 +500,12 @@ class SnykToolWindowPanel(
                     enableCodeScanAccordingToServerSetting()
                     displayEmptyDescription()
                 } catch (e: Exception) {
-                    displaySnykError(SnykError(e.message ?: "Exception while initializing plugin {${e.message}", ""))
+                    displaySnykError(
+                        SnykError(
+                            e.message ?: "Exception while initializing plugin {${e.message}",
+                            ""
+                        )
+                    )
                     logger.error("Failed to apply Snyk settings", e)
                 }
             }
@@ -589,7 +603,8 @@ class SnykToolWindowPanel(
         val newOssTreeNodeText = getNewOssTreeNodeText(settings, realError, ossResultsCount, addHMLPostfix)
         newOssTreeNodeText?.let { rootOssTreeNode.userObject = it }
 
-        val newSecurityIssuesNodeText = getNewSecurityIssuesNodeText(settings, securityIssuesCount, addHMLPostfix)
+        val newSecurityIssuesNodeText =
+            getNewSecurityIssuesNodeText(settings, securityIssuesCount, addHMLPostfix)
         newSecurityIssuesNodeText?.let { rootSecurityIssuesTreeNode.userObject = it }
 
         val newQualityIssuesNodeText = getNewQualityIssuesNodeText(settings, qualityIssuesCount, addHMLPostfix)
@@ -598,23 +613,20 @@ class SnykToolWindowPanel(
         val newIacTreeNodeText = getNewIacTreeNodeText(settings, iacResultsCount, addHMLPostfix)
         newIacTreeNodeText?.let { rootIacIssuesTreeNode.userObject = it }
 
-        val newContainerTreeNodeText = getNewContainerTreeNodeText(settings, containerResultsCount, addHMLPostfix)
+        val newContainerTreeNodeText =
+            getNewContainerTreeNodeText(settings, containerResultsCount, addHMLPostfix)
         newContainerTreeNodeText?.let { rootContainerIssuesTreeNode.userObject = it }
 
         val newRootTreeNodeText = getNewRootTreeNodeText()
         newRootTreeNodeText.let { rootTreeNode.info = it }
     }
 
-    private fun getNewRootTreeNodeText() : String {
+    private fun getNewRootTreeNodeText(): String {
         val folderConfig = service<FolderConfigSettings>().getFolderConfig(project.basePath.toString())
-            if (folderConfig?.let {
-                getRootNodeText(
-                    it.folderPath,
-                    it.baseBranch
-                )
-            } != null)  return folderConfig.let { getRootNodeText(it.folderPath, it.baseBranch) }
-            return "Choose branch on ${project.basePath}"
+        if (folderConfig?.let { getRootNodeText(it) } != null) return getRootNodeText(folderConfig)
+        return "Choose branch on ${project.basePath}"
     }
+
     private fun getNewContainerTreeNodeText(
         settings: SnykApplicationSettingsStateService,
         containerResultsCount: Int?,
@@ -783,7 +795,8 @@ class SnykToolWindowPanel(
 
     fun displayContainerResults(containerResult: ContainerResult) {
         val userObjectsForExpandedChildren = userObjectsForExpandedNodes(rootContainerIssuesTreeNode)
-        val selectedNodeUserObject = TreeUtil.findObjectInPath(vulnerabilitiesTree.selectionPath, Any::class.java)
+        val selectedNodeUserObject =
+            TreeUtil.findObjectInPath(vulnerabilitiesTree.selectionPath, Any::class.java)
 
         rootContainerIssuesTreeNode.removeAllChildren()
 

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLS.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLS.kt
@@ -126,7 +126,7 @@ class SnykToolWindowSnykScanListenerLS(
 
             PRODUCT_IAC -> {
                 this.rootIacIssuesTreeNode.removeAllChildren()
-                this.rootOssIssuesTreeNode.userObject = "$IAC_ROOT_TEXT (error)"
+                this.rootIacIssuesTreeNode.userObject = "$IAC_ROOT_TEXT (error)"
             }
 
             PRODUCT_CONTAINER -> {

--- a/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
+++ b/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
@@ -29,6 +29,7 @@ import io.snyk.plugin.getContentRootVirtualFiles
 import io.snyk.plugin.getSyncPublisher
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.refreshAnnotationsForOpenFiles
+import io.snyk.plugin.sha256
 import io.snyk.plugin.toVirtualFile
 import io.snyk.plugin.ui.SnykBalloonNotificationHelper
 import io.snyk.plugin.ui.toolwindow.SnykPluginDisposable
@@ -282,7 +283,7 @@ class SnykLanguageClient :
     @JsonNotification(value = "$/snyk.hasAuthenticated")
     fun hasAuthenticated(param: HasAuthenticatedParam) {
         if (disposed) return
-        val oldToken = pluginSettings().token
+        val oldToken = pluginSettings().token ?: ""
         val oldApiUrl = pluginSettings().customEndpointUrl
         if (oldToken == param.token && oldApiUrl == param.apiUrl) return
 
@@ -293,7 +294,7 @@ class SnykLanguageClient :
         logger.info("received authentication information: Token-Length: ${param.token?.length}}, URL: ${param.apiUrl}")
         logger.info("use token-auth? ${pluginSettings().useTokenAuthentication}")
         logger.debug("is same token?  ${oldToken == param.token}")
-        logger.debug("old-token-hash: ${oldToken.hashCode()}, new-token-hash: ${param.token.hashCode()}" )
+        logger.debug("old-token-hash: ${oldToken.sha256()}, new-token-hash: ${param.token?.sha256()}" )
 
         pluginSettings().token = param.token
 
@@ -302,7 +303,7 @@ class SnykLanguageClient :
         StoreUtil.saveSettings(ApplicationManager.getApplication(), true)
         logger.info("force-saved settings")
 
-        if (oldToken.isNullOrBlank() && !param.token.isNullOrBlank() && pluginSettings().scanOnSave) {
+        if (oldToken.isBlank() && !param.token.isNullOrBlank() && pluginSettings().scanOnSave) {
             val wrapper = LanguageServerWrapper.getInstance()
             ProjectManager.getInstance().openProjects.forEach {
                 wrapper.sendScanCommand(it)

--- a/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
+++ b/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
@@ -293,6 +293,7 @@ class SnykLanguageClient :
         logger.info("received authentication information: Token-Length: ${param.token?.length}}, URL: ${param.apiUrl}")
         logger.info("use token-auth? ${pluginSettings().useTokenAuthentication}")
         logger.debug("is same token?  ${oldToken == param.token}")
+        logger.debug("old-token-hash: ${oldToken.hashCode()}, new-token-hash: ${param.token.hashCode()}" )
 
         pluginSettings().token = param.token
 

--- a/src/main/kotlin/snyk/common/lsp/Types.kt
+++ b/src/main/kotlin/snyk/common/lsp/Types.kt
@@ -537,8 +537,8 @@ data class FolderConfigsParam(
 data class FolderConfig(
     @SerializedName("folderPath") val folderPath: String,
     @SerializedName("baseBranch") val baseBranch: String,
-    @SerializedName("localBranches") val localBranches: List<String> = emptyList(),
-    @SerializedName("additionalParameters") val additionalParameters: List<String> = emptyList(),
+    @SerializedName("localBranches") val localBranches: List<String>? = emptyList(),
+    @SerializedName("additionalParameters") val additionalParameters: List<String>? = emptyList(),
     @SerializedName("referenceFolderPath") val referenceFolderPath: String? = null,
     @SerializedName("scanCommandConfig") val scanCommandConfig: ScanCommandConfig? = null,
 )

--- a/src/main/kotlin/snyk/common/lsp/Types.kt
+++ b/src/main/kotlin/snyk/common/lsp/Types.kt
@@ -524,9 +524,28 @@ data class FolderConfigsParam(
     @SerializedName("folderConfigs") val folderConfigs: List<FolderConfig>?,
 )
 
+/**
+ * FolderConfig stores the configuration for a workspace folder
+ *
+ * @param folderPath the path of the folder
+ * @param baseBranch the base branch to compare against (if git repository)
+ * @param localBranches the local branches in the git repository
+ * @param additionalParameters additional parameters to pass to the scan command
+ * @param referenceFolderPath the reference folder to scan, if not a git repository
+ * @param scanCommandConfig the scan command configuration to specify a command to be executed before and/or after the scan
+ */
 data class FolderConfig(
     @SerializedName("folderPath") val folderPath: String,
     @SerializedName("baseBranch") val baseBranch: String,
     @SerializedName("localBranches") val localBranches: List<String> = emptyList(),
-    @SerializedName("additionalParameters") val additionalParameters: List<String> = emptyList()
+    @SerializedName("additionalParameters") val additionalParameters: List<String> = emptyList(),
+    @SerializedName("referenceFolderPath") val referenceFolderPath: String? = null,
+    @SerializedName("scanCommandConfig") val scanCommandConfig: ScanCommandConfig? = null,
+)
+
+data class ScanCommandConfig(
+    val preScanCommand: String = "",
+    val preScanOnlyReferenceFolder: Boolean = true,
+    val postScanCommand: String = "",
+    val postScanOnlyReferenceFolder: Boolean = true,
 )

--- a/src/test/kotlin/io/snyk/plugin/ui/BranchChooserComboBoxDialogTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/BranchChooserComboBoxDialogTest.kt
@@ -14,9 +14,9 @@ import org.eclipse.lsp4j.DidChangeConfigurationParams
 import org.eclipse.lsp4j.services.LanguageServer
 import org.junit.Test
 import snyk.common.lsp.FolderConfig
+import snyk.common.lsp.LanguageServerWrapper
 import snyk.common.lsp.settings.FolderConfigSettings
 import snyk.common.lsp.settings.LanguageServerSettings
-import snyk.common.lsp.LanguageServerWrapper
 import snyk.trust.WorkspaceTrustService
 import snyk.trust.WorkspaceTrustSettings
 import kotlin.io.path.absolutePathString
@@ -53,7 +53,7 @@ class BranchChooserComboBoxDialogTest : LightPlatform4TestCase() {
             selectedItem = "main"
         }
 
-        cut.comboBoxes = mutableListOf(comboBox)
+        cut.baseBranches = mutableListOf(comboBox)
 
         cut.execute()
         PlatformTestUtil.dispatchAllEventsInIdeEventQueue()
@@ -73,7 +73,7 @@ class BranchChooserComboBoxDialogTest : LightPlatform4TestCase() {
             name = folderConfig.folderPath
             selectedItem = "main"
         }
-        cut.comboBoxes = mutableListOf(comboBox)
+        cut.baseBranches = mutableListOf(comboBox)
 
         cut.execute()
         PlatformTestUtil.dispatchAllEventsInIdeEventQueue()
@@ -98,7 +98,7 @@ class BranchChooserComboBoxDialogTest : LightPlatform4TestCase() {
             selectedItem = "main"
         }
 
-        cut.comboBoxes = mutableListOf(comboBox)
+        cut.baseBranches = mutableListOf(comboBox)
 
         cut.doCancelAction()
 

--- a/src/test/kotlin/io/snyk/plugin/ui/ReferenceChooserDialogTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/ReferenceChooserDialogTest.kt
@@ -22,10 +22,10 @@ import snyk.trust.WorkspaceTrustSettings
 import kotlin.io.path.absolutePathString
 
 
-class BranchChooserComboBoxDialogTest : LightPlatform4TestCase() {
+class ReferenceChooserDialogTest : LightPlatform4TestCase() {
     private val lsMock: LanguageServer = mockk(relaxed = true)
     private lateinit var folderConfig: FolderConfig
-    lateinit var cut: BranchChooserComboBoxDialog
+    lateinit var cut: ReferenceChooserDialog
 
     override fun setUp() {
         super.setUp()
@@ -37,7 +37,7 @@ class BranchChooserComboBoxDialogTest : LightPlatform4TestCase() {
         languageServerWrapper.isInitialized = true
         languageServerWrapper.languageServer = lsMock
         project.basePath?.let { service<WorkspaceTrustService>().addTrustedPath(it.toPath().parent!!.toNioPath()) }
-        cut = BranchChooserComboBoxDialog(project)
+        cut = ReferenceChooserDialog(project)
     }
 
     override fun tearDown() {
@@ -53,7 +53,7 @@ class BranchChooserComboBoxDialogTest : LightPlatform4TestCase() {
             selectedItem = "main"
         }
 
-        cut.baseBranches = mutableListOf(comboBox)
+        cut.baseBranches = mutableMapOf(Pair(folderConfig, comboBox))
 
         cut.execute()
         PlatformTestUtil.dispatchAllEventsInIdeEventQueue()
@@ -73,7 +73,7 @@ class BranchChooserComboBoxDialogTest : LightPlatform4TestCase() {
             name = folderConfig.folderPath
             selectedItem = "main"
         }
-        cut.baseBranches = mutableListOf(comboBox)
+        cut.baseBranches = mutableMapOf(Pair(folderConfig, comboBox))
 
         cut.execute()
         PlatformTestUtil.dispatchAllEventsInIdeEventQueue()
@@ -98,7 +98,7 @@ class BranchChooserComboBoxDialogTest : LightPlatform4TestCase() {
             selectedItem = "main"
         }
 
-        cut.baseBranches = mutableListOf(comboBox)
+        cut.baseBranches = mutableMapOf(Pair(folderConfig, comboBox))
 
         cut.doCancelAction()
 
@@ -108,5 +108,18 @@ class BranchChooserComboBoxDialogTest : LightPlatform4TestCase() {
         verify(exactly = 0) {
             lsMock.workspaceService.didChangeConfiguration(capture(capturedParam))
         }
+    }
+
+    @Test
+    fun `enforce either reference folder or base branch is set`() {
+        val comboBox = ComboBox(emptyArray<String>())
+        cut.baseBranches = mutableMapOf(Pair(folderConfig, comboBox))
+
+        cut.doOKAction()
+
+        PlatformTestUtil.dispatchAllEventsInIdeEventQueue()
+        val capturedParam = CapturingSlot<DidChangeConfigurationParams>()
+        verify(exactly = 0) {
+            lsMock.workspaceService.didChangeConfiguration(capture(capturedParam))}
     }
 }


### PR DESCRIPTION
### Description

This code change introduces the ability to specify a reference folder for Snyk scans, in addition to the existing base branch option. This is particularly useful for projects that are not under Git version control.

Here's a breakdown of the changes:

* **`FolderConfig`**:  A new field `referenceFolderPath` has been added to store the path of the reference folder.  Additionally, `scanCommandConfig` has been added to support running commands before and after a scan, optionally only on the reference folder.
* **`SnykToolWindowPanel.kt`**:
    * `getRootNodeText()` now displays the reference folder information if it's set, otherwise it falls back to the base branch.
    * The UI now updates to reflect the chosen reference folder. Error handling has been slightly improved.
* **`BranchChooserComboboxDialog.kt`**:
    * This dialog now includes a file chooser for selecting the reference folder.
    * The dialog validates that either a base branch or a reference folder is selected. The member `comboBoxes` has been renamed to `baseBranches` and changed to a `MutableMap<FolderConfig, ComboBox<String>>`. Also a new `MutableMap<FolderConfig, TextFieldWithBrowseButton>` has been introduced for the reference folders.
* **`BranchChooserComboBoxDialogTest.kt`**:  The tests have been updated to reflect the changes in `BranchChooserComboboxDialog.kt`, specifically the change from `comboBoxes` to `baseBranches`.
* **`Utils.kt`**: A new function `isExecutable()` has been added for validating pre/post scan commands.
* **`SnykLanguageClient.kt`**:  A debug log message has been added to show the hash codes of the old and new tokens during authentication

Key improvements:

* **Support for non-Git projects**:  The reference folder option allows Snyk to scan projects not managed by Git.
* **More flexible configuration**:  Users can now specify both a base branch and a reference folder, or just one of them.
* **Improved UI**: The tool window displays the chosen reference folder.
* **Better error handling**:  The code includes more robust error handling for configuration updates.

This change makes the Snyk plugin more versatile and user-friendly, especially for users working with projects outside of Git. The addition of pre/post scan commands provides further customization options for the scanning process.  The debugging enhancements in `SnykLanguageClient.kt` should help diagnose token-related issues more easily.
### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
