### PR TITLE
fix: Update endpoint description [IDE-1056]

### DIFF
--- a/src/main/kotlin/io/snyk/plugin/ui/SnykSettingsDialog.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/SnykSettingsDialog.kt
@@ -328,7 +328,7 @@ class SnykSettingsDialog(
         )
 
         val endpointDescriptionLabel = JLabel(
-            "<html>If you're using SSO(OAuth2), Custom Endpoint configuration is automatic. <br>" +
+            "<html>If you're using SSO with Snyk and OAuth2 the custom endpoint configuration is automatically populated. <br>" +
                 "Otherwise, for public regional instances, see the " +
                 "<a href='https://docs.snyk.io/working-with-snyk/regional-hosting-and-data-residency#available-snyk-regions'>docs</a>.<br>" +
                 "For private instances, contact your team or account manager.</html>"

--- a/src/main/kotlin/io/snyk/plugin/ui/SnykSettingsDialog.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/SnykSettingsDialog.kt
@@ -328,7 +328,7 @@ class SnykSettingsDialog(
         )
 
         val endpointDescriptionLabel = JLabel(
-            "<html>If you're using SSO with Snyk and OAuth2 the custom endpoint configuration is automatically populated. <br>" +
+            "<html>If you're using SSO with Snyk and OAuth2, the custom endpoint configuration is automatically populated. <br>" +
                 "Otherwise, for public regional instances, see the " +
                 "<a href='https://docs.snyk.io/working-with-snyk/regional-hosting-and-data-residency#available-snyk-regions'>docs</a>.<br>" +
                 "For private instances, contact your team or account manager.</html>"

--- a/src/main/kotlin/io/snyk/plugin/ui/SnykSettingsDialog.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/SnykSettingsDialog.kt
@@ -51,10 +51,15 @@ import org.jetbrains.concurrency.runAsync
 import snyk.SnykBundle
 import snyk.common.lsp.LanguageServerWrapper
 import snyk.common.lsp.settings.FolderConfigSettings
+import java.awt.Cursor
+import java.awt.Desktop
 import java.awt.GridBagConstraints
 import java.awt.GridBagLayout
 import java.awt.Insets
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
 import java.io.File.separator
+import java.net.URI
 import java.util.Objects.nonNull
 import java.util.function.Supplier
 import javax.swing.JButton
@@ -322,11 +327,20 @@ class SnykSettingsDialog(
             ),
         )
 
-        val endpointDescriptionLabel =
-            JLabel(
-                "<html>Sets API endpoint to use for Snyk requests. Useful for custom Snyk setups. <br/>" +
-                    "E.g. <code>https://api.eu.snyk.io</code>.</html>",
-            ).apply { font = FontUtil.minusOne(this.font) }
+        val endpointDescriptionLabel = JLabel(
+            "<html>If you're using SSO(OAuth2), Custom Endpoint configuration is automatic. <br>" +
+                "Otherwise, for public regional instances, see the " +
+                "<a href='https://docs.snyk.io/working-with-snyk/regional-hosting-and-data-residency#available-snyk-regions'>docs</a>.<br>" +
+                "For private instances, contact your team or account manager.</html>"
+        ).apply {
+            font = FontUtil.minusOne(this.font)
+            cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+            addMouseListener(object : MouseAdapter() {
+                override fun mouseClicked(e: MouseEvent) {
+                    Desktop.getDesktop().browse(URI("https://docs.snyk.io/working-with-snyk/regional-hosting-and-data-residency#available-snyk-regions"))
+                }
+            })
+        }
 
         generalSettingsPanel.add(
             endpointDescriptionLabel,


### PR DESCRIPTION
### Description

In IDEs, you can configure a custom endpoint in order to target a custom region (e.g EU). The current description for this option is "Sets API endpoint to use for Snyk requests. Useful for custom Snyk setups. E.g. https://api.eu.snyk.io/.". With the recent platform changes, on OAuth using SSO, we automatically redirect to the right instance and that field does not need to be configured anymore.


Update
`If you're using SSO (OAuth2), API endpoint configuration is automatic. Otherwise, for public regional instances, see the docs. For private instances, contact your team or account manager.`


### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
