### PR TITLE
chore(ci): more RAM for security-scans [IDE-1286]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 
 jobs:
   security-scans:
-    resource_class: small
+    resource_class: medium+
     docker:
       - image: cimg/openjdk:21.0
     steps:


### PR DESCRIPTION
### Description

We were OoM'ing before: [example looking at the "Resources" tab](https://app.circleci.com/pipelines/github/snyk/snyk-intellij-plugin/1133/workflows/d6c78b1e-9afb-4932-9a9f-19f272ae0e0e/jobs/2240/resources).
I chose medium+, as we currently use about 3.36GB of RAM currently ([example](https://app.circleci.com/pipelines/github/snyk/snyk-intellij-plugin/1135/workflows/6e3e0661-d2c7-4f61-9a8d-9d0572034c98/jobs/2245/resources)), so it gives us a bit more buffer.

Class | vCPUs | RAM
-- | -- | --
small | 1 | 2GB
medium | 2 | 4GB
medium+ | 3 | 6GB
large | 4 | 8GB
xlarge | 8 | 16GB
2xlarge | 16 | 32GB
2xlarge+ | 20 | 40GB

From https://circleci.com/docs/configuration-reference/#docker-execution-environment

### Checklist

- [x] Tests added and all succeed
- [ ] Linted
 - N/A
- [ ] CHANGELOG.md updated
 - N/A
- [ ] README.md updated, if user-facing
 - N/A

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
