### PR TITLE
fix: TextEdits applying to the wrong lines

### DIFF
--- a/src/main/kotlin/snyk/common/editor/DocumentChanger.kt
+++ b/src/main/kotlin/snyk/common/editor/DocumentChanger.kt
@@ -10,7 +10,13 @@ object DocumentChanger {
         val fileURI = change.key
         val virtualFile = VirtualFileManager.getInstance().findFileByUrl(fileURI) ?: return
         val document = virtualFile.getDocument() ?: return
-        for (e in change.value) {
+        // Our LS is coded to give us the TextEdits in ascending order, but we must apply them in descending order.
+        // Imagine we had an edit that added 10 lines to the start of the file followed by an edit that added a line to the 4th line of the file,
+        // ascending order applying would incorrectly place the second edit withing the 10 lines added at the start!
+        // N.b. Line edits on a single line are returned as two edits, a deletion of the line and an addition to the line after, so reversing works for this too.
+        // N.b. The previous note is a lie for edits at the end of the file when no LF at EOF is present, for those the addition is marked for the same line as the deletion.
+        // TODO - Handle edits at EOF when there is no LF at EOF.
+        for (e in change.value.reversed()) {
             // normalize range
             var startLine = e.range.start.line
             var startCharacter = e.range.start.character


### PR DESCRIPTION
### Description

The previous code was based on bad logic for creating `WorkspaceEdit`s in the LS.
This LS bug has been fixed, but it isn't compatible with our code which expected the incorrect `WorkspaceEdit`s.
This has been fixed by applying the edits from the end of the file to the start of the file.

Unfortunately there is one case where this fix doesn't work, which is when applying a fix to the end of the file, if the file doesn't end with a LF character.

### Checklist

- [ ] Tests added and all succeed
 - No tests added, because I just want a fix in quickly before release, I will add some later.
- [ ] Linted
- [ ] CHANGELOG.md updated
 - No, since we never released with applying WorkspaceEdits being broken.
- [ ] README.md updated, if user-facing
 - N/A

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
