### PR TITLE
chore: disable SnykToolWindowPanelIntegTest tests [IDE-611]

### DIFF
--- a/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanelIntegTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanelIntegTest.kt
@@ -65,6 +65,7 @@ import javax.swing.tree.TreeNode
 import kotlin.reflect.KClass
 
 @RunWith(JUnit4::class)
+@Ignore("Too unstable in CI")
 class SnykToolWindowPanelIntegTest : HeavyPlatformTestCase() {
 
     private val containerResultName = "container-test-results/nginx-with-remediation.json"


### PR DESCRIPTION
### Description

They are too unstable on CI unfortunately.
E.g. https://github.com/snyk/snyk-intellij-plugin/actions/runs/14597741442/job/40947912517
and https://github.com/snyk/snyk-intellij-plugin/actions/runs/14665426298/job/41158970310?pr=692

### Checklist

- [x] Tests added and all succeed
 - Tests removed ;)
- [x] Linted
- [ ] CHANGELOG.md updated
 - N/A
- [ ] README.md updated, if user-facing
 - N/A

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
