### PR TITLE
fix: reduce usage of EDT in tree view and rendering updates, optimize data access paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,4 @@
 # Snyk Security Changelog
-## [2.12.2]
-### Changed
-- fix: initialize jcef browser with 'about:blank' fix usage in 2025.1
-
 ## [2.13.0]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Snyk Security Changelog
-## [2.12.2]
-### Changed
-- fix: initialize jcef browser with 'about:blank' fix usage in 2025.1
+
 
 ## [2.13.0]
 ### Changed
 - remove unnecessary dependency on com.intellij.modules.lang to enable Jetbrains Gateway usage
+- optimize time spent in UI thread to avoid freezes on large projects
+
+## [2.12.2]
+### Changed
+- fix: initialize jcef browser with 'about:blank' fix usage in 2025.1
 
 ## [2.12.1]
 ### Changed

--- a/src/main/kotlin/io/snyk/plugin/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/Utils.kt
@@ -273,6 +273,8 @@ fun refreshAnnotationsForFile(psiFile: PsiFile) {
     }
 }
 
+private const val SINGLE_FILE_DECORATION_UPDATE_THRESHOLD = 5
+
 fun refreshAnnotationsForOpenFiles(project: Project) {
     if (project.isDisposed || ApplicationManager.getApplication().isDisposed) return
     runAsync {
@@ -286,7 +288,7 @@ fun refreshAnnotationsForOpenFiles(project: Project) {
             }
         }
 
-        if (openFiles.size > 5) {
+        if (openFiles.size > SINGLE_FILE_DECORATION_UPDATE_THRESHOLD) {
             invokeLater {
                 if (!project.isDisposed) {
                     DaemonCodeAnalyzer.getInstance(project).restart()

--- a/src/main/kotlin/io/snyk/plugin/ui/UIUtils.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/UIUtils.kt
@@ -1,6 +1,7 @@
 package io.snyk.plugin.ui
 
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.invokeLater
 import com.intellij.openapi.util.IconLoader
 import com.intellij.ui.BrowserHyperlinkListener
 import com.intellij.ui.ColorUtil
@@ -367,7 +368,9 @@ fun txtToHtml(s: String): String {
 fun getDisabledIcon(originalIcon: Icon?): Icon? = originalIcon?.let { IconLoader.getDisabledIcon(it) }
 
 fun expandTreeNodeRecursively(tree: JTree, node: DefaultMutableTreeNode) {
-    tree.expandPath(TreePath(node.path))
+    invokeLater {
+        tree.expandPath(TreePath(node.path))
+    }
     node.children().asSequence().forEach {
         expandTreeNodeRecursively(tree, it as DefaultMutableTreeNode)
     }

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
@@ -297,32 +297,22 @@ class SnykToolWindowPanel(
                     override fun filtersChanged() {
                         val codeSecurityResultsLS =
                             getSnykCachedResultsForProduct(project, ProductType.CODE_SECURITY) ?: return
-                        ApplicationManager.getApplication().invokeLater {
-                            scanListenerLS.displaySnykCodeResults(codeSecurityResultsLS)
-                        }
+                        scanListenerLS.displaySnykCodeResults(codeSecurityResultsLS)
 
                         val codeQualityResultsLS =
                             getSnykCachedResultsForProduct(project, ProductType.CODE_QUALITY) ?: return
-                        ApplicationManager.getApplication().invokeLater {
-                            scanListenerLS.displaySnykCodeResults(codeQualityResultsLS)
-                        }
+                        scanListenerLS.displaySnykCodeResults(codeQualityResultsLS)
 
                         val ossResultsLS =
                             getSnykCachedResultsForProduct(project, ProductType.OSS) ?: return
-                        ApplicationManager.getApplication().invokeLater {
-                            scanListenerLS.displayOssResults(ossResultsLS)
-                        }
+                        scanListenerLS.displayOssResults(ossResultsLS)
 
                         val iacResultsLS =
                             getSnykCachedResultsForProduct(project, ProductType.IAC) ?: return
-                        ApplicationManager.getApplication().invokeLater {
-                            scanListenerLS.displayIacResults(iacResultsLS)
-                        }
+                        scanListenerLS.displayIacResults(iacResultsLS)
 
                         val snykCachedResults = getSnykCachedResults(project) ?: return
-                        ApplicationManager.getApplication().invokeLater {
-                            snykCachedResults.currentContainerResult?.let { displayContainerResults(it) }
-                        }
+                        snykCachedResults.currentContainerResult?.let { displayContainerResults(it) }
                     }
                 },
             )
@@ -826,10 +816,13 @@ class SnykToolWindowPanel(
     }
 
     fun displayContainerResults(containerResult: ContainerResult) {
-        val userObjectsForExpandedChildren = userObjectsForExpandedNodes(rootContainerIssuesTreeNode)
-        val selectedNodeUserObject =
-            TreeUtil.findObjectInPath(vulnerabilitiesTree.selectionPath, Any::class.java)
-
+        var userObjectsForExpandedChildren: List<Any>? = emptyList()
+        var selectedNodeUserObject: Any? = Object()
+        ApplicationManager.getApplication().invokeAndWait {
+            userObjectsForExpandedChildren = userObjectsForExpandedNodes(rootContainerIssuesTreeNode)
+            selectedNodeUserObject =
+                TreeUtil.findObjectInPath(vulnerabilitiesTree.selectionPath, Any::class.java)
+        }
         rootContainerIssuesTreeNode.removeAllChildren()
 
         fun navigateToImage(
@@ -967,20 +960,29 @@ class SnykToolWindowPanel(
         if (selectedNode is InfoTreeNode) return
 
         displayEmptyDescription()
-        (vulnerabilitiesTree.model as DefaultTreeModel).reload(nodeToReload)
+
+        ApplicationManager.getApplication().invokeAndWait {
+            (vulnerabilitiesTree.model as DefaultTreeModel).reload(nodeToReload)
+        }
 
         userObjectsForExpandedChildren?.let {
             it.forEach { userObject ->
                 val pathToNewNode = TreeUtil.findNodeWithObject(nodeToReload, userObject)?.path
                 if (pathToNewNode != null) {
-                    vulnerabilitiesTree.expandPath(TreePath(pathToNewNode))
+                    invokeLater {
+                        vulnerabilitiesTree.expandPath(TreePath(pathToNewNode))
+                    }
                 }
             }
         } ?: expandTreeNodeRecursively(vulnerabilitiesTree, nodeToReload)
 
         smartReloadMode = true
         try {
-            selectedNode?.let { TreeUtil.selectNode(vulnerabilitiesTree, it) }
+            selectedNode?.let {
+                invokeLater {
+                    TreeUtil.selectNode(vulnerabilitiesTree, it)
+                }
+            }
         } finally {
             smartReloadMode = false
         }

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
@@ -483,9 +483,7 @@ class SnykToolWindowPanel(
             it.cacheKubernetesFileFromProject()
         }
 
-        ApplicationManager.getApplication().invokeLater {
-            doCleanUi(true)
-        }
+        doCleanUi(true)
         refreshAnnotationsForOpenFiles(project)
     }
 

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykTreeCellRenderer.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykTreeCellRenderer.kt
@@ -75,9 +75,8 @@ class SnykTreeCellRenderer : ColoredTreeCellRenderer() {
                 val pair = updateTextTooltipAndIcon(file, productType, value, entry.value.first())
                 pair.first?.let { nodeIcon = pair.first }
                 text = pair.second
-                val cachedIssues =
-                    getSnykCachedResultsForProduct(entry.key.project, productType)
-                        ?.filter { it.key.virtualFile == file.virtualFile } ?: emptyMap()
+                val allIssues = getSnykCachedResultsForProduct(entry.key.project, productType)
+                val cachedIssues = allIssues?.get(entry.key) ?: emptyList()
                 if (cachedIssues.isEmpty()) {
                     attributes = SimpleTextAttributes.GRAYED_ATTRIBUTES
                     nodeIcon = getDisabledIcon(nodeIcon)

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykTreeCellRenderer.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykTreeCellRenderer.kt
@@ -57,9 +57,12 @@ class SnykTreeCellRenderer : ColoredTreeCellRenderer() {
                 val (entry, productType) =
                     parentFileNode.userObject as Pair<Map.Entry<SnykFile, List<ScanIssue>>, ProductType>
 
-                text = "${if (issue.isIgnored()) " [ Ignored ]" else ""}${if (issue.hasAIFix()) " ⚡️" else ""} ${issue.longTitle()}"
+                text =
+                    "${if (issue.isIgnored()) " [ Ignored ]" else ""}${if (issue.hasAIFix()) " ⚡️" else ""} ${issue.longTitle()}"
                 val cachedIssues = getSnykCachedResultsForProduct(entry.key.project, productType)
-                if (cachedIssues != null && cachedIssues[entry.key]?.isEmpty() == true) {
+                val entryIssues = cachedIssues?.get(entry.key) ?: emptyList()
+                val empty = entryIssues.isEmpty()
+                if (empty || !issueIsContained(entryIssues, issue)) {
                     attributes = SimpleTextAttributes.GRAYED_ATTRIBUTES
                     nodeIcon = getDisabledIcon(nodeIcon)
                 }
@@ -219,6 +222,13 @@ class SnykTreeCellRenderer : ColoredTreeCellRenderer() {
         icon = nodeIcon
         font = UIUtil.getTreeFont()
         text?.let { append(it, attributes) }
+    }
+
+    private fun issueIsContained(
+        entryIssues: List<ScanIssue>,
+        issue: ScanIssue
+    ): Boolean {
+        return HashSet(entryIssues).contains(issue)
     }
 
     private fun updateTextTooltipAndIcon(

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykTreeCellRenderer.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykTreeCellRenderer.kt
@@ -61,8 +61,7 @@ class SnykTreeCellRenderer : ColoredTreeCellRenderer() {
                     "${if (issue.isIgnored()) " [ Ignored ]" else ""}${if (issue.hasAIFix()) " ⚡️" else ""} ${issue.longTitle()}"
                 val cachedIssues = getSnykCachedResultsForProduct(entry.key.project, productType)
                 val entryIssues = cachedIssues?.get(entry.key) ?: emptyList()
-                val empty = entryIssues.isEmpty()
-                if (empty || !issueIsContained(entryIssues, issue)) {
+                if (!entryIssues.issueIsContained(issue)) {
                     attributes = SimpleTextAttributes.GRAYED_ATTRIBUTES
                     nodeIcon = getDisabledIcon(nodeIcon)
                 }
@@ -224,11 +223,9 @@ class SnykTreeCellRenderer : ColoredTreeCellRenderer() {
         text?.let { append(it, attributes) }
     }
 
-    private fun issueIsContained(
-        entryIssues: List<ScanIssue>,
-        issue: ScanIssue
-    ): Boolean {
-        return HashSet(entryIssues).contains(issue)
+    fun List<ScanIssue>.issueIsContained(issue: ScanIssue): Boolean {
+        // this is a bit weird, I admit. But HashSet.contains() has an O(1) complexity.
+        return this.isNotEmpty() && HashSet(this).contains(issue)
     }
 
     private fun updateTextTooltipAndIcon(

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykTreeCellRenderer.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykTreeCellRenderer.kt
@@ -59,7 +59,7 @@ class SnykTreeCellRenderer : ColoredTreeCellRenderer() {
 
                 text = "${if (issue.isIgnored()) " [ Ignored ]" else ""}${if (issue.hasAIFix()) " ⚡️" else ""} ${issue.longTitle()}"
                 val cachedIssues = getSnykCachedResultsForProduct(entry.key.project, productType)
-                if (cachedIssues?.values?.flatten()?.contains(issue) == false) {
+                if (cachedIssues != null && cachedIssues[entry.key]?.isEmpty() == true) {
                     attributes = SimpleTextAttributes.GRAYED_ATTRIBUTES
                     nodeIcon = getDisabledIcon(nodeIcon)
                 }

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykTreeCellRenderer.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykTreeCellRenderer.kt
@@ -223,7 +223,9 @@ class SnykTreeCellRenderer : ColoredTreeCellRenderer() {
     }
 
     fun List<ScanIssue>.issueIsContained(issue: ScanIssue): Boolean {
-        // this is a bit weird, I admit. But HashSet.contains() has an O(1) complexity.
+        // This is a bit weird, I admit. But HashSet.contains() has an O(1) complexity.
+        // even with copying over the whole list (O(n)), in this case it is faster due to `hashCode`
+        // checking the hashes is much faster than comparing the objects in the list.
         return this.isNotEmpty() && HashSet(this).contains(issue)
     }
 

--- a/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
+++ b/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
@@ -28,6 +28,7 @@ import io.snyk.plugin.getContentRootVirtualFiles
 import io.snyk.plugin.getDecodedParam
 import io.snyk.plugin.getSyncPublisher
 import io.snyk.plugin.pluginSettings
+import io.snyk.plugin.refreshAnnotationsForFile
 import io.snyk.plugin.refreshAnnotationsForOpenFiles
 import io.snyk.plugin.sha256
 import io.snyk.plugin.toVirtualFile
@@ -163,10 +164,10 @@ class SnykLanguageClient :
         WriteCommandAction.runWriteCommandAction(project) {
             params?.edit?.changes?.forEach {
                 DocumentChanger.applyChange(it)
+                refreshAnnotationsForFile(project, it.key.toVirtualFile())
             }
         }
 
-        refreshUI()
         return CompletableFuture.completedFuture(ApplyWorkspaceEditResponse(true))
     }
 


### PR DESCRIPTION
### Description

This Pull Request introduces functional, readability, and performance improvements across the codebase. Key updates include adjustments to optimize UI thread performance, the addition of helper methods for annotation refreshes, code formatting improvements, and changes enhancing maintainability.

- Updates the changelog to include a performance optimization for avoiding UI freezes in large projects.
- Refactors Utils.kt by improving null checks, enhancing readability, and adding functions to handle file annotations more efficiently.
- Optimizes the logic for refreshing open file annotations, including improvements for better performance based on file count.
- Refines the UI behavior in SnykToolWindowPanel.kt, simplifying redundant method calls while maintaining functionality.
- Enhances logic in SnykTreeCellRenderer.kt to check for scan issues more accurately and adds [helper functions](https://github.com/snyk/snyk-intellij-plugin/pull/698/files#diff-f7ace1752a84fb0ef3c4fd530431e8341c00868125831ab9d8fc970b66e52d63R229).
- Updates in SnykLanguageClient.kt link file changes with immediate annotation refreshes for improved user feedback.

This PR primarily addresses performance improvements, functional refinements, and better code handling for clarity and efficiency.

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs
As we can see here, the only long usage is expanding the tree nodes. With issue filtering, this would be neglible (this project has >60000 issues), and we cannot optimize it without stopping to expand the tree nodes.

![image](https://github.com/user-attachments/assets/f68d0741-ae70-4766-a2f2-5f1399bf2fc7)
