### PR TITLE
fix: allow navigation to ranges in files which are not IDE documents [IDE-1781]

### DIFF
--- a/src/main/kotlin/io/snyk/plugin/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/Utils.kt
@@ -352,10 +352,13 @@ fun navigateToSource(
 ) {
   runAsync {
     if (project.isDisposed || !virtualFile.isValid) return@runAsync
-    val textLength = virtualFile.getDocument()?.textLength ?: return@runAsync
-    if (selectionStartOffset !in (0 until textLength)) {
+    // Check that the offset is valid. If not, log it and let PsiNavigationSupport handle it instead of returning early
+    // This can happen if the IDE does not consider the file to be a document (e.g., .gitleaksignore)
+    val document = virtualFile.getDocument()
+    val textLength = document?.textLength
+
+    if (textLength != null && selectionStartOffset !in (0 until textLength)) {
       logger.warn("Navigation to wrong offset: $selectionStartOffset with file length=$textLength")
-      return@runAsync
     }
 
     if (selectionStartOffset >= 0) {
@@ -373,7 +376,7 @@ fun navigateToSource(
       }
     }
 
-    if (selectionEndOffset != null) {
+    if (document != null && selectionEndOffset != null) {
       // highlight(by selection) suggestion range in source file
       invokeLater {
         if (project.isDisposed) return@invokeLater

--- a/src/main/kotlin/io/snyk/plugin/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/Utils.kt
@@ -355,10 +355,15 @@ fun navigateToSource(
     // Check that the offset is valid. If not, log it and let PsiNavigationSupport handle it instead of returning early
     // This can happen if the IDE does not consider the file to be a document (e.g., .gitleaksignore)
     val document = virtualFile.getDocument()
+
+    if (document == null) {
+      logger.warn("Cannot parse ${virtualFile.name} as a document; navigation to selection may fail")
+    }
+
     val textLength = document?.textLength
 
     if (textLength != null && selectionStartOffset !in (0 until textLength)) {
-      logger.warn("Navigation to wrong offset: $selectionStartOffset with file length=$textLength")
+      logger.warn("Navigation to wrong offset: $selectionStartOffset. ${virtualFile.name} file length=$textLength")
     }
 
     if (selectionStartOffset >= 0) {

--- a/src/main/kotlin/io/snyk/plugin/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/Utils.kt
@@ -352,18 +352,24 @@ fun navigateToSource(
 ) {
   runAsync {
     if (project.isDisposed || !virtualFile.isValid) return@runAsync
-    // Check that the offset is valid. If not, log it and let PsiNavigationSupport handle it instead of returning early
-    // This can happen if the IDE does not consider the file to be a document (e.g., .gitleaksignore)
+    // Check that the offset is valid. If not, log it and let PsiNavigationSupport handle it instead
+    // of returning early
+    // This can happen if the IDE does not consider the file to be a document (e.g.,
+    // .gitleaksignore)
     val document = virtualFile.getDocument()
 
     if (document == null) {
-      logger.warn("Cannot parse ${virtualFile.name} as a document; navigation to selection may fail")
+      logger.warn(
+        "Cannot parse ${virtualFile.name} as a document; navigation to selection may fail"
+      )
     }
 
     val textLength = document?.textLength
 
     if (textLength != null && selectionStartOffset !in (0 until textLength)) {
-      logger.warn("Navigation to wrong offset: $selectionStartOffset. ${virtualFile.name} file length=$textLength")
+      logger.warn(
+        "Navigation to wrong offset: $selectionStartOffset. ${virtualFile.name} file length=$textLength"
+      )
     }
 
     if (selectionStartOffset >= 0) {

--- a/src/test/kotlin/io/snyk/plugin/UtilsKtTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/UtilsKtTest.kt
@@ -325,12 +325,10 @@ class UtilsKtTest {
     every { appMock.isDisposed } returns false
     // Mock invokeLater to execute runnables immediately
     // The top-level invokeLater delegates to Application.invokeLater with ModalityState
-    every { appMock.invokeLater(any<Runnable>()) } answers {
-      firstArg<Runnable>().run()
-    }
-    every { appMock.invokeLater(any<Runnable>(), any<com.intellij.openapi.application.ModalityState>()) } answers {
-      firstArg<Runnable>().run()
-    }
+    every { appMock.invokeLater(any<Runnable>()) } answers { firstArg<Runnable>().run() }
+    every {
+      appMock.invokeLater(any<Runnable>(), any<com.intellij.openapi.application.ModalityState>())
+    } answers { firstArg<Runnable>().run() }
 
     val project = mockk<Project>(relaxed = true)
     every { project.isDisposed } returns false
@@ -366,12 +364,10 @@ class UtilsKtTest {
     val appMock = mockk<com.intellij.openapi.application.Application>(relaxed = true)
     every { ApplicationManager.getApplication() } returns appMock
     every { appMock.isDisposed } returns false
-    every { appMock.invokeLater(any<Runnable>()) } answers {
-      firstArg<Runnable>().run()
-    }
-    every { appMock.invokeLater(any<Runnable>(), any<com.intellij.openapi.application.ModalityState>()) } answers {
-      firstArg<Runnable>().run()
-    }
+    every { appMock.invokeLater(any<Runnable>()) } answers { firstArg<Runnable>().run() }
+    every {
+      appMock.invokeLater(any<Runnable>(), any<com.intellij.openapi.application.ModalityState>())
+    } answers { firstArg<Runnable>().run() }
 
     val project = mockk<Project>(relaxed = true)
     every { project.isDisposed } returns false

--- a/src/test/kotlin/io/snyk/plugin/UtilsKtTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/UtilsKtTest.kt
@@ -1,8 +1,10 @@
 package io.snyk.plugin
 
+import com.intellij.ide.util.PsiNavigationSupport
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.pom.Navigatable
 import com.intellij.util.messages.MessageBus
 import com.intellij.util.messages.Topic
 import io.mockk.every
@@ -309,6 +311,93 @@ class UtilsKtTest {
 
     // Should not have accessed messageBus.syncPublisher since application is disposed
     verify(exactly = 0) { messageBus.syncPublisher(any<Topic<TestListener>>()) }
+  }
+
+  @Test
+  fun `navigateToSource should still open file when getDocument returns null`() {
+    unmockkAll()
+    mockkStatic("io.snyk.plugin.UtilsKt")
+    mockkStatic(ApplicationManager::class)
+    mockkStatic(PsiNavigationSupport::class)
+
+    val appMock = mockk<com.intellij.openapi.application.Application>(relaxed = true)
+    every { ApplicationManager.getApplication() } returns appMock
+    every { appMock.isDisposed } returns false
+    // Mock invokeLater to execute runnables immediately
+    // The top-level invokeLater delegates to Application.invokeLater with ModalityState
+    every { appMock.invokeLater(any<Runnable>()) } answers {
+      firstArg<Runnable>().run()
+    }
+    every { appMock.invokeLater(any<Runnable>(), any<com.intellij.openapi.application.ModalityState>()) } answers {
+      firstArg<Runnable>().run()
+    }
+
+    val project = mockk<Project>(relaxed = true)
+    every { project.isDisposed } returns false
+
+    val virtualFile = mockk<VirtualFile>(relaxed = true)
+    every { virtualFile.isValid } returns true
+    // Simulate a file type that IntelliJ doesn't recognize (e.g., .gitleaksignore)
+    every { virtualFile.getDocument() } returns null
+
+    val latch = CountDownLatch(1)
+    val navigatable = mockk<Navigatable>(relaxed = true)
+    every { navigatable.canNavigateToSource() } returns true
+    every { navigatable.canNavigate() } returns true
+    every { navigatable.navigate(any()) } answers { latch.countDown() }
+
+    val psiNavSupport = mockk<PsiNavigationSupport>(relaxed = true)
+    every { PsiNavigationSupport.getInstance() } returns psiNavSupport
+    every { psiNavSupport.createNavigatable(project, virtualFile, 5) } returns navigatable
+
+    navigateToSource(project, virtualFile, 5, 10)
+
+    assertTrue("Navigation should complete within timeout", latch.await(2, TimeUnit.SECONDS))
+    verify { navigatable.navigate(false) }
+  }
+
+  @Test
+  fun `navigateToSource should still open file when offset is out of bounds`() {
+    unmockkAll()
+    mockkStatic("io.snyk.plugin.UtilsKt")
+    mockkStatic(ApplicationManager::class)
+    mockkStatic(PsiNavigationSupport::class)
+
+    val appMock = mockk<com.intellij.openapi.application.Application>(relaxed = true)
+    every { ApplicationManager.getApplication() } returns appMock
+    every { appMock.isDisposed } returns false
+    every { appMock.invokeLater(any<Runnable>()) } answers {
+      firstArg<Runnable>().run()
+    }
+    every { appMock.invokeLater(any<Runnable>(), any<com.intellij.openapi.application.ModalityState>()) } answers {
+      firstArg<Runnable>().run()
+    }
+
+    val project = mockk<Project>(relaxed = true)
+    every { project.isDisposed } returns false
+
+    val document = mockk<com.intellij.openapi.editor.Document>(relaxed = true)
+    every { document.textLength } returns 50
+
+    val virtualFile = mockk<VirtualFile>(relaxed = true)
+    every { virtualFile.isValid } returns true
+    every { virtualFile.getDocument() } returns document
+
+    // Offset 100 is beyond document length of 50
+    val latch = CountDownLatch(1)
+    val navigatable = mockk<Navigatable>(relaxed = true)
+    every { navigatable.canNavigateToSource() } returns true
+    every { navigatable.canNavigate() } returns true
+    every { navigatable.navigate(any()) } answers { latch.countDown() }
+
+    val psiNavSupport = mockk<PsiNavigationSupport>(relaxed = true)
+    every { PsiNavigationSupport.getInstance() } returns psiNavSupport
+    every { psiNavSupport.createNavigatable(project, virtualFile, 100) } returns navigatable
+
+    navigateToSource(project, virtualFile, 100, 110)
+
+    assertTrue("Navigation should complete within timeout", latch.await(2, TimeUnit.SECONDS))
+    verify { navigatable.navigate(false) }
   }
 
   interface TestListener {


### PR DESCRIPTION
### Description

The navigateToSource function used when a user clicks on an issue in the tree view previously validated the range by comparing to the length of the target file as an IDE document.

This mean that we were silently failing to navigate to files that the IDE could not process as a document (e.g., .gitleaksignore). The fix is to log the discrepancy and let the PsiNavigationSupport library handle it. The file will now open, even if the correct range cannot be determined.

Note that we expect that the ranges returned by the Secrets scanner should always be correct, so this was an overly defensive practice.

### Checklist

- [x] Read and understood the [Code of Conduct](https://github.com/snyk/snyk-intellij-plugin/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/snyk-intellij-plugin/blob/master/CONTRIBUTING.md).
- [x] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
