### PR TITLE
fix: URI handling for URIs with special/blank characters [IDE-1203][IDE-1235]

### DIFF
--- a/.windsurfrules
+++ b/.windsurfrules
@@ -6,6 +6,7 @@ always write and update test cases. iterate until they pass.
 use existing mocks, don't write new ones.
 if you use mocks, use mockk to generate them.
 always run the tests after editing.
+use junit4 syntax
 
 ** security **
 determine the absolute path of the project directory. you can do that e.g. by executing pwd on the shell within the directory.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Snyk Security Changelog
 ## [2.13.1]
 ### Fixed
-- fixed not initialized exception in error handling during language server startup 
+- fixed not initialized exception in error handling during language server startup
+- fixed handling of special characters in filepaths
 
 ## [2.13.0]
 

--- a/src/main/kotlin/io/snyk/plugin/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/Utils.kt
@@ -428,8 +428,12 @@ fun String.toVirtualFile(): VirtualFile {
 }
 
 fun String.fromUriToPath(): Path {
-    val filePath = Paths.get(URI.create(this))
-    return filePath.normalize()
+    try {
+        val filePath = Paths.get(URI.create(this))
+        return filePath.normalize()
+    } catch (e: IllegalArgumentException) {
+        throw FileNotFoundException("Invalid URI format: $this", e)
+    }
 }
 
 fun String.toVirtualFileOrNull(): VirtualFile? {

--- a/src/main/kotlin/io/snyk/plugin/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/Utils.kt
@@ -445,7 +445,7 @@ fun VirtualFile.toLanguageServerURI(): String {
 }
 
 fun String.fromPathToUriString(): String {
-    return Paths.get(this).toUri().toString()
+    return Paths.get(this).toUri().toASCIIString()
 }
 
 private fun String.startsWithWindowsDriveLetter(): Boolean {

--- a/src/main/kotlin/io/snyk/plugin/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/Utils.kt
@@ -441,7 +441,7 @@ fun String.toVirtualFileOrNull(): VirtualFile? {
 }
 
 fun VirtualFile.toLanguageServerURI(): String {
-    return this.url.fromPathToUriString()
+    return this.path.fromPathToUriString()
 }
 
 fun String.fromPathToUriString(): String {

--- a/src/main/kotlin/io/snyk/plugin/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/Utils.kt
@@ -445,7 +445,7 @@ fun VirtualFile.toLanguageServerURI(): String {
 }
 
 fun String.fromPathToUriString(): String {
-    return Paths.get(this).toUri().toASCIIString()
+    return Paths.get(this).normalize().toUri().toASCIIString()
 }
 
 private fun String.startsWithWindowsDriveLetter(): Boolean {
@@ -456,7 +456,7 @@ fun VirtualFile.getDocument(): Document? = runReadAction { FileDocumentManager.g
 
 fun Project.getContentRootPaths(): SortedSet<Path> {
     return getContentRootVirtualFiles()
-        .mapNotNull { it.path.toNioPathOrNull() }
+        .mapNotNull { it.path.toNioPathOrNull()?.normalize() }
         .toSortedSet()
 }
 

--- a/src/main/kotlin/io/snyk/plugin/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/Utils.kt
@@ -428,12 +428,8 @@ fun String.toVirtualFile(): VirtualFile {
 }
 
 fun String.fromUriToPath(): Path {
-    try {
-        val filePath = Paths.get(URI.create(this))
-        return filePath.normalize()
-    } catch (e: IllegalArgumentException) {
-        throw FileNotFoundException("Invalid URI format: $this", e)
-    }
+    val filePath = Paths.get(URI.create(this))
+    return filePath.normalize()
 }
 
 fun String.toVirtualFileOrNull(): VirtualFile? {

--- a/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykTaskQueueService.kt
@@ -22,6 +22,7 @@ import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.refreshAnnotationsForOpenFiles
 import io.snyk.plugin.ui.SnykBalloonNotificationHelper
 import org.jetbrains.annotations.TestOnly
+import org.jetbrains.concurrency.runAsync
 import snyk.common.lsp.LanguageServerWrapper
 import snyk.common.lsp.ScanState
 import snyk.trust.confirmScanningAndSetWorkspaceTrustedStateIfNeeded
@@ -56,7 +57,13 @@ class SnykTaskQueueService(val project: Project) {
 
         // wait for modules to be loaded and indexed so we can add all relevant content roots
         DumbService.getInstance(project).runWhenSmart {
-            languageServerWrapper.addContentRoots(project)
+            runAsync {
+                try {
+                    languageServerWrapper.addContentRoots(project)
+                } catch (e: RuntimeException) {
+                    logger.error("unable to add content roots for project $project", e)
+                }
+            }
         }
     }
 

--- a/src/main/kotlin/io/snyk/plugin/ui/SnykSettingsDialog.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/SnykSettingsDialog.kt
@@ -185,7 +185,7 @@ class SnykSettingsDialog(
             // TODO: check for concrete project roots, and if we received a message for them
             // this is an edge case, when a project is opened after ls initialization and
             // preferences dialog is opened before ls sends the additional parameters
-            additionalParametersTextField.isEnabled = LanguageServerWrapper.getInstance().folderConfigsRefreshed.isNotEmpty()
+            additionalParametersTextField.isEnabled = LanguageServerWrapper.getInstance().getFolderConfigsRefreshed().isNotEmpty()
             additionalParametersTextField.text = getAdditionalParams(project)
             scanOnSaveCheckbox.isSelected = applicationSettings.scanOnSave
             cliReleaseChannelDropDown.selectedItem = applicationSettings.cliReleaseChannel

--- a/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
@@ -12,13 +12,13 @@ import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.util.io.toNioPathOrNull
 import com.intellij.openapi.vfs.VirtualFile
+import io.snyk.plugin.fromUriToPath
 import io.snyk.plugin.getCliFile
 import io.snyk.plugin.getContentRootVirtualFiles
 import io.snyk.plugin.getSnykTaskQueueService
 import io.snyk.plugin.getWaitForResultsTimeout
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.runInBackground
-import io.snyk.plugin.toFilePathString
 import io.snyk.plugin.toLanguageServerURI
 import io.snyk.plugin.ui.toolwindow.SnykPluginDisposable
 import org.eclipse.lsp4j.ClientCapabilities
@@ -64,9 +64,9 @@ import snyk.common.lsp.commands.COMMAND_WORKSPACE_FOLDER_SCAN
 import snyk.common.lsp.commands.SNYK_GENERATE_ISSUE_DESCRIPTION
 import snyk.common.lsp.progress.ProgressManager
 import snyk.common.lsp.settings.FolderConfigSettings
+import snyk.common.lsp.settings.IssueViewOptions
 import snyk.common.lsp.settings.LanguageServerSettings
 import snyk.common.lsp.settings.SeverityFilter
-import snyk.common.lsp.settings.IssueViewOptions
 import snyk.common.removeTrailingSlashesIfPresent
 import snyk.pluginInfo
 import snyk.trust.WorkspaceTrustService
@@ -485,10 +485,10 @@ class LanguageServerWrapper(
         // the folderConfigs in language server
         val folderConfigs = configuredWorkspaceFolders
             .filter {
-                val folderPath = it.uri.toFilePathString()
+                val folderPath = it.uri.fromUriToPath().toString()
                 folderConfigsRefreshed[folderPath] == true
             }.map {
-                val folderPath = it.uri.toFilePathString()
+                val folderPath = it.uri.fromUriToPath().toString()
                 service<FolderConfigSettings>().getFolderConfig(folderPath) }
             .toList()
 

--- a/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
@@ -98,7 +98,7 @@ class LanguageServerWrapper(
 
     // internal for test set up
     internal val configuredWorkspaceFolders: MutableSet<WorkspaceFolder> = Collections.synchronizedSet(mutableSetOf())
-    internal var folderConfigsRefreshed: MutableMap<String, Boolean> = ConcurrentHashMap()
+    private var folderConfigsRefreshed: MutableMap<String, Boolean> = ConcurrentHashMap()
     private var disposed = false
         get() {
             return ApplicationManager.getApplication().isDisposed || field
@@ -765,6 +765,15 @@ class LanguageServerWrapper(
     override fun dispose() {
         disposed = true
         shutdown()
+    }
+
+    fun getFolderConfigsRefreshed(): Map<String?, Boolean?> {
+        return Collections.unmodifiableMap(this.folderConfigsRefreshed)
+    }
+
+    fun updateFolderConfigRefresh(folderPath: String, refreshed: Boolean) {
+        val path = Paths.get(folderPath).normalize().toAbsolutePath().toString()
+        this.folderConfigsRefreshed[path] = refreshed
     }
 
 

--- a/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
@@ -85,7 +85,7 @@ import java.util.logging.Level
 import java.util.logging.Logger.getLogger
 import kotlin.io.path.exists
 
-private const val INITIALIZATION_TIMEOUT = 2000L
+private const val INITIALIZATION_TIMEOUT = 20L
 
 @Suppress("TooGenericExceptionCaught")
 class LanguageServerWrapper(

--- a/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
+++ b/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
@@ -200,7 +200,8 @@ class SnykLanguageClient :
             val service = service<FolderConfigSettings>()
             service.addAll(folderConfigs)
             folderConfigs.forEach {
-                LanguageServerWrapper.getInstance().folderConfigsRefreshed[it.folderPath] = true
+                val normalizedPath = Paths.get(it.folderPath).normalize().toAbsolutePath().toString()
+                LanguageServerWrapper.getInstance().folderConfigsRefreshed[normalizedPath] = true
             }
         }
     }

--- a/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
+++ b/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
@@ -200,8 +200,7 @@ class SnykLanguageClient :
             val service = service<FolderConfigSettings>()
             service.addAll(folderConfigs)
             folderConfigs.forEach {
-                val normalizedPath = Paths.get(it.folderPath).normalize().toAbsolutePath().toString()
-                LanguageServerWrapper.getInstance().folderConfigsRefreshed[normalizedPath] = true
+                LanguageServerWrapper.getInstance().updateFolderConfigRefresh(it.folderPath, true)
             }
         }
     }

--- a/src/main/kotlin/snyk/common/lsp/settings/FolderConfigSettings.kt
+++ b/src/main/kotlin/snyk/common/lsp/settings/FolderConfigSettings.kt
@@ -18,21 +18,24 @@ class FolderConfigSettings {
 
     @Suppress("UselessCallOnNotNull", "USELESS_ELVIS", "UNNECESSARY_SAFE_CALL", "RedundantSuppression")
     fun addFolderConfig(@NotNull folderConfig: FolderConfig) {
-        if (folderConfig?.folderPath.isNullOrBlank() ?: true) return
-        val normalizedPath = Paths.get(folderConfig.folderPath).normalize().toAbsolutePath().toString()
-        configs[normalizedPath] = folderConfig
+        if (folderConfig.folderPath.isNullOrBlank()) return
+        val normalizedAbsolutePath = Paths.get(folderConfig.folderPath).normalize().toAbsolutePath().toString()
+        val configToStore = folderConfig.copy(folderPath = normalizedAbsolutePath)
+        configs[normalizedAbsolutePath] = configToStore
     }
 
     internal fun getFolderConfig(folderPath: String): FolderConfig {
-        val normalizedPath = Paths.get(folderPath).normalize().toAbsolutePath().toString()
-        val folderConfig = configs[normalizedPath] ?: createEmpty(normalizedPath)
+        val normalizedAbsolutePath = Paths.get(folderPath).normalize().toAbsolutePath().toString()
+        val folderConfig = configs[normalizedAbsolutePath] ?: createEmpty(normalizedAbsolutePath)
         return folderConfig
     }
 
-    private fun createEmpty(folderPath: String): FolderConfig {
-        val folderConfig = FolderConfig(folderPath = folderPath, baseBranch = "main")
-        addFolderConfig(folderConfig)
-        return folderConfig
+    private fun createEmpty(normalizedAbsolutePath: String): FolderConfig {
+        val newConfig = FolderConfig(folderPath = normalizedAbsolutePath, baseBranch = "main")
+        // Directly add to map, as addFolderConfig would re-normalize and copy, which is redundant here
+        // since normalizedAbsolutePath is already what we want for the key and the object's path.
+        configs[normalizedAbsolutePath] = newConfig
+        return newConfig
     }
 
     fun getAll(): Map<String, FolderConfig> {

--- a/src/main/kotlin/snyk/common/lsp/settings/FolderConfigSettings.kt
+++ b/src/main/kotlin/snyk/common/lsp/settings/FolderConfigSettings.kt
@@ -7,6 +7,7 @@ import io.snyk.plugin.getContentRootPaths
 import org.jetbrains.annotations.NotNull
 import snyk.common.lsp.FolderConfig
 import snyk.common.lsp.LanguageServerWrapper
+import java.nio.file.Paths
 import java.util.concurrent.ConcurrentHashMap
 import java.util.stream.Collectors
 
@@ -18,11 +19,13 @@ class FolderConfigSettings {
     @Suppress("UselessCallOnNotNull", "USELESS_ELVIS", "UNNECESSARY_SAFE_CALL", "RedundantSuppression")
     fun addFolderConfig(@NotNull folderConfig: FolderConfig) {
         if (folderConfig?.folderPath.isNullOrBlank() ?: true) return
-        configs[folderConfig.folderPath] = folderConfig
+        val normalizedPath = Paths.get(folderConfig.folderPath).normalize().toAbsolutePath().toString()
+        configs[normalizedPath] = folderConfig
     }
 
     internal fun getFolderConfig(folderPath: String): FolderConfig {
-        val folderConfig = configs[folderPath] ?: createEmpty(folderPath)
+        val normalizedPath = Paths.get(folderPath).normalize().toAbsolutePath().toString()
+        val folderConfig = configs[normalizedPath] ?: createEmpty(normalizedPath)
         return folderConfig
     }
 

--- a/src/main/kotlin/snyk/common/lsp/settings/FolderConfigSettings.kt
+++ b/src/main/kotlin/snyk/common/lsp/settings/FolderConfigSettings.kt
@@ -2,8 +2,8 @@ package snyk.common.lsp.settings
 
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.project.Project
+import io.snyk.plugin.fromUriToPath
 import io.snyk.plugin.getContentRootPaths
-import io.snyk.plugin.toFilePathString
 import org.jetbrains.annotations.NotNull
 import snyk.common.lsp.FolderConfig
 import snyk.common.lsp.LanguageServerWrapper
@@ -58,7 +58,7 @@ class FolderConfigSettings {
         val additionalParameters = LanguageServerWrapper.getInstance().getWorkspaceFoldersFromRoots(project)
             .asSequence()
             .filter { LanguageServerWrapper.getInstance().configuredWorkspaceFolders.contains(it) }
-            .map { getFolderConfig(it.uri.toFilePathString()) }
+            .map { getFolderConfig(it.uri.fromUriToPath().toString()) }
             .filter { it.additionalParameters?.isNotEmpty() ?: false }
             .map { it.additionalParameters?.joinToString(" ") }
             .joinToString(" ")

--- a/src/main/kotlin/snyk/trust/TrustedProjects.kt
+++ b/src/main/kotlin/snyk/trust/TrustedProjects.kt
@@ -4,7 +4,6 @@ package snyk.trust
 
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.invokeAndWaitIfNeeded
-import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project

--- a/src/main/resources/html/ScanSummaryInit.html
+++ b/src/main/resources/html/ScanSummaryInit.html
@@ -39,13 +39,10 @@
   ${ideStyle}
 </head>
 <body>
-  <div class="snx-header">
-    <h1 class="snx-title snx-h1">Snyk Security is loading...</h1>
-  </div>
   <div class="snx-summary">
     <div class="snx-status">
       <span class="snx-loader"></span>
-      <p class="snx-message">Waiting for the Snyk CLI to be downloaded and the Language Server to be initialized. </p>
+      <p class="snx-message">Snyk Security is loading...</p>
     </div>
   </div>
 </body>

--- a/src/test/kotlin/io/snyk/plugin/UtilsKtTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/UtilsKtTest.kt
@@ -29,13 +29,27 @@ class UtilsKtTest {
     }
 
     @Test
-    fun toLanguageServerURL() {
+    fun `toLanguageServerURL (windows)`() {
+        unmockkAll()
+        if (!SystemUtils.IS_OS_WINDOWS) return
         val path = "C:\\Users\\username\\file.txt"
         val virtualFile = mockk<VirtualFile>()
         every { virtualFile.path } returns path
 
         assertEquals("file:///C:/Users/username/file.txt", virtualFile.toLanguageServerURI())
     }
+
+    @Test
+    fun `toLanguageServerURL (posix)`() {
+        unmockkAll()
+        if (SystemUtils.IS_OS_WINDOWS) return
+        val path = "/Users/username/file.txt"
+        val virtualFile = mockk<VirtualFile>()
+        every { virtualFile.path } returns path
+
+        assertEquals("file:///Users/username/file.txt", virtualFile.toLanguageServerURI())
+    }
+
 
     @Test
     fun isAdditionalParametersValid() {

--- a/src/test/kotlin/io/snyk/plugin/UtilsKtTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/UtilsKtTest.kt
@@ -30,18 +30,11 @@ class UtilsKtTest {
 
     @Test
     fun toLanguageServerURL() {
-        val path = "C:/Users/username/file.txt"
-        var uri = "file://$path"
-        var virtualFile = mockk<VirtualFile>()
-        every { virtualFile.url } returns uri
+        val path = "C:\\Users\\username\\file.txt"
+        val virtualFile = mockk<VirtualFile>()
+        every { virtualFile.path } returns path
 
-        assertEquals("file:///$path", virtualFile.toLanguageServerURI())
-
-        uri = "file:///$path"
-        virtualFile = mockk<VirtualFile>()
-        every { virtualFile.url } returns uri
-
-        assertEquals("file:///$path", virtualFile.toLanguageServerURI())
+        assertEquals("file:///C:/Users/username/file.txt", virtualFile.toLanguageServerURI())
     }
 
     @Test

--- a/src/test/kotlin/io/snyk/plugin/UtilsKtTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/UtilsKtTest.kt
@@ -55,12 +55,16 @@ class UtilsKtTest {
         unmockkAll()
         if (SystemUtils.IS_OS_WINDOWS) return
         val expectedPaths = arrayOf(
-            "/Users/username/file.txt", // Valid path
-            "/Users/user name/file.txt", // Valid path
+            "/Users/username/file.txt",
+            "/Users/Username/file.txt",
+            "/Users/user name/file.txt",
+            "/Users/user name/hyphenated - folder/file.txt",
         )
         val inputUris = arrayOf(
-            "file:///Users/username/file.txt", // Invalid URI
-            "file:///Users/user%20name/file.txt", // Invalid URI
+            "file:///Users/username/file.txt", // URI
+            "file:///Users/Username/file.txt", // URI
+            "file:///Users/user%20name/file.txt", // URI with space
+            "file:///Users/user%20name/hyphenated%20-%20folder/file.txt", // URI with hyphen and space
         )
 
 
@@ -79,16 +83,20 @@ class UtilsKtTest {
         if (!SystemUtils.IS_OS_WINDOWS) return
         val expectedPaths = arrayOf(
             "C:\\Users\\username\\file.txt", // Valid path
+            "c:\\Users\\username\\file.txt", // Valid path
             "C:\\Users\\username with spaces\\file.txt", // Valid path
+            "C:\\Users\\username with hyphenated - spaces\\file.txt", // Valid path
             "C:\\Users\\username with \$peci@l characters\\file.txt", // Valid path
-            "\\\\my server\\shared folder\\file name with spaces & special%.txt"
+            "\\\\myserver\\shared folder\\file name with spaces \$peci@l%.txt"
         )
 
         val inputUris = arrayOf(
             "file:///C:/Users/username/file.txt", // Valid URI
+            "file:///c:/Users/username/file.txt", // Valid URI
             "file:///C:/Users/username%20with%20spaces/file.txt", // Valid URI
-            "file:///C:/Users/username%20with%20%24peci@l%20characters/file.txt", // Valid URI
-            "file://my%20server/shared%20folder/file%20name%20with%20spaces%20%26%20special%25.txt" // UNC
+            "file:///C:/Users/username%20with%20hyphenated%20-%20spaces/file.txt", // Valid URI
+            "file:///C:/Users/username%20with%20\$peci@l%20characters/file.txt", // Valid URI
+            "file://myserver/shared%20folder/file%20name%20with%20spaces%20\$peci@l%25.txt" // UNC
         )
 
         var i = 0

--- a/src/test/kotlin/io/snyk/plugin/UtilsKtTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/UtilsKtTest.kt
@@ -9,10 +9,10 @@ import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
 import org.apache.commons.lang3.SystemProperties
+import org.apache.commons.lang3.SystemUtils
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
-import java.io.File
 
 class UtilsKtTest {
 
@@ -51,47 +51,52 @@ class UtilsKtTest {
     }
 
     @Test
-    fun toFilePathString() {
-
-        // Windows files
-        var pathsToTest = arrayOf(
-            "C:\\Users\\username\\file.txt", // Valid path with Windows style separators
-            "c:\\Users\\username\\file.txt", // Valid path with Windows style separators and a lowercase drive letter
-            "C:/Users/username/file.txt", // Valid path with Unix style separators
-            "C:\\Users\\.\\username\\..\\username\\file.txt", // valid path with extra relative sub paths
-            "file:///C:/Users/username/file.txt", // Valid URI with blank host
-            "file:///c:/Users/username/file.txt", // Valid URI with blank host and a lowercase drive letter
-            "file:/C:/Users/username/file.txt", // Valid URI with no host
-            "file:///C:/Users/./username/../username/file.txt", // Valid URI and extra relative sub paths
-            "file://C:/Users/username/file.txt", // Invalid URI
-            "file://C:\\Users\\username\\file.txt", // Invalid URI
+    fun `conversion between path and uri - ensure we can convert a URI to a path and back (posix)`() {
+        unmockkAll()
+        if (SystemUtils.IS_OS_WINDOWS) return
+        val expectedPaths = arrayOf(
+            "/Users/username/file.txt", // Valid path
+            "/Users/user name/file.txt", // Valid path
+        )
+        val inputUris = arrayOf(
+            "file:///Users/username/file.txt", // Invalid URI
+            "file:///Users/user%20name/file.txt", // Invalid URI
         )
 
-        var expectedPath = "C:\\Users\\username\\file.txt"
-        var expectedUri = "file:///C:/Users/username/file.txt"
 
-        for (path in pathsToTest) {
-            assertEquals("Testing path $path normalization", expectedPath, path.toFilePathString())
-            assertEquals("Testing path $path URI conversion", expectedUri, path.toFileURIString())
+        var i = 0
+        for (uri in inputUris) {
+            val actualPath = uri.fromUriToPath().toString()
+            assertEquals("Testing $uri to path conversion", expectedPaths[i], actualPath)
+            assertEquals("Testing $actualPath to uri conversion", uri, actualPath.fromPathToUriString())
+            i++
         }
+    }
 
-        // Unix style files
-        pathsToTest = arrayOf(
-            "\\users\\username\\file.txt", // Valid path with Windows style separators
-            "/users/username/file.txt", // Valid path with Unix style separators
-            "/users/./username/../username/file.txt", // valid path with extra relative sub paths
-            "file:///users/username/file.txt", // Valid path with scheme
-            "file:/users/username/file.txt", // Valid path with scheme
-            "file:///users/./username/../username/file.txt", // Valid path with scheme and extra relative sub paths
-            "file://users/username/file.txt", // Invalid path with scheme.
+    @Test
+    fun `conversion between path and uri - ensure we can convert a URI to a path and back (windows)`() {
+        unmockkAll()
+        if (!SystemUtils.IS_OS_WINDOWS) return
+        val expectedPaths = arrayOf(
+            "C:\\Users\\username\\file.txt", // Valid path
+            "C:\\Users\\username with spaces\\file.txt", // Valid path
+            "C:\\Users\\username with \$peci@l characters\\file.txt", // Valid path
+            "\\\\my server\\shared folder\\file name with spaces & special%.txt"
         )
 
-        expectedPath = "/users/username/file.txt"
-        expectedUri = "file:///users/username/file.txt"
+        val inputUris = arrayOf(
+            "file:///C:/Users/username/file.txt", // Valid URI
+            "file:///C:/Users/username%20with%20spaces/file.txt", // Valid URI
+            "file:///C:/Users/username%20with%20%24peci@l%20characters/file.txt", // Valid URI
+            "file://my%20server/shared%20folder/file%20name%20with%20spaces%20%26%20special%25.txt" // UNC
+        )
 
-        for (path in pathsToTest) {
-            assertEquals("Testing path $path normalization", expectedPath, path.toFilePathString())
-            assertEquals("Testing path $path URI conversion", expectedUri, path.toFileURIString())
+        var i = 0
+        for (uri in inputUris) {
+            val actualPath = uri.fromUriToPath().toString()
+            assertEquals("Testing $uri to path conversion", expectedPaths[i], actualPath)
+            assertEquals("Testing $actualPath to uri conversion", uri, actualPath.fromPathToUriString())
+            i++
         }
     }
 }

--- a/src/test/kotlin/io/snyk/plugin/ui/ReferenceChooserDialogTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/ReferenceChooserDialogTest.kt
@@ -9,7 +9,6 @@ import io.mockk.mockk
 import io.mockk.unmockkAll
 import io.mockk.verify
 import io.snyk.plugin.getContentRootPaths
-import io.snyk.plugin.toFilePathString
 import org.eclipse.lsp4j.DidChangeConfigurationParams
 import org.eclipse.lsp4j.WorkspaceFolder
 import org.eclipse.lsp4j.services.LanguageServer
@@ -34,7 +33,7 @@ class ReferenceChooserDialogTest : LightPlatform4TestCase() {
         languageServerWrapper.languageServer = lsMock
 
         project.getContentRootPaths().forEach {
-            val absolutePathString = it.toString().toFilePathString()
+            val absolutePathString = it.toString()
             service<WorkspaceTrustSettings>().addTrustedPath(absolutePathString)
             folderConfig = FolderConfig(absolutePathString, "testBranch")
             service<FolderConfigSettings>().addFolderConfig(folderConfig)

--- a/src/test/kotlin/io/snyk/plugin/ui/ReferenceChooserDialogTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/ReferenceChooserDialogTest.kt
@@ -8,6 +8,7 @@ import io.mockk.CapturingSlot
 import io.mockk.mockk
 import io.mockk.unmockkAll
 import io.mockk.verify
+import io.snyk.plugin.fromPathToUriString
 import io.snyk.plugin.getContentRootPaths
 import org.eclipse.lsp4j.DidChangeConfigurationParams
 import org.eclipse.lsp4j.WorkspaceFolder
@@ -37,7 +38,7 @@ class ReferenceChooserDialogTest : LightPlatform4TestCase() {
             service<WorkspaceTrustSettings>().addTrustedPath(absolutePathString)
             folderConfig = FolderConfig(absolutePathString, "testBranch")
             service<FolderConfigSettings>().addFolderConfig(folderConfig)
-            languageServerWrapper.configuredWorkspaceFolders.add(WorkspaceFolder(absolutePathString, "test"))
+            languageServerWrapper.configuredWorkspaceFolders.add(WorkspaceFolder(absolutePathString.fromPathToUriString(), "test"))
             languageServerWrapper.folderConfigsRefreshed[folderConfig.folderPath] = true
         }
         cut = ReferenceChooserDialog(project)

--- a/src/test/kotlin/io/snyk/plugin/ui/ReferenceChooserDialogTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/ReferenceChooserDialogTest.kt
@@ -34,12 +34,12 @@ class ReferenceChooserDialogTest : LightPlatform4TestCase() {
         languageServerWrapper.languageServer = lsMock
 
         project.getContentRootPaths().forEach {
-            val absolutePathString = it.toAbsolutePath().toString()
+            val absolutePathString = it.toAbsolutePath().normalize().toString()
             service<WorkspaceTrustSettings>().addTrustedPath(absolutePathString)
             folderConfig = FolderConfig(absolutePathString, "testBranch")
             service<FolderConfigSettings>().addFolderConfig(folderConfig)
             languageServerWrapper.configuredWorkspaceFolders.add(WorkspaceFolder(absolutePathString.fromPathToUriString(), "test"))
-            languageServerWrapper.updateFolderConfigRefresh(folderConfig.folderPath, true)
+            languageServerWrapper.updateFolderConfigRefresh(absolutePathString, true)
         }
         cut = ReferenceChooserDialog(project)
     }

--- a/src/test/kotlin/io/snyk/plugin/ui/ReferenceChooserDialogTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/ReferenceChooserDialogTest.kt
@@ -34,7 +34,7 @@ class ReferenceChooserDialogTest : LightPlatform4TestCase() {
         languageServerWrapper.languageServer = lsMock
 
         project.getContentRootPaths().forEach {
-            val absolutePathString = it.toString()
+            val absolutePathString = it.toAbsolutePath().toString()
             service<WorkspaceTrustSettings>().addTrustedPath(absolutePathString)
             folderConfig = FolderConfig(absolutePathString, "testBranch")
             service<FolderConfigSettings>().addFolderConfig(folderConfig)

--- a/src/test/kotlin/io/snyk/plugin/ui/ReferenceChooserDialogTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/ReferenceChooserDialogTest.kt
@@ -39,7 +39,7 @@ class ReferenceChooserDialogTest : LightPlatform4TestCase() {
             folderConfig = FolderConfig(absolutePathString, "testBranch")
             service<FolderConfigSettings>().addFolderConfig(folderConfig)
             languageServerWrapper.configuredWorkspaceFolders.add(WorkspaceFolder(absolutePathString.fromPathToUriString(), "test"))
-            languageServerWrapper.folderConfigsRefreshed[folderConfig.folderPath] = true
+            languageServerWrapper.updateFolderConfigRefresh(folderConfig.folderPath, true)
         }
         cut = ReferenceChooserDialog(project)
     }

--- a/src/test/kotlin/snyk/common/lsp/settings/FolderConfigSettingsTest.kt
+++ b/src/test/kotlin/snyk/common/lsp/settings/FolderConfigSettingsTest.kt
@@ -1,0 +1,169 @@
+package snyk.common.lsp.settings
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import snyk.common.lsp.FolderConfig
+import java.nio.file.Paths
+
+class FolderConfigSettingsTest {
+
+    private lateinit var settings: FolderConfigSettings
+
+    @Before
+    fun setUp() {
+        settings = FolderConfigSettings()
+        settings.clear()
+    }
+
+    @Test
+    fun `addFolderConfig stores and getFolderConfig retrieves with simple path`() {
+        val path = "/test/projectA"
+        val normalizedPath = Paths.get(path).normalize().toAbsolutePath().toString()
+        val config = FolderConfig(
+            folderPath = path,
+            baseBranch = "main",
+            additionalParameters = listOf("--scan-all-unmanaged")
+        )
+
+        settings.addFolderConfig(config)
+
+        val retrievedConfig = settings.getFolderConfig(path)
+        assertNotNull("Retrieved config should not be null", retrievedConfig)
+        assertEquals("Normalized path should match", normalizedPath, retrievedConfig.folderPath)
+        assertEquals("Base branch should match", "main", retrievedConfig.baseBranch)
+        assertEquals("Additional parameters should match", listOf("--scan-all-unmanaged"), retrievedConfig.additionalParameters)
+
+        assertEquals("Settings map size should be 1", 1, settings.getAll().size)
+        assertTrue("Settings map should contain normalized path key", settings.getAll().containsKey(normalizedPath))
+    }
+
+    @Test
+    fun `addFolderConfig normalizes path with dot and double-dot segments`() {
+        val rawPath = "/test/projectB/./subfolder/../othersubfolder"
+        val expectedNormalizedPath = Paths.get(rawPath).normalize().toAbsolutePath().toString()
+
+        val config = FolderConfig(folderPath = rawPath, baseBranch = "develop")
+        settings.addFolderConfig(config)
+
+        val retrievedConfig = settings.getFolderConfig(rawPath)
+        assertNotNull("Retrieved config should not be null", retrievedConfig)
+        assertEquals("Normalized path should match", expectedNormalizedPath, retrievedConfig.folderPath)
+        assertEquals("Base branch should match", "develop", retrievedConfig.baseBranch)
+
+        val retrievedAgain = settings.getFolderConfig(expectedNormalizedPath)
+        assertNotNull("Retrieved again config should not be null", retrievedAgain)
+        assertEquals("Normalized path should match when retrieved again", expectedNormalizedPath, retrievedAgain.folderPath)
+    }
+
+    @Test
+    fun `getFolderConfig retrieves config using equivalent normalized paths`() {
+        val path1 = "/my/project/folder"
+        val path2 = "/my/project/./folder"
+        val path3 = "/my/project/../project/folder"
+        val normalizedPath1 = Paths.get(path1).normalize().toAbsolutePath().toString()
+
+        val config = FolderConfig(folderPath = path1, baseBranch = "feature-branch")
+        settings.addFolderConfig(config)
+
+        val retrievedConfig1 = settings.getFolderConfig(path1)
+        assertEquals("Path1 normalized path should match", normalizedPath1, retrievedConfig1.folderPath)
+        assertEquals("Path1 base branch should match", "feature-branch", retrievedConfig1.baseBranch)
+
+        val retrievedConfig2 = settings.getFolderConfig(path2)
+        assertEquals("Path2 normalized path should match", normalizedPath1, retrievedConfig2.folderPath)
+        assertEquals("Path2 base branch should match", "feature-branch", retrievedConfig2.baseBranch)
+
+        val retrievedConfig3 = settings.getFolderConfig(path3)
+        assertEquals("Path3 normalized path should match", normalizedPath1, retrievedConfig3.folderPath)
+        assertEquals("Path3 base branch should match", "feature-branch", retrievedConfig3.baseBranch)
+    }
+
+    @Test
+    fun `addFolderConfig ignores empty or blank folderPaths`() {
+        settings.addFolderConfig(FolderConfig(folderPath = "", baseBranch = "main"))
+        assertEquals("Config with empty path should be ignored", 0, settings.getAll().size)
+
+        settings.addFolderConfig(FolderConfig(folderPath = "   ", baseBranch = "main"))
+        assertEquals("Config with blank path should be ignored", 0, settings.getAll().size)
+    }
+
+    @Test
+    fun `getFolderConfig creates and stores new config if not found, with normalized path`() {
+        val rawPath = "/new/folder/./for/creation"
+        val expectedNormalizedPath = Paths.get(rawPath).normalize().toAbsolutePath().toString()
+
+        assertTrue("Settings should be empty initially", settings.getAll().isEmpty())
+
+        val newConfig = settings.getFolderConfig(rawPath)
+        assertNotNull("New config should not be null", newConfig)
+        assertEquals("FolderPath in new config should be normalized", expectedNormalizedPath, newConfig.folderPath)
+        assertEquals("New config should have default baseBranch", "main", newConfig.baseBranch)
+        assertEquals("New config additionalParameters should be emptyList", emptyList<String>(), newConfig.additionalParameters)
+        assertEquals("New config localBranches should be emptyList", emptyList<String>(), newConfig.localBranches)
+        assertEquals("New config referenceFolderPath should be empty string", "", newConfig.referenceFolderPath)
+        assertEquals("New config scanCommandConfig should be emptyMap", emptyMap<String, Any>(), newConfig.scanCommandConfig)
+
+        val allConfigs = settings.getAll()
+        assertEquals("A new config should have been added", 1, allConfigs.size)
+        assertTrue("Internal map should contain the new config with normalized path as key",
+            allConfigs.containsKey(expectedNormalizedPath))
+        assertEquals("Stored config folderPath should match", expectedNormalizedPath, allConfigs[expectedNormalizedPath]?.folderPath)
+    }
+
+    @Test
+    fun `addFolderConfig overwrites existing config with same normalized path`() {
+        val path = "/my/overwritable/folder"
+        val equivalentPath = "/my/overwritable/./folder/../folder"
+        val normalizedPath = Paths.get(path).normalize().toAbsolutePath().toString()
+
+        val config1 = FolderConfig(folderPath = path, baseBranch = "v1", additionalParameters = listOf("param1"))
+        settings.addFolderConfig(config1)
+
+        var retrieved = settings.getFolderConfig(path)
+        assertEquals("Retrieved v1 baseBranch", "v1", retrieved.baseBranch)
+        assertEquals("Retrieved v1 additionalParameters", listOf("param1"), retrieved.additionalParameters)
+        assertEquals("Retrieved v1 normalizedPath", normalizedPath, retrieved.folderPath)
+
+        val config2 = FolderConfig(folderPath = equivalentPath, baseBranch = "v2", additionalParameters = listOf("param2"))
+        settings.addFolderConfig(config2)
+
+        retrieved = settings.getFolderConfig(path)
+        assertEquals("BaseBranch should be from the overriding config", "v2", retrieved.baseBranch)
+        assertEquals("AdditionalParameters should be from the overriding config", listOf("param2"), retrieved.additionalParameters)
+        assertEquals("NormalizedPath should remain the same after overwrite", normalizedPath, retrieved.folderPath)
+
+        assertEquals("Should still be only one entry in settings map", 1, settings.getAll().size)
+    }
+
+    @Test
+    fun `paths are treated as case-sensitive by default by the underlying map`() {
+        val pathUpper = "/Case/Sensitive/Path"
+        val pathLower = "/case/sensitive/path"
+
+        val normalizedUpper = Paths.get(pathUpper).normalize().toAbsolutePath().toString()
+        val normalizedLower = Paths.get(pathLower).normalize().toAbsolutePath().toString()
+
+        val configUpper = FolderConfig(folderPath = pathUpper, baseBranch = "upper")
+        settings.addFolderConfig(configUpper)
+
+        val configLower = FolderConfig(folderPath = pathLower, baseBranch = "lower")
+        settings.addFolderConfig(configLower)
+
+        if (normalizedUpper.equals(normalizedLower, ignoreCase = true) && normalizedUpper != normalizedLower) {
+            assertEquals("Configs with paths differing only in case should be distinct if normalized strings differ", 2, settings.getAll().size)
+            assertEquals("BaseBranch for upper case path", "upper", settings.getFolderConfig(pathUpper).baseBranch)
+            assertEquals("BaseBranch for lower case path", "lower", settings.getFolderConfig(pathLower).baseBranch)
+        } else if (normalizedUpper == normalizedLower) {
+            assertEquals("If normalized paths are identical, one should overwrite the other", 1, settings.getAll().size)
+            assertEquals("Lower should overwrite if normalized paths are identical (upper retrieval)", "lower", settings.getFolderConfig(pathUpper).baseBranch)
+            assertEquals("Lower should overwrite if normalized paths are identical (lower retrieval)", "lower", settings.getFolderConfig(pathLower).baseBranch)
+        } else {
+            assertEquals("Distinct normalized paths should result in distinct entries", 2, settings.getAll().size)
+            assertEquals("BaseBranch for upper case path (distinct)", "upper", settings.getFolderConfig(pathUpper).baseBranch)
+            assertEquals("BaseBranch for lower case path (distinct)", "lower", settings.getFolderConfig(pathLower).baseBranch)
+        }
+    }
+}


### PR DESCRIPTION
### Description
This PR improves URI and file path handling within the Snyk IntelliJ Plugin, with a primary focus on ensuring consistent normalization and absolutization of folder paths, particularly in `FolderConfigSettings`. These changes enhance reliability and prevent issues related to inconsistent path representations across different operating systems and user inputs.

**Key Changes and Fixes:**

*   **Consistent Path Normalization in `FolderConfigSettings`:**
    *   Modified `FolderConfigSettings` to ensure that the `folderPath` property of stored `FolderConfig` objects is always the fully normalized and absolute path. This resolves inconsistencies where the stored path might not have matched the normalized key used in the internal map.
    *   `addFolderConfig` now stores a copy of the input `FolderConfig` with its `folderPath` explicitly set to the normalized, absolute version.
    *   `createEmpty` now directly instantiates `FolderConfig` with the (already normalized) path, improving clarity.
    *   Added `FolderConfigSettingsTest.kt` with comprehensive JUnit 4 unit tests to validate path normalization logic under various scenarios (e.g., paths with `.` and `..`, equivalent path strings).

*   **Improved URI/Path Conversion Utilities (`Utils.kt`):**
    *   Enhanced path and URI conversion functions (`toLanguageServerURI`, `fromUriToPath`, etc.) for better cross-platform compatibility, with specific improvements for Windows path handling (e.g., drive letters, URI encoding/decoding).
    *   Added extensive tests in `UtilsKtTest.kt` to cover various path and URI conversion scenarios on different OS paradigms.

*   **Language Server Initialization:**
    *   Improved error handling and logging during content root addition and LS initialization.
    *   Added user notifications for LS initialization failures.

*   **Other Fixes & Refinements:**
    *   Addressed minor issues in test setups and utility functions.
    *   Updated `CHANGELOG.md`.
    *   Changed startup message

**How to Test:**
*(Consider adding specific testing instructions here, e.g.,)*
1.  Verify that adding workspace folders with various path formats (e.g., `.` , `..`, symlinks if applicable) results in correct behavior and storage in Snyk settings.
2.  Test on both Windows and POSIX-like systems (macOS/Linux) to ensure path handling is consistent.
3.  Confirm that language server initialization is stable and provides appropriate feedback on errors.
4.  Run all unit tests, particularly `FolderConfigSettingsTest.kt` and `UtilsKtTest.kt`, to ensure they pass.

This PR aims to make the plugin's handling of file paths and URIs more robust and predictable, reducing potential errors and improving the user experience.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

![image](https://github.com/user-attachments/assets/833ae681-173a-47bd-9503-2524db5fe2f9)
