### PR TITLE
fix: prevent "${nonce}" check bypass [IDE-1050]

### DIFF
--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/PanelHTMLUtils.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/PanelHTMLUtils.kt
@@ -16,12 +16,16 @@ class PanelHTMLUtils {
                 .joinToString("")
         }
 
-        fun getFormattedHtml(html: String, ideScript: String = ""): String {
+        // Must not have blank template replacements, as they could be used to skip the "${nonce}" injection check
+        // and still end up with the nonce injected, e.g. "${nonce${resolvesToEmpty}}" becomes "${nonce}" - See IDE-1050.
+        fun getFormattedHtml(
+            html: String,
+            ideScript: String = " "
+        ): String {
             val nonce = extractLsNonceIfPresent(html)?: getNonce()
             var formattedHtml = html.replace("\${ideStyle}", "<style nonce=\${nonce}>${getCss()}</style>")
-            formattedHtml = formattedHtml.replace("\${headerEnd}", "")
-            formattedHtml = formattedHtml.replace(
-                "\${ideScript}", "$ideScript")
+            formattedHtml = formattedHtml.replace("\${headerEnd}", " ")
+            formattedHtml = formattedHtml.replace("\${ideScript}", ideScript)
             formattedHtml = formattedHtml.replace("\${ideGenerateAIFix}", getGenerateAiFixScript())
             formattedHtml = formattedHtml.replace("\${ideApplyAIFix}", getApplyAiFixScript())
             formattedHtml = formattedHtml.replace("\${ideSubmitIgnoreRequest}", getSubmitIgnoreRequestScript())


### PR DESCRIPTION
### Description

By using a space for replacements the attacker cannot use a bypass of using "${nonce${resolvesToEmpty}}".

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
