### PR TITLE
fix: update cache on receive diags

### DIFF
--- a/src/main/kotlin/io/snyk/plugin/events/SnykScanListenerLS.kt
+++ b/src/main/kotlin/io/snyk/plugin/events/SnykScanListenerLS.kt
@@ -2,6 +2,7 @@ package io.snyk.plugin.events
 
 import com.intellij.util.messages.Topic
 import io.snyk.plugin.SnykFile
+import snyk.common.lsp.LsProduct
 import snyk.common.lsp.ScanIssue
 import snyk.common.lsp.SnykScanParams
 
@@ -9,11 +10,6 @@ interface SnykScanListenerLS {
     companion object {
         val SNYK_SCAN_TOPIC =
             Topic.create("Snyk scan LS", SnykScanListenerLS::class.java)
-
-        val PRODUCT_CODE = "code"
-        val PRODUCT_OSS = "oss"
-        val PRODUCT_IAC = "iac"
-        val PRODUCT_CONTAINER = "container"
     }
 
     fun scanningStarted(snykScan: SnykScanParams) {}
@@ -26,5 +22,5 @@ interface SnykScanListenerLS {
 
     fun scanningError(snykScan: SnykScanParams)
 
-    fun onPublishDiagnostics(product: String, snykFile: SnykFile, issueList: List<ScanIssue>)
+    fun onPublishDiagnostics(product: LsProduct, snykFile: SnykFile, issueList: List<ScanIssue>)
 }

--- a/src/main/kotlin/io/snyk/plugin/events/SnykShowIssueDetailListener.kt
+++ b/src/main/kotlin/io/snyk/plugin/events/SnykShowIssueDetailListener.kt
@@ -7,9 +7,7 @@ interface SnykShowIssueDetailListener {
         val SHOW_ISSUE_DETAIL_TOPIC =
             Topic.create("Snyk Show Issue Detail LS", SnykShowIssueDetailListener::class.java)
 
-        const val SNYK_URI_SCHEME = "snyk"
-        const val SNYK_CODE_PRODUCT = "Snyk Code"
-        const val SHOW_DETAIL_ACTION = "showInDetailPanel"
+        const val SHOW_DETAIL_ACTION = "showInDetailPanel" // The action as defined in the Language Server
     }
 
     fun onShowIssueDetail(aiFixParams: AiFixParams)

--- a/src/main/kotlin/io/snyk/plugin/events/SnykShowIssueDetailListener.kt
+++ b/src/main/kotlin/io/snyk/plugin/events/SnykShowIssueDetailListener.kt
@@ -4,10 +4,12 @@ import com.intellij.util.messages.Topic
 import snyk.common.lsp.AiFixParams
 interface SnykShowIssueDetailListener {
     companion object {
-        val SHOW_ISSUE_DETAIL_TOPIC = Topic.create(
-            "Snyk Show Issue Detail LS",
-            SnykShowIssueDetailListener::class.java
-        )
+        val SHOW_ISSUE_DETAIL_TOPIC =
+            Topic.create("Snyk Show Issue Detail LS", SnykShowIssueDetailListener::class.java)
+
+        const val SNYK_URI_SCHEME = "snyk"
+        const val SNYK_CODE_PRODUCT = "Snyk Code"
+        const val SHOW_DETAIL_ACTION = "showInDetailPanel"
     }
 
     fun onShowIssueDetail(aiFixParams: AiFixParams)

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindow.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindow.kt
@@ -20,6 +20,7 @@ import io.snyk.plugin.events.SnykTaskQueueListener
 import io.snyk.plugin.getSnykToolWindowPanel
 import io.snyk.plugin.ui.expandTreeNodeRecursively
 import snyk.common.SnykError
+import snyk.common.lsp.LsProduct
 import snyk.common.lsp.ScanIssue
 import snyk.common.lsp.SnykScanParams
 import snyk.container.ContainerResult
@@ -95,7 +96,7 @@ class SnykToolWindow(private val project: Project) : SimpleToolWindowPanel(false
                     updateActionsPresentation()
                 }
 
-                override fun onPublishDiagnostics(product: String, snykFile: SnykFile, issueList: List<ScanIssue>) =
+                override fun onPublishDiagnostics(product: LsProduct, snykFile: SnykFile, issueList: List<ScanIssue>) =
                     Unit
             })
 

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
@@ -25,9 +25,6 @@ import io.snyk.plugin.events.SnykCliDownloadListener
 import io.snyk.plugin.events.SnykResultsFilteringListener
 import io.snyk.plugin.events.SnykScanListener
 import io.snyk.plugin.events.SnykScanListenerLS
