### PR TITLE
fix: remove stale JS which was displayed in HTML [IDE-1204]

### DIFF
--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/JCEFDescriptionPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/JCEFDescriptionPanel.kt
@@ -161,37 +161,7 @@ class SuggestionDescriptionPanelFromLS(
 
     fun getCustomCssAndScript(): String {
         val html = issue.details()
-        val ideScript = getCustomScript()
-        return PanelHTMLUtils.getFormattedHtml(html, ideScript)
-    }
-    private fun getCustomScript(): String {
-        return """
-              // Show the AI fixes received from the Language Server
-              function showAIFixes(suggestion) {
-                toggleElement(fixSectionElem, "show");
-                toggleElement(fixLoadingIndicatorElem, "hide");
-                toggleElement(fixWrapperElem, "hide");
-
-                showCurrentDiff(suggestion);
-              }
-
-              function showGenerateAIFixError() {
-                toggleElement(fixLoadingIndicatorElem, "hide");
-                toggleElement(fixWrapperElem, "hide");
-                toggleElement(fixSectionElem, "hide");
-                toggleElement(fixErrorSectionElem, "show");
-              }
-
-              window.receiveApplyFixResponse = function (success) {
-              console.log('[[receiveApplyFixResponse]]', success);
-                if (success) {
-                    console.log('Fix applied', success);
-                    document.getElementById('apply-fix').disabled = true;
-                } else {
-                    console.error('Failed to apply fix', success);
-                }
-              };
-        """.trimIndent()
+        return PanelHTMLUtils.getFormattedHtml(html)
     }
 }
 


### PR DESCRIPTION
### Description

Due to LS not putting `${ideScript}` in `<script>` tags in the IaC HTML, the JS was being displayed as text.
But `${ideScript}` is in `<script>` tags in the Code HTML, leading to an issue.
Luckily we can skip the issue, as the JS code injected is all stale now anyway.

Proof it is stale is below. Here are the only places they were being called (which have all been deleted):
- [`showAIFixes`](https://github.com/snyk/snyk-intellij-plugin/commit/f2ab96aa81f66c099187dd0f33aca2bf8fc21346#diff-2fe5cac6c04cc0d617b140ead2162807fcb566f072da5fc652a586a23c103972L188)
- [`showGenerateAIFixError`](https://github.com/snyk/snyk-intellij-plugin/commit/f2ab96aa81f66c099187dd0f33aca2bf8fc21346#diff-2fe5cac6c04cc0d617b140ead2162807fcb566f072da5fc652a586a23c103972L185)
- [`window.receiveApplyFixResponse`](https://github.com/snyk/snyk-intellij-plugin/commit/f2ab96aa81f66c099187dd0f33aca2bf8fc21346#diff-50b25cdab7498d0c424b990b365d6f5fb445dbb5c233cd8cc23ba872afaa28f4L52-L60)

### Checklist

- [ ] Tests added and all succeed
 - N/A
 - I did manually test to ensure AI fixes still worked ("Generate fix" button, code lenses and code actions) and AI fix applying.
- [ ] Linted
 - N/A
- [ ] CHANGELOG.md updated
 - N/A - Not a big enough bug fix.
- [ ] README.md updated, if user-facing
 - N/A

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
