### PR TITLE
fix: null pointer exception error fields [IDE-1581]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Snyk Security Changelog
 
+## [2.18.1]
+### Fixed
+- Fixed Agent Fix not applying edits for file paths containing spaces or special characters by properly handling URL-encoded URIs in workspace edit operations
+- Fixed inconsistent error handling in tree node text: OSS now checks for errors before scanning status (matching IAC and Code Security behavior)
+- Fixed IAC error display to filter out errors when no supported files are found, matching OSS behavior
 ## [2.18.0]
 ### Changed
 - Added organization configuration at project level

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
@@ -542,7 +542,7 @@ class SnykToolWindowPanel(
         addHMLPostfix: String
     ) = when {
         getSnykCachedResults(project)?.currentIacError != null -> {
-            val errorSuffix = getSnykCachedResults(project)!!.currentSnykCodeError!!.treeNodeSuffix
+            val errorSuffix = getSnykCachedResults(project)!!.currentIacError!!.treeNodeSuffix
             "$IAC_ROOT_TEXT $errorSuffix"
         }
         isIacRunning(project) && settings.iacScanEnabled -> "$IAC_ROOT_TEXT (scanning...)"
@@ -591,7 +591,7 @@ class SnykToolWindowPanel(
     ) = when {
         isOssRunning(project) && settings.ossScanEnable -> "$OSS_ROOT_TEXT (scanning...)"
         realError -> {
-            val errorSuffix = getSnykCachedResults(project)!!.currentSnykCodeError!!.treeNodeSuffix
+            val errorSuffix = getSnykCachedResults(project)!!.currentOssError!!.treeNodeSuffix
             "$OSS_ROOT_TEXT $errorSuffix"
         }
 

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
@@ -510,17 +510,19 @@ class SnykToolWindowPanel(
     ) {
         val settings = pluginSettings()
 
-        val realError =
+        val realOssError =
             getSnykCachedResults(project)?.currentOssError != null && ossResultsCount != NODE_NOT_SUPPORTED_STATE
+        val realIacError =
+            getSnykCachedResults(project)?.currentIacError != null && iacResultsCount != NODE_NOT_SUPPORTED_STATE
 
-        val newOssTreeNodeText = getNewOssTreeNodeText(settings, realError, ossResultsCount, addHMLPostfix)
+        val newOssTreeNodeText = getNewOssTreeNodeText(settings, realOssError, ossResultsCount, addHMLPostfix)
         newOssTreeNodeText?.let { rootOssTreeNode.userObject = it }
 
         val newSecurityIssuesNodeText =
             getNewSecurityIssuesNodeText(settings, securityIssuesCount, addHMLPostfix)
         newSecurityIssuesNodeText?.let { rootSecurityIssuesTreeNode.userObject = it }
 
-        val newIacTreeNodeText = getNewIacTreeNodeText(settings, iacResultsCount, addHMLPostfix)
+        val newIacTreeNodeText = getNewIacTreeNodeText(settings, realIacError, iacResultsCount, addHMLPostfix)
         newIacTreeNodeText?.let { rootIacIssuesTreeNode.userObject = it }
 
         val newRootTreeNodeText = getNewRootTreeNodeText()
@@ -538,10 +540,11 @@ class SnykToolWindowPanel(
 
     private fun getNewIacTreeNodeText(
         settings: SnykApplicationSettingsStateService,
+        realError: Boolean,
         iacResultsCount: Int?,
         addHMLPostfix: String
     ) = when {
-        getSnykCachedResults(project)?.currentIacError != null -> {
+        realError -> {
             val errorSuffix = getSnykCachedResults(project)!!.currentIacError!!.treeNodeSuffix
             "$IAC_ROOT_TEXT $errorSuffix"
         }
@@ -589,11 +592,11 @@ class SnykToolWindowPanel(
         ossResultsCount: Int?,
         addHMLPostfix: String
     ) = when {
-        isOssRunning(project) && settings.ossScanEnable -> "$OSS_ROOT_TEXT (scanning...)"
         realError -> {
             val errorSuffix = getSnykCachedResults(project)!!.currentOssError!!.treeNodeSuffix
             "$OSS_ROOT_TEXT $errorSuffix"
         }
+        isOssRunning(project) && settings.ossScanEnable -> "$OSS_ROOT_TEXT (scanning...)"
 
         else ->
             ossResultsCount?.let { count ->


### PR DESCRIPTION
### Description

In `getNewIacTreeNodeText`, when `currentIacError` is not null, the code tries to access `currentSnykCodeError` (line 545), which may be null, causing a NullPointerException. Similarly, in `getNewOssTreeNodeText` (line 594), when `realError` is true, it accesses `currentSnykCodeError` instead of `currentOssError`. Both should use the appropriate error field for their respective product types. @code-client-go/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt:544-545 @code-client-go/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt:593-594 

### Checklist

- [ ] Read and understood the [Code of Conduct](https://github.com/snyk/snyk-intellij-plugin/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/snyk-intellij-plugin/blob/master/CONTRIBUTING.md).
- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
