### PR TITLE
fix: edt usage for model tree node reload

### DIFF
--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
@@ -383,7 +383,10 @@ class SnykToolWindowPanel(
             securityIssuesCount = NODE_INITIAL_STATE,
             iacResultsCount = NODE_INITIAL_STATE,
         )
-        (vulnerabilitiesTree.model as DefaultTreeModel).reload()
+
+        invokeLater {
+            (vulnerabilitiesTree.model as DefaultTreeModel).reload()
+        }
 
         if (reDisplayDescription) {
             displayEmptyDescription()
@@ -399,8 +402,9 @@ class SnykToolWindowPanel(
             ),
     ) {
         rootNodesToUpdate.forEach {
-            if (it.childCount > 0) it.removeAllChildren()
-            (vulnerabilitiesTree.model as DefaultTreeModel).reload(it)
+            if (it.childCount > 0) {
+                it.removeAllChildren()
+            }
         }
     }
 


### PR DESCRIPTION
### Description

This PR ensures, the TreeNode reloads are done in the UI Thread, as required by IntelliJ 2025.2

### Checklist

- [ ] Read and understood the [Code of Conduct](https://github.com/snyk/snyk-intellij-plugin/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/snyk-intellij-plugin/blob/master/CONTRIBUTING.md).
- [ ] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
