### PR TITLE
fix: implement comparable on folderconfig

### DIFF
--- a/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
+++ b/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
@@ -282,7 +282,6 @@ class SnykLanguageClient :
     fun snykScanSummary(summaryParams: SnykScanSummaryParams) {
         if (disposed) return
         ProjectManager.getInstance().openProjects.filter{!it.isDisposed}.forEach { p ->
-            logger.debug("Publishing Snyk scan summary for $p: ${summaryParams.scanSummary}")
             getSyncPublisher(p, SnykScanSummaryListenerLS.SNYK_SCAN_SUMMARY_TOPIC)?.onSummaryReceived(summaryParams)
         }
     }

--- a/src/main/kotlin/snyk/common/lsp/Types.kt
+++ b/src/main/kotlin/snyk/common/lsp/Types.kt
@@ -558,7 +558,11 @@ data class FolderConfig(
     @SerializedName("additionalParameters") val additionalParameters: List<String>? = emptyList(),
     @SerializedName("referenceFolderPath") val referenceFolderPath: String? = "",
     @SerializedName("scanCommandConfig") val scanCommandConfig: Map<String,ScanCommandConfig>? = emptyMap(),
-)
+) : Comparable<FolderConfig> {
+    override fun compareTo(other: FolderConfig): Int {
+        return this.folderPath.compareTo(other.folderPath)
+    }
+}
 
 data class ScanCommandConfig(
     val preScanCommand: String = "",


### PR DESCRIPTION
### Description

Previously, folderConfig did not implement comparable, even though we call `sorted` function on the list of configs. This leads to a ClassCastException

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