-import io.snyk.plugin.events.SnykScanListenerLS.Companion.PRODUCT_CODE
-import io.snyk.plugin.events.SnykScanListenerLS.Companion.PRODUCT_IAC
-import io.snyk.plugin.events.SnykScanListenerLS.Companion.PRODUCT_OSS
 import io.snyk.plugin.events.SnykSettingsListener
 import io.snyk.plugin.events.SnykTaskQueueListener
 import io.snyk.plugin.getKubernetesImageCache
@@ -78,6 +75,7 @@ import snyk.common.SnykError
 import snyk.common.lsp.AiFixParams
 import snyk.common.lsp.FolderConfig
 import snyk.common.lsp.LanguageServerWrapper
+import snyk.common.lsp.LsProduct
 import snyk.common.lsp.ScanIssue
 import snyk.common.lsp.SnykScanParams
 import snyk.common.lsp.settings.FolderConfigSettings
@@ -199,13 +197,15 @@ class SnykToolWindowPanel(
             .subscribe(
                 SnykScanListenerLS.SNYK_SCAN_TOPIC,
                 object : SnykScanListenerLS {
-                    override fun onPublishDiagnostics(product: String, snykFile: SnykFile, issueList: List<ScanIssue>) {
+                    override fun onPublishDiagnostics(product: LsProduct, snykFile: SnykFile, issueList: List<ScanIssue>) {
                         // Refresh the tree view on receiving new diags from the Language Server
                         getSnykCachedResults(project)?.let {
                             when (product) {
-                                PRODUCT_CODE -> it.currentSnykCodeResultsLS[snykFile] = issueList
-                                PRODUCT_OSS -> it.currentOSSResultsLS[snykFile] = issueList
-                                PRODUCT_IAC -> it.currentIacResultsLS[snykFile] = issueList
+                                LsProduct.Code -> it.currentSnykCodeResultsLS[snykFile] = issueList
+                                LsProduct.OpenSource -> it.currentOSSResultsLS[snykFile] = issueList
+                                LsProduct.InfrastructureAsCode -> it.currentIacResultsLS[snykFile] = issueList
+                                LsProduct.Container -> Unit
+                                LsProduct.Unknown -> Unit
                             }
                         }
                         vulnerabilitiesTree.isRootVisible = pluginSettings().isDeltaFindingsEnabled()

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLS.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLS.kt
@@ -2,6 +2,7 @@ package io.snyk.plugin.ui.toolwindow
 
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.invokeLater
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.util.TextRange
@@ -35,7 +36,6 @@ import snyk.common.lsp.LsProduct
 import snyk.common.lsp.ScanIssue
 import snyk.common.lsp.SnykScanParams
 import javax.swing.JTree
-import javax.swing.SwingUtilities.invokeLater
 import javax.swing.tree.DefaultMutableTreeNode
 import javax.swing.tree.DefaultTreeModel
 

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLS.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowSnykScanListenerLS.kt
@@ -86,7 +86,6 @@ class SnykToolWindowSnykScanListenerLS(
     override fun scanningOssFinished() {
         if (disposed) return
         ApplicationManager.getApplication().invokeLater {
-            this.rootOssIssuesTreeNode.allowsChildren = true
             this.rootOssIssuesTreeNode.userObject = "$OSS_ROOT_TEXT (scanning finished)"
             this.snykToolWindowPanel.triggerSelectionListeners = false
             val snykCachedResults = getSnykCachedResults(project)

--- a/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
+++ b/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
@@ -24,8 +24,6 @@ import io.snyk.plugin.events.SnykShowIssueDetailListener
 import io.snyk.plugin.events.SnykScanListenerLS
 import io.snyk.plugin.events.SnykScanSummaryListenerLS
 import io.snyk.plugin.events.SnykShowIssueDetailListener.Companion.SHOW_DETAIL_ACTION
-import io.snyk.plugin.events.SnykShowIssueDetailListener.Companion.SNYK_CODE_PRODUCT
-import io.snyk.plugin.events.SnykShowIssueDetailListener.Companion.SNYK_URI_SCHEME
 import io.snyk.plugin.getContentRootVirtualFiles
 import io.snyk.plugin.getDecodedParam
 import io.snyk.plugin.getSyncPublisher
@@ -445,8 +443,8 @@ class SnykLanguageClient :
         val uri = URI.create(param.uri)
 
         return if (
-            uri.scheme == SNYK_URI_SCHEME &&
-            uri.getDecodedParam("product") == SNYK_CODE_PRODUCT &&
+            uri.scheme == "snyk" &&
+            uri.getDecodedParam("product") == LsProduct.Code.toString() &&
             uri.getDecodedParam("action") == SHOW_DETAIL_ACTION
             ) {
 

--- a/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
+++ b/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
@@ -444,7 +444,7 @@ class SnykLanguageClient :
 
         return if (
             uri.scheme == "snyk" &&
-            uri.getDecodedParam("product") == LsProduct.Code.toString() &&
+            uri.getDecodedParam("product") == LsProduct.Code.longName &&
             uri.getDecodedParam("action") == SHOW_DETAIL_ACTION
             ) {
 

--- a/src/main/kotlin/snyk/common/lsp/Types.kt
+++ b/src/main/kotlin/snyk/common/lsp/Types.kt
@@ -30,8 +30,8 @@ data class CliError(
 
 // Define the SnykScanParams data class
 data class SnykScanParams(
-    val status: String, // Status (Defined in SnykScanListenerLS.companion)
-    val product: String, // Product under scan (Defined in SnykScanListenerLS.companion)
+    val status: String, // Status (Must map to an LsScanStatus enum)
+    val product: String, // Product under scan (Must map to an LsProduct)
     val folderPath: String, // FolderPath is the root-folder of the current scan
     val issues: List<ScanIssue>, // Issues contain the scan results in the common issues model
     val errorMessage: String? = null, // Error Message if applicable

--- a/src/main/kotlin/snyk/common/lsp/Types.kt
+++ b/src/main/kotlin/snyk/common/lsp/Types.kt
@@ -52,14 +52,12 @@ data class ErrorResponse(
     @SerializedName("path") val path: String
 )
 
-enum class LsProduct(private val longName: String, private val shortName: String) {
+enum class LsProduct(val longName: String, val shortName: String) {
     OpenSource("Snyk Open Source", "oss"),
     Code("Snyk Code", "code"),
     InfrastructureAsCode("Snyk IaC", "iac"),
     Container("Snyk Container", "container"),
     Unknown("", "");
-
-    override fun toString(): String = longName
 
     companion object {
         fun getFor(name: String): LsProduct {

--- a/src/main/kotlin/snyk/common/lsp/Types.kt
+++ b/src/main/kotlin/snyk/common/lsp/Types.kt
@@ -7,13 +7,11 @@ import com.intellij.openapi.editor.Document
 import com.intellij.openapi.util.TextRange
 import com.intellij.openapi.vfs.VirtualFile
 import io.snyk.plugin.Severity
-import io.snyk.plugin.SnykFile
 import io.snyk.plugin.getDocument
 import io.snyk.plugin.toVirtualFile
 import io.snyk.plugin.ui.PackageManagerIconProvider.Companion.getIcon
 import org.eclipse.lsp4j.Range
 import snyk.common.ProductType
-import java.net.URI
 import java.util.Date
 import java.util.Locale
 import javax.swing.Icon
@@ -32,12 +30,12 @@ data class CliError(
 
 // Define the SnykScanParams data class
 data class SnykScanParams(
-    val status: String, // Status can be either Initial, InProgress, Success or Error
-    val product: String, // Product under scan (Snyk Code, Snyk Open Source, etc...)
+    val status: String, // Status (Defined in SnykScanListenerLS.companion)
+    val product: String, // Product under scan (Defined in SnykScanListenerLS.companion)
     val folderPath: String, // FolderPath is the root-folder of the current scan
     val issues: List<ScanIssue>, // Issues contain the scan results in the common issues model
     val errorMessage: String? = null, // Error Message if applicable
-    val cliError: CliError? = null, // structured error information if applicable
+    val cliError: CliError? = null, // Structured error information if applicable
 )
 
 data class SnykScanSummaryParams(
@@ -54,16 +52,29 @@ data class ErrorResponse(
     @SerializedName("path") val path: String
 )
 
-enum class LsProductConstants(val value: String) {
-    OpenSource("Snyk Open Source"),
-    Code("Snyk Code"),
-    InfrastructureAsCode("Snyk IaC"),
-    Container("Snyk Container"),
-    Unknown("");
+enum class LsProduct(private val longName: String, private val shortName: String) {
+    OpenSource("Snyk Open Source", "oss"),
+    Code("Snyk Code", "code"),
+    InfrastructureAsCode("Snyk IaC", "iac"),
+    Container("Snyk Container", "container"),
+    Unknown("", "");
 
-    override fun toString(): String {
-        return value
+    override fun toString(): String = longName
+
+    companion object {
+        fun getFor(name: String): LsProduct {
+            return entries.toTypedArray().firstOrNull() { name in arrayOf(it.longName, it.shortName) } ?: Unknown
+        }
     }
+}
+
+enum class LsScanState(val value: String) {
+    Initial("initial"),
+    InProgress("inProgress"),
+    Success("success"),
+    Error("error");
+
+    override fun toString(): String = value
 }
 
 // Define the ScanIssue data class


### PR DESCRIPTION
### Description

Depending on the LSP method used, LS sends the either the long or the short product name ("Snyk Code" vs "code", for example). This was hard to track, and we had a few bugs where events were getting lost because we were comparing against the wrong strings.

This fix generalises the processing to handle either form, ensuring that all LS callbacks are handled.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
