### PR TITLE
fix: added listener for reference folder changes

### DIFF
--- a/src/main/kotlin/io/snyk/plugin/ui/ReferenceChooserComboboxDialog.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/ReferenceChooserComboboxDialog.kt
@@ -88,7 +88,11 @@ class ReferenceChooserDialog(val project: Project) : DialogWrapper(true) {
             "Optional. Here you can specify a reference directory to be used for scanning."
 
         // Add change listener to track modifications
-        referenceFolder.addPropertyChangeListener("text") { hasChanges = true }
+        referenceFolder.textField.document.addDocumentListener(object : javax.swing.event.DocumentListener {
+            override fun insertUpdate(e: javax.swing.event.DocumentEvent?) { hasChanges = true }
+            override fun removeUpdate(e: javax.swing.event.DocumentEvent?) { hasChanges = true }
+            override fun changedUpdate(e: javax.swing.event.DocumentEvent?) { hasChanges = true }
+        })
 
         val descriptor = FileChooserDescriptor(
             false,


### PR DESCRIPTION
### Description

Now correctly listens to changes in the reference folder text fields and submits changes in folderconfigs to Snyk Language Server.


### Checklist

- [ ] Read and understood the [Code of Conduct](https://github.com/snyk/snyk-intellij-plugin/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/snyk-intellij-plugin/blob/master/CONTRIBUTING.md).
- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
