### PR TITLE
fix: create CLI download directory if it non existent

### DIFF
--- a/src/main/kotlin/io/snyk/plugin/services/download/CliDownloader.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/download/CliDownloader.kt
@@ -40,6 +40,9 @@ class CliDownloader {
 
     fun downloadFile(cliFile: File, cliVersion: String, indicator: ProgressIndicator): File {
         indicator.checkCanceled()
+        if (!cliFile.parentFile.exists()){
+            Files.createDirectories(cliFile.parentFile.toPath())
+        }
         val downloadFile = try {
             File.createTempFile(cliFile.name, ".download", cliFile.parentFile)
         } catch (e: Exception) {


### PR DESCRIPTION
The CLI Download would fail in the plugin if the directory we are trying to download into does not exist, this PR fixes the issue by creating the directory if it is not present.
### Description

_Provide description of this PR and changes, if linked Jira ticket doesn't cover it in full._

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
