### PR TITLE
fix: handle URIs with encoded spaces in applyEdit [IDE-1555]

### DIFF
--- a/src/main/kotlin/snyk/common/editor/DocumentChanger.kt
+++ b/src/main/kotlin/snyk/common/editor/DocumentChanger.kt
@@ -1,12 +1,12 @@
 package snyk.common.editor
 
-import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.diagnostic.logger
 import io.snyk.plugin.getDocument
 import io.snyk.plugin.toVirtualFileOrNull
 import org.eclipse.lsp4j.TextEdit
 
 object DocumentChanger {
-    private val logger = Logger.getInstance("Snyk DocumentChanger")
+    private val logger = logger<DocumentChanger>()
 
     fun applyChange(change: Map.Entry<String, List<TextEdit>>?) {
         if (change == null) {
@@ -20,12 +20,8 @@ object DocumentChanger {
         // This converts the URI to a path first, which automatically decodes URL-encoded characters
         val virtualFile = fileURI.toVirtualFileOrNull()
         if (virtualFile == null) {
-            logger.warn("applyChange: Could not find VirtualFile for URI: $fileURI")
-            logger.debug("applyChange: URI contains spaces: ${fileURI.contains(" ")}")
-            logger.debug("applyChange: URI contains %20: ${fileURI.contains("%20")}")
             return
         }
-        logger.debug("applyChange: Found VirtualFile: ${virtualFile.path} for URI: $fileURI")
 
         val document = virtualFile.getDocument() ?: return
         // Our LS is coded to give us the TextEdits in ascending order, but we must apply them in descending order.

--- a/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
+++ b/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
@@ -160,6 +160,15 @@ class SnykLanguageClient(private val project: Project, val progressManager: Prog
         val falseFuture = CompletableFuture.completedFuture(ApplyWorkspaceEditResponse(false))
         if (disposed) return falseFuture
 
+        if (params?.edit?.changes != null) {
+            logger.debug("applyEdit: Received ${params.edit.changes.size} file change(s)")
+            params.edit.changes.forEach { (uri, edits) ->
+                logger.debug("applyEdit: URI: $uri (length: ${uri.length}), edit count: ${edits.size}")
+                logger.debug("applyEdit: URI contains space: ${uri.contains(" ")}")
+                logger.debug("applyEdit: URI contains %20: ${uri.contains("%20")}")
+            }
+        }
+
         WriteCommandAction.runWriteCommandAction(project) {
             params?.edit?.changes?.forEach {
                 DocumentChanger.applyChange(it)

--- a/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
+++ b/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
@@ -160,15 +160,6 @@ class SnykLanguageClient(private val project: Project, val progressManager: Prog
         val falseFuture = CompletableFuture.completedFuture(ApplyWorkspaceEditResponse(false))
         if (disposed) return falseFuture
 
-        if (params?.edit?.changes != null) {
-            logger.debug("applyEdit: Received ${params.edit.changes.size} file change(s)")
-            params.edit.changes.forEach { (uri, edits) ->
-                logger.debug("applyEdit: URI: $uri (length: ${uri.length}), edit count: ${edits.size}")
-                logger.debug("applyEdit: URI contains space: ${uri.contains(" ")}")
-                logger.debug("applyEdit: URI contains %20: ${uri.contains("%20")}")
-            }
-        }
-
         WriteCommandAction.runWriteCommandAction(project) {
             params?.edit?.changes?.forEach {
                 DocumentChanger.applyChange(it)


### PR DESCRIPTION
- Replace VirtualFileManager.findFileByUrl() with toVirtualFileOrNull() which properly decodes URL-encoded characters (e.g., %20 to spaces)
- Add debug logging to applyEdit and DocumentChanger to trace URI handling
- Fixes issue where applyEdit failed for paths containing spaces, dots, and underscores

The issue was that findFileByUrl() doesn't handle URL-encoded URIs. Using toVirtualFileOrNull() converts the URI to a path first, which automatically decodes %20 to spaces, then finds the file using the decoded path.

### Description

_Provide description of this PR and changes, if linked Jira ticket doesn't cover it in full._

### Checklist

- [ ] Read and understood the [Code of Conduct](https://github.com/snyk/snyk-intellij-plugin/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/snyk-intellij-plugin/blob/master/CONTRIBUTING.md).
- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
