### PR TITLE
feat(IDE-1701): settings page auth flow — bridge persist and forward apiUrl

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,6 +47,10 @@ repositories {
   maven { url = uri("https://cache-redirector.jetbrains.com/intellij-dependencies") }
 }
 
+configurations.all {
+  resolutionStrategy.force("com.fasterxml.jackson.core:jackson-core:2.18.6")
+}
+
 dependencies {
   intellijPlatform {
     intellijIdeaCommunity(properties("platformVersion"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,9 +47,7 @@ repositories {
   maven { url = uri("https://cache-redirector.jetbrains.com/intellij-dependencies") }
 }
 
-configurations.all {
-  resolutionStrategy.force("com.fasterxml.jackson.core:jackson-core:2.18.6")
-}
+configurations.all { resolutionStrategy.force("com.fasterxml.jackson.core:jackson-core:2.18.6") }
 
 dependencies {
   intellijPlatform {

--- a/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
@@ -25,7 +25,7 @@ class SnykApplicationSettingsStateService :
   // events
   var pluginInstalledSent: Boolean = false
 
-  val requiredLsProtocolVersion = 25
+  val requiredLsProtocolVersion = 24
 
   @Deprecated("left for old users migration only") var useTokenAuthentication = false
   var authenticationType = AuthenticationType.OAUTH2

--- a/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
@@ -25,7 +25,7 @@ class SnykApplicationSettingsStateService :
   // events
   var pluginInstalledSent: Boolean = false
 
-  val requiredLsProtocolVersion = 24
+  val requiredLsProtocolVersion = 25
 
   @Deprecated("left for old users migration only") var useTokenAuthentication = false
   var authenticationType = AuthenticationType.OAUTH2

--- a/src/main/kotlin/io/snyk/plugin/settings/SnykProjectSettingsConfigurable.kt
+++ b/src/main/kotlin/io/snyk/plugin/settings/SnykProjectSettingsConfigurable.kt
@@ -117,7 +117,14 @@ class SnykProjectSettingsConfigurable(val project: Project) : SearchableConfigur
       settingsStateService.customEndpointUrl = customEndpoint
     }
 
-    settingsStateService.token = snykSettingsDialog.getToken()
+    // When the auth method changes, clear the stored token. The old token is incompatible
+    // with the new method and must not be forwarded to the LS via workspace/didChangeConfiguration,
+    // which would cause spurious "invalid credentials" notifications on the server side.
+    if (isAuthenticationMethodModified()) {
+      settingsStateService.token = ""
+    } else {
+      settingsStateService.token = snykSettingsDialog.getToken()
+    }
     settingsStateService.authenticationType = snykSettingsDialog.getAuthenticationType()
     settingsStateService.organization = snykSettingsDialog.getOrganization()
     settingsStateService.ignoreUnknownCA = snykSettingsDialog.isIgnoreUnknownCA()

--- a/src/main/kotlin/io/snyk/plugin/ui/SnykSettingsDialog.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/SnykSettingsDialog.kt
@@ -81,8 +81,7 @@ class SnykSettingsDialog(
   snykProjectSettingsConfigurable: SnykProjectSettingsConfigurable,
 ) {
   companion object {
-    @Volatile
-    var instance: SnykSettingsDialog? = null
+    @Volatile var instance: SnykSettingsDialog? = null
   }
 
   private val rootPanel =
@@ -250,15 +249,16 @@ class SnykSettingsDialog(
   fun getRootPanel(): JComponent = rootPanel
 
   fun updateAuthFields(token: String, apiUrl: String?) {
-    ApplicationManager.getApplication().invokeLater(
-      {
-        tokenTextField.text = token
-        if (!apiUrl.isNullOrBlank()) {
-          customEndpointTextField.text = apiUrl
-        }
-      },
-      com.intellij.openapi.application.ModalityState.any(),
-    )
+    ApplicationManager.getApplication()
+      .invokeLater(
+        {
+          tokenTextField.text = token
+          if (!apiUrl.isNullOrBlank()) {
+            customEndpointTextField.text = apiUrl
+          }
+        },
+        com.intellij.openapi.application.ModalityState.any(),
+      )
   }
 
   fun initializeFromSettings() {

--- a/src/main/kotlin/io/snyk/plugin/ui/SnykSettingsDialog.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/SnykSettingsDialog.kt
@@ -80,13 +80,20 @@ class SnykSettingsDialog(
   applicationSettings: SnykApplicationSettingsStateService,
   snykProjectSettingsConfigurable: SnykProjectSettingsConfigurable,
 ) {
+  companion object {
+    @Volatile
+    var instance: SnykSettingsDialog? = null
+  }
+
   private val rootPanel =
     object : JPanel(), Disposable {
       init {
         Disposer.register(SnykPluginDisposable.getInstance(project), this)
       }
 
-      override fun dispose() = Unit
+      override fun dispose() {
+        instance = null
+      }
     }
 
   private val alarm = Alarm(Alarm.ThreadToUse.POOLED_THREAD, rootPanel)
@@ -153,6 +160,7 @@ class SnykSettingsDialog(
   private val logger = Logger.getInstance(this::class.java)
 
   init {
+    instance = this
     initializeUiComponents()
     initializeValidation()
 
@@ -240,6 +248,18 @@ class SnykSettingsDialog(
   }
 
   fun getRootPanel(): JComponent = rootPanel
+
+  fun updateAuthFields(token: String, apiUrl: String?) {
+    ApplicationManager.getApplication().invokeLater(
+      {
+        tokenTextField.text = token
+        if (!apiUrl.isNullOrBlank()) {
+          customEndpointTextField.text = apiUrl
+        }
+      },
+      com.intellij.openapi.application.ModalityState.any(),
+    )
+  }
 
   fun initializeFromSettings() {
     val settings = pluginSettings()

--- a/src/main/kotlin/io/snyk/plugin/ui/jcef/ExecuteCommandBridge.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/jcef/ExecuteCommandBridge.kt
@@ -19,6 +19,12 @@ import snyk.common.lsp.LanguageServerWrapper
  * - Dispatch incoming command requests to the Language Server.
  * - Return results to the JS callback via `window.__ideCallbacks__`.
  */
+data class ExecuteCommandRequest(
+  val command: String = "",
+  val args: List<Any> = emptyList(),
+  val callbackId: String? = null,
+)
+
 class ExecuteCommandBridge(private val project: Project) {
   private val log = logger<ExecuteCommandBridge>()
   private val gson = Gson()
@@ -82,7 +88,7 @@ class ExecuteCommandBridge(private val project: Project) {
    */
   internal fun dispatch(value: String, callbackExecutor: ((String, String) -> Unit)? = null) {
     try {
-      val request = gson.fromJson(value, TreeViewCommandRequest::class.java)
+      val request = gson.fromJson(value, ExecuteCommandRequest::class.java)
       log.debug("ExecuteCommandBridge: received command=${request.command}, args=${request.args}")
       if (request.command.isBlank()) {
         log.warn("ExecuteCommandBridge: received empty command, ignoring")

--- a/src/main/kotlin/io/snyk/plugin/ui/jcef/ExecuteCommandBridge.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/jcef/ExecuteCommandBridge.kt
@@ -5,6 +5,8 @@ import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.ui.jcef.JBCefBrowserBase
 import com.intellij.ui.jcef.JBCefJSQuery
+import io.snyk.plugin.pluginSettings
+import io.snyk.plugin.services.AuthenticationType
 import org.jetbrains.concurrency.runAsync
 import snyk.common.lsp.LanguageServerWrapper
 
@@ -23,6 +25,9 @@ class ExecuteCommandBridge(private val project: Project) {
 
   companion object {
     internal val SAFE_CALLBACK_ID = Regex("^[a-zA-Z0-9_]+$")
+    // Login blocks until the user completes OAuth in the browser.
+    private const val LOGIN_TIMEOUT_MS = 120_000L
+    private val LONG_RUNNING_COMMANDS = setOf("snyk.login")
   }
 
   /**
@@ -90,7 +95,11 @@ class ExecuteCommandBridge(private val project: Project) {
       val ls = LanguageServerWrapper.getInstance(project)
       runAsync {
         try {
-          val result = ls.executeCommandWithArgs(request.command, request.args)
+          val timeout = if (request.command in LONG_RUNNING_COMMANDS) LOGIN_TIMEOUT_MS else 5_000L
+          if (request.command == "snyk.login" && request.args.size >= 3) {
+            saveLoginArgs(request.args)
+          }
+          val result = ls.executeCommandWithArgs(request.command, request.args, timeout)
           if (request.callbackId != null && callbackExecutor != null) {
             callbackExecutor(request.callbackId, gson.toJson(result))
           }
@@ -106,6 +115,26 @@ class ExecuteCommandBridge(private val project: Project) {
       }
     } catch (e: Exception) {
       log.warn("ExecuteCommandBridge: error parsing command request", e)
+    }
+  }
+
+  private fun saveLoginArgs(args: List<Any>) {
+    try {
+      val authMethodStr = args[0] as? String ?: return
+      val endpoint = args[1] as? String ?: ""
+      val ignoreUnknownCA = args[2] as? Boolean ?: false
+      val authType =
+        when (authMethodStr) {
+          "oauth" -> AuthenticationType.OAUTH2
+          "pat" -> AuthenticationType.PAT
+          "token" -> AuthenticationType.API_TOKEN
+          else -> AuthenticationType.OAUTH2
+        }
+      pluginSettings().authenticationType = authType
+      pluginSettings().customEndpointUrl = endpoint
+      pluginSettings().ignoreUnknownCA = ignoreUnknownCA
+    } catch (e: Exception) {
+      log.warn("ExecuteCommandBridge: error saving login args", e)
     }
   }
 }

--- a/src/main/kotlin/io/snyk/plugin/ui/jcef/ExecuteCommandBridge.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/jcef/ExecuteCommandBridge.kt
@@ -1,0 +1,111 @@
+package io.snyk.plugin.ui.jcef
+
+import com.google.gson.Gson
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
+import com.intellij.ui.jcef.JBCefBrowserBase
+import com.intellij.ui.jcef.JBCefJSQuery
+import org.jetbrains.concurrency.runAsync
+import snyk.common.lsp.LanguageServerWrapper
+
+/**
+ * Shared bridge for the `window.__ideExecuteCommand__` JS↔IDE contract. Used by both the HTML tree
+ * view and the HTML settings page.
+ *
+ * Responsibilities:
+ * - Inject the JS-side `window.__ideExecuteCommand__` bridge into a JCEF panel.
+ * - Dispatch incoming command requests to the Language Server.
+ * - Return results to the JS callback via `window.__ideCallbacks__`.
+ */
+class ExecuteCommandBridge(private val project: Project) {
+  private val log = logger<ExecuteCommandBridge>()
+  private val gson = Gson()
+
+  companion object {
+    internal val SAFE_CALLBACK_ID = Regex("^[a-zA-Z0-9_]+$")
+  }
+
+  /**
+   * Generates the JS that defines `window.__ideExecuteCommand__` in the webview. Must be called
+   * after each page load via `onLoadEnd`.
+   */
+  fun buildBridgeScript(executeCommandQuery: JBCefJSQuery): String =
+    """
+    (function() {
+        if (window.__ideExecuteCommand__) return;
+        window.__ideCallbacks__ = {};
+        var __cbCounter = 0;
+        window.__ideExecuteCommand__ = function(command, args, callback) {
+            var callbackId = null;
+            if (typeof callback === 'function') {
+                callbackId = '__cb_' + (++__cbCounter);
+                window.__ideCallbacks__[callbackId] = function(result) {
+                    delete window.__ideCallbacks__[callbackId];
+                    callback(result);
+                };
+            }
+            var payload = JSON.stringify({
+                command: command,
+                args: args || [],
+                callbackId: callbackId
+            });
+            ${executeCommandQuery.inject("payload")}
+        };
+    })();
+    """
+      .trimIndent()
+
+  /**
+   * Handles an incoming `JBCefJSQuery` value: dispatches the command and fires the JS callback.
+   * Intended for use as a `JBCefJSQuery.addHandler` body.
+   */
+  fun handleCommand(value: String, jbCefBrowser: JBCefBrowserBase): JBCefJSQuery.Response {
+    dispatch(value) { callbackId, escaped ->
+      jbCefBrowser.cefBrowser.executeJavaScript(
+        "if(window.__ideCallbacks__&&window.__ideCallbacks__['$callbackId'])" +
+          "{window.__ideCallbacks__['$callbackId']($escaped);}",
+        jbCefBrowser.cefBrowser.url,
+        0,
+      )
+    }
+    return JBCefJSQuery.Response("ok")
+  }
+
+  /**
+   * Parses a JSON command request, sends it to the Language Server, and invokes [callbackExecutor]
+   * with the result when finished.
+   */
+  internal fun dispatch(value: String, callbackExecutor: ((String, String) -> Unit)? = null) {
+    try {
+      val request = gson.fromJson(value, TreeViewCommandRequest::class.java)
+      log.debug("ExecuteCommandBridge: received command=${request.command}, args=${request.args}")
+      if (request.command.isBlank()) {
+        log.warn("ExecuteCommandBridge: received empty command, ignoring")
+        return
+      }
+      if (request.callbackId != null && !SAFE_CALLBACK_ID.matches(request.callbackId)) {
+        log.warn("ExecuteCommandBridge: invalid callbackId '${request.callbackId}', ignoring")
+        return
+      }
+      val ls = LanguageServerWrapper.getInstance(project)
+      runAsync {
+        try {
+          val result = ls.executeCommandWithArgs(request.command, request.args)
+          if (request.callbackId != null && callbackExecutor != null) {
+            callbackExecutor(request.callbackId, gson.toJson(result))
+          }
+        } catch (e: Exception) {
+          log.warn("ExecuteCommandBridge: error executing command ${request.command}", e)
+          if (request.callbackId != null && callbackExecutor != null) {
+            callbackExecutor(
+              request.callbackId,
+              gson.toJson(mapOf("error" to (e.message ?: "unknown error"))),
+            )
+          }
+        }
+      }
+    } catch (e: Exception) {
+      log.warn("ExecuteCommandBridge: error parsing command request", e)
+    }
+  }
+}

--- a/src/main/kotlin/io/snyk/plugin/ui/jcef/ExecuteCommandBridge.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/jcef/ExecuteCommandBridge.kt
@@ -88,6 +88,12 @@ class ExecuteCommandBridge(private val project: Project) {
         log.warn("ExecuteCommandBridge: received empty command, ignoring")
         return
       }
+      if (!request.command.startsWith("snyk.")) {
+        log.warn(
+          "ExecuteCommandBridge: webview attempted to execute disallowed command: ${request.command}"
+        )
+        return
+      }
       if (request.callbackId != null && !SAFE_CALLBACK_ID.matches(request.callbackId)) {
         log.warn("ExecuteCommandBridge: invalid callbackId '${request.callbackId}', ignoring")
         return

--- a/src/main/kotlin/io/snyk/plugin/ui/jcef/SaveConfigHandler.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/jcef/SaveConfigHandler.kt
@@ -8,7 +8,6 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.ui.jcef.JBCefBrowserBase
 import com.intellij.ui.jcef.JBCefJSQuery
-import io.snyk.plugin.events.SnykSettingsListener
 import io.snyk.plugin.getDefaultCliPath
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.services.AuthenticationType
@@ -104,35 +103,6 @@ class SaveConfigHandler(
       }
       JBCefJSQuery.Response("success")
     }
-
-    // Subscribe to settings changes to update auth token in browser
-    project.messageBus
-      .connect()
-      .subscribe(
-        SnykSettingsListener.SNYK_SETTINGS_TOPIC,
-        object : SnykSettingsListener {
-          override fun settingsChanged() {
-            // Defer JavaScript execution to avoid EDT blocking
-            invokeLater {
-              val token = pluginSettings().token
-              if (token?.isNotEmpty() == true) {
-                val escapedToken = token.replace("\\", "\\\\").replace("'", "\\'")
-                jbCefBrowser.cefBrowser.executeJavaScript(
-                  "if (typeof window.setAuthToken === 'function') { window.setAuthToken('$escapedToken'); }",
-                  jbCefBrowser.cefBrowser.url,
-                  0,
-                )
-              } else {
-                jbCefBrowser.cefBrowser.executeJavaScript(
-                  "if (typeof window.setAuthToken === 'function') { window.setAuthToken(''); }",
-                  jbCefBrowser.cefBrowser.url,
-                  0,
-                )
-              }
-            }
-          }
-        },
-      )
 
     executeCommandQuery.addHandler { value ->
       dispatchSettingsCommand(value) { callbackId, escaped ->

--- a/src/main/kotlin/io/snyk/plugin/ui/jcef/SaveConfigHandler.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/jcef/SaveConfigHandler.kt
@@ -10,16 +10,13 @@ import com.intellij.ui.jcef.JBCefBrowserBase
 import com.intellij.ui.jcef.JBCefJSQuery
 import io.snyk.plugin.events.SnykSettingsListener
 import io.snyk.plugin.getDefaultCliPath
-import io.snyk.plugin.getSnykCliAuthenticationService
 import io.snyk.plugin.pluginSettings
-import io.snyk.plugin.runInBackground
 import io.snyk.plugin.services.AuthenticationType
 import io.snyk.plugin.services.SnykApplicationSettingsStateService
 import java.nio.file.Paths
 import org.cef.browser.CefBrowser
 import org.cef.browser.CefFrame
 import org.cef.handler.CefLoadHandlerAdapter
-import snyk.common.lsp.LanguageServerWrapper
 import snyk.common.lsp.settings.FolderConfigSettings
 import snyk.trust.WorkspaceTrustService
 
@@ -31,6 +28,14 @@ class SaveConfigHandler(
 ) {
   private val logger = Logger.getInstance(SaveConfigHandler::class.java)
   private val gson = GsonBuilder().create()
+  private val executeCommandBridge = ExecuteCommandBridge(project)
+
+  internal fun dispatchSettingsCommand(
+    value: String,
+    callbackExecutor: ((String, String) -> Unit)? = null,
+  ) {
+    executeCommandBridge.dispatch(value, callbackExecutor)
+  }
 
   fun generateSaveConfigHandler(
     jbCefBrowser: JBCefBrowserBase,
@@ -38,9 +43,8 @@ class SaveConfigHandler(
   ): CefLoadHandlerAdapter {
     val saveConfigQuery = JBCefJSQuery.create(jbCefBrowser)
     val saveAttemptFinishedQuery = JBCefJSQuery.create(jbCefBrowser)
-    val loginQuery = JBCefJSQuery.create(jbCefBrowser)
-    val logoutQuery = JBCefJSQuery.create(jbCefBrowser)
     val onFormDirtyChangeQuery = JBCefJSQuery.create(jbCefBrowser)
+    val executeCommandQuery = JBCefJSQuery.create(jbCefBrowser)
 
     saveConfigQuery.addHandler { jsonString ->
       var response: JBCefJSQuery.Response
@@ -130,25 +134,24 @@ class SaveConfigHandler(
         },
       )
 
-    loginQuery.addHandler {
-      // Don't use runInBackground - authenticate() handles its own threading
-      getSnykCliAuthenticationService(project)?.authenticate()
-      JBCefJSQuery.Response("success")
-    }
-
-    logoutQuery.addHandler {
-      runInBackground("Snyk: logging out...") {
-        pluginSettings().token = ""
-        LanguageServerWrapper.getInstance(project).logout()
+    executeCommandQuery.addHandler { value ->
+      dispatchSettingsCommand(value) { callbackId, escaped ->
+        invokeLater {
+          jbCefBrowser.cefBrowser.executeJavaScript(
+            "if(window.__ideCallbacks__&&window.__ideCallbacks__['$callbackId'])" +
+              "{window.__ideCallbacks__['$callbackId']($escaped);}",
+            jbCefBrowser.cefBrowser.url,
+            0,
+          )
+        }
       }
-      JBCefJSQuery.Response("success")
+      JBCefJSQuery.Response("ok")
     }
 
     return object : CefLoadHandlerAdapter() {
       override fun onLoadEnd(browser: CefBrowser, frame: CefFrame, httpStatusCode: Int) {
         if (frame.isMain) {
-          // Inject IDE bridge functions
-          val script =
+          val configBridgeScript =
             """
                     (function() {
                         if (typeof window.__saveIdeConfig__ !== 'function') {
@@ -160,15 +163,14 @@ class SaveConfigHandler(
                         if (typeof window.__onFormDirtyChange__ !== 'function') {
                             window.__onFormDirtyChange__ = function(isDirty) { ${onFormDirtyChangeQuery.inject("String(isDirty)")} };
                         }
-                        if (typeof window.__ideLogin__ !== 'function') {
-                            window.__ideLogin__ = function() { ${loginQuery.inject("'login'")} };
-                        }
-                        if (typeof window.__ideLogout__ !== 'function') {
-                            window.__ideLogout__ = function() { ${logoutQuery.inject("'logout'")} };
-                        }
                     })();
                     """
-          browser.executeJavaScript(script, browser.url, 0)
+          browser.executeJavaScript(configBridgeScript, browser.url, 0)
+          browser.executeJavaScript(
+            executeCommandBridge.buildBridgeScript(executeCommandQuery),
+            browser.url,
+            0,
+          )
         }
       }
     }

--- a/src/main/kotlin/io/snyk/plugin/ui/jcef/TreeViewBridgeHandler.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/jcef/TreeViewBridgeHandler.kt
@@ -1,15 +1,11 @@
 package io.snyk.plugin.ui.jcef
 
-import com.google.gson.Gson
-import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.ui.jcef.JBCefBrowserBase
 import com.intellij.ui.jcef.JBCefJSQuery
 import org.cef.browser.CefBrowser
 import org.cef.browser.CefFrame
 import org.cef.handler.CefLoadHandlerAdapter
-import org.jetbrains.concurrency.runAsync
-import snyk.common.lsp.LanguageServerWrapper
 
 data class TreeViewCommandRequest(
   val command: String = "",
@@ -18,113 +14,29 @@ data class TreeViewCommandRequest(
 )
 
 class TreeViewBridgeHandler(private val project: Project) {
-  private val logger = logger<TreeViewBridgeHandler>()
-  private val gson = Gson()
-
-  companion object {
-    internal val ALLOWED_COMMANDS =
-      setOf(
-        "snyk.navigateToRange",
-        "snyk.toggleTreeFilter",
-        "snyk.getTreeViewIssueChunk",
-        "snyk.setNodeExpanded",
-        "snyk.showScanErrorDetails",
-        "snyk.updateFolderConfig",
-      )
-    private val SAFE_CALLBACK_ID = Regex("^[a-zA-Z0-9_]+$")
-  }
+  private val bridge = ExecuteCommandBridge(project)
 
   fun generate(jbCefBrowser: JBCefBrowserBase): CefLoadHandlerAdapter {
     val executeCommandQuery = JBCefJSQuery.create(jbCefBrowser)
-    executeCommandQuery.addHandler { value -> handleCommand(value, jbCefBrowser) }
+    executeCommandQuery.addHandler { value -> bridge.handleCommand(value, jbCefBrowser) }
 
     return object : CefLoadHandlerAdapter() {
       override fun onLoadEnd(browser: CefBrowser, frame: CefFrame, httpStatusCode: Int) {
         if (frame.isMain) {
-          browser.executeJavaScript(buildBridgeScript(executeCommandQuery), browser.url, 0)
+          browser.executeJavaScript(bridge.buildBridgeScript(executeCommandQuery), browser.url, 0)
         }
       }
     }
   }
 
-  internal fun handleCommand(value: String, jbCefBrowser: JBCefBrowserBase): JBCefJSQuery.Response {
-    dispatchCommand(value) { callbackId, escaped ->
-      jbCefBrowser.cefBrowser.executeJavaScript(
-        "if(window.__ideCallbacks__&&window.__ideCallbacks__['$callbackId'])" +
-          "{window.__ideCallbacks__['$callbackId']($escaped);}",
-        jbCefBrowser.cefBrowser.url,
-        0,
-      )
-    }
-    return JBCefJSQuery.Response("ok")
-  }
+  internal fun handleCommand(value: String, jbCefBrowser: JBCefBrowserBase): JBCefJSQuery.Response =
+    bridge.handleCommand(value, jbCefBrowser)
 
   internal fun dispatchCommand(
     value: String,
     callbackExecutor: ((String, String) -> Unit)? = null,
-  ) {
-    try {
-      val request = gson.fromJson(value, TreeViewCommandRequest::class.java)
-      logger.debug("TreeViewBridge: received command=${request.command}, args=${request.args}")
-      if (request.callbackId != null && !SAFE_CALLBACK_ID.matches(request.callbackId)) {
-        logger.warn("TreeViewBridge: invalid callbackId '${request.callbackId}', ignoring")
-        return
-      }
-      if (request.command !in ALLOWED_COMMANDS) {
-        logger.warn(
-          "TreeViewBridge: command '${request.command}' is not in the allowlist, ignoring"
-        )
-        if (request.callbackId != null && callbackExecutor != null) {
-          callbackExecutor(request.callbackId, gson.toJson(mapOf("error" to "command not allowed")))
-        }
-        return
-      }
-      val ls = LanguageServerWrapper.getInstance(project)
-      runAsync {
-        try {
-          val result = ls.executeCommandWithArgs(request.command, request.args)
-          if (request.callbackId != null && callbackExecutor != null) {
-            val escaped = gson.toJson(result)
-            callbackExecutor(request.callbackId, escaped)
-          }
-        } catch (e: Exception) {
-          logger.warn("TreeViewBridge: error executing command ${request.command}", e)
-          if (request.callbackId != null && callbackExecutor != null) {
-            callbackExecutor(
-              request.callbackId,
-              gson.toJson(mapOf("error" to (e.message ?: "unknown error"))),
-            )
-          }
-        }
-      }
-    } catch (e: Exception) {
-      logger.warn("TreeViewBridge: error parsing command request", e)
-    }
-  }
+  ) = bridge.dispatch(value, callbackExecutor)
 
   internal fun buildBridgeScript(executeCommandQuery: JBCefJSQuery): String =
-    """
-    (function() {
-        if (window.__ideExecuteCommand__) return;
-        window.__ideCallbacks__ = {};
-        var __cbCounter = 0;
-        window.__ideExecuteCommand__ = function(command, args, callback) {
-            var callbackId = null;
-            if (typeof callback === 'function') {
-                callbackId = '__cb_' + (++__cbCounter);
-                window.__ideCallbacks__[callbackId] = function(result) {
-                    delete window.__ideCallbacks__[callbackId];
-                    callback(result);
-                };
-            }
-            var payload = JSON.stringify({
-                command: command,
-                args: args || [],
-                callbackId: callbackId
-            });
-            ${executeCommandQuery.inject("payload")}
-        };
-    })();
-    """
-      .trimIndent()
+    bridge.buildBridgeScript(executeCommandQuery)
 }

--- a/src/main/kotlin/io/snyk/plugin/ui/jcef/TreeViewBridgeHandler.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/jcef/TreeViewBridgeHandler.kt
@@ -7,12 +7,6 @@ import org.cef.browser.CefBrowser
 import org.cef.browser.CefFrame
 import org.cef.handler.CefLoadHandlerAdapter
 
-data class TreeViewCommandRequest(
-  val command: String = "",
-  val args: List<Any> = emptyList(),
-  val callbackId: String? = null,
-)
-
 class TreeViewBridgeHandler(private val project: Project) {
   private val bridge = ExecuteCommandBridge(project)
 

--- a/src/main/kotlin/io/snyk/plugin/ui/settings/HTMLSettingsPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/settings/HTMLSettingsPanel.kt
@@ -33,6 +33,10 @@ import snyk.common.lsp.LanguageServerWrapper
 
 class HTMLSettingsPanel(private val project: Project) : JPanel(BorderLayout()), Disposable {
 
+  companion object {
+    @Volatile var instance: HTMLSettingsPanel? = null
+  }
+
   private val logger = Logger.getInstance(HTMLSettingsPanel::class.java)
   private var jbCefClient: JBCefClient? = null
   private var jbCefBrowser: JBCefBrowser? = null
@@ -48,6 +52,7 @@ class HTMLSettingsPanel(private val project: Project) : JPanel(BorderLayout()), 
     // Set panel background to match IDE theme (prevents white flash)
     background = UIUtil.getPanelBackground()
 
+    instance = this
     Disposer.register(SnykPluginDisposable.getInstance(project), this)
     initializePanel()
     subscribeToCliDownloadEvents()
@@ -393,8 +398,31 @@ class HTMLSettingsPanel(private val project: Project) : JPanel(BorderLayout()), 
     }
   }
 
+  fun setAuthToken(token: String, apiUrl: String?) {
+    if (isDisposed) return
+    ApplicationManager.getApplication()
+      .invokeLater(
+        {
+          if (isDisposed) return@invokeLater
+          val safeToken = token.replace("\\", "\\\\").replace("'", "\\'")
+          val safeApiUrl = (apiUrl ?: "").replace("\\", "\\\\").replace("'", "\\'")
+          jbCefBrowser
+            ?.cefBrowser
+            ?.executeJavaScript(
+              "if (typeof window.setAuthToken === 'function') { window.setAuthToken('$safeToken', '$safeApiUrl'); }",
+              jbCefBrowser?.cefBrowser?.url ?: "",
+              0,
+            )
+        },
+        ModalityState.any(),
+      )
+  }
+
   override fun dispose() {
     isDisposed = true
+    if (instance === this) {
+      instance = null
+    }
     disposeCurrentBrowser()
   }
 }

--- a/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
@@ -497,12 +497,12 @@ class LanguageServerWrapper(private val project: Project) : Disposable {
   private fun executeCommand(param: ExecuteCommandParams, timeoutMillis: Long = 5000): Any? =
     languageServer.workspaceService.executeCommand(param).get(timeoutMillis, TimeUnit.MILLISECONDS)
 
-  fun executeCommandWithArgs(command: String, args: List<Any>): Any? {
+  fun executeCommandWithArgs(command: String, args: List<Any>, timeoutMillis: Long = 5_000): Any? {
     if (!isInitialized) return null
     val param = ExecuteCommandParams()
     param.command = command
     param.arguments = args
-    return executeCommand(param)
+    return executeCommand(param, timeoutMillis)
   }
 
   fun sendFolderScanCommand(folder: String, project: Project) {

--- a/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
+++ b/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
@@ -36,6 +36,7 @@ import io.snyk.plugin.sha256
 import io.snyk.plugin.toVirtualFile
 import io.snyk.plugin.toVirtualFileOrNull
 import io.snyk.plugin.ui.SnykBalloonNotificationHelper
+import io.snyk.plugin.ui.settings.HTMLSettingsPanel
 import io.snyk.plugin.ui.toolwindow.SnykPluginDisposable
 import java.net.URI
 import java.util.concurrent.ArrayBlockingQueue
@@ -320,10 +321,6 @@ class SnykLanguageClient(private val project: Project, val progressManager: Prog
     val oldApiUrl = pluginSettings().customEndpointUrl
     if (oldToken == param.token && oldApiUrl == param.apiUrl) return
 
-    if (!param.apiUrl.isNullOrBlank()) {
-      pluginSettings().customEndpointUrl = param.apiUrl
-    }
-
     logger.info(
       "received authentication information: Token-Length: ${param.token?.length}}, URL: ${param.apiUrl}"
     )
@@ -331,6 +328,12 @@ class SnykLanguageClient(private val project: Project, val progressManager: Prog
     logger.debug("is same token?  ${oldToken == param.token}")
     logger.debug("old-token-hash: ${oldToken.sha256()}, new-token-hash: ${param.token?.sha256()}")
 
+    // Always inject into the webview so the settings page shows the token immediately.
+    HTMLSettingsPanel.instance?.setAuthToken(param.token ?: "", param.apiUrl)
+
+    if (!param.apiUrl.isNullOrBlank()) {
+      pluginSettings().customEndpointUrl = param.apiUrl
+    }
     pluginSettings().token = param.token
 
     // we use internal API here, as we need to force immediate persistence to ensure new

--- a/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
+++ b/src/main/kotlin/snyk/common/lsp/SnykLanguageClient.kt
@@ -36,6 +36,7 @@ import io.snyk.plugin.sha256
 import io.snyk.plugin.toVirtualFile
 import io.snyk.plugin.toVirtualFileOrNull
 import io.snyk.plugin.ui.SnykBalloonNotificationHelper
+import io.snyk.plugin.ui.SnykSettingsDialog
 import io.snyk.plugin.ui.settings.HTMLSettingsPanel
 import io.snyk.plugin.ui.toolwindow.SnykPluginDisposable
 import java.net.URI
@@ -328,8 +329,9 @@ class SnykLanguageClient(private val project: Project, val progressManager: Prog
     logger.debug("is same token?  ${oldToken == param.token}")
     logger.debug("old-token-hash: ${oldToken.sha256()}, new-token-hash: ${param.token?.sha256()}")
 
-    // Always inject into the webview so the settings page shows the token immediately.
+    // Always inject into both settings UIs so the settings page shows the token immediately.
     HTMLSettingsPanel.instance?.setAuthToken(param.token ?: "", param.apiUrl)
+    SnykSettingsDialog.instance?.updateAuthFields(param.token ?: "", param.apiUrl)
 
     if (!param.apiUrl.isNullOrBlank()) {
       pluginSettings().customEndpointUrl = param.apiUrl

--- a/src/main/kotlin/snyk/common/lsp/Types.kt
+++ b/src/main/kotlin/snyk/common/lsp/Types.kt
@@ -186,7 +186,7 @@ data class ScanIssue(
   fun longTitle(): String {
     val rangeBracket = "[${this.range.start.line + 1},${this.range.start.character}]"
     val packageInfo =
-      if (this.additionalData.packageName.isNotEmpty()) {
+      if (!this.additionalData.packageName.isNullOrEmpty()) {
         "${this.additionalData.packageName}@${this.additionalData.version}: "
       } else {
         ""

--- a/src/test/kotlin/io/snyk/plugin/ui/jcef/SaveConfigHandlerExecuteCommandTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/jcef/SaveConfigHandlerExecuteCommandTest.kt
@@ -11,6 +11,7 @@ import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.verify
 import io.snyk.plugin.pluginSettings
+import io.snyk.plugin.services.AuthenticationType
 import io.snyk.plugin.services.SnykApplicationSettingsStateService
 import io.snyk.plugin.ui.toolwindow.SnykPluginDisposable
 import java.util.concurrent.CountDownLatch
@@ -55,9 +56,9 @@ class SaveConfigHandlerExecuteCommandTest {
   @Test
   fun `dispatchSettingsCommand routes snyk login to language server with auth args`() {
     val request =
-      TreeViewCommandRequest(
+      ExecuteCommandRequest(
         command = "snyk.login",
-        args = listOf("oauth2", "https://api.snyk.io", false),
+        args = listOf("oauth", "https://api.snyk.io", false),
       )
     val payload = gson.toJson(request)
 
@@ -67,7 +68,7 @@ class SaveConfigHandlerExecuteCommandTest {
       verify {
         lsWrapperMock.executeCommandWithArgs(
           "snyk.login",
-          listOf("oauth2", "https://api.snyk.io", false),
+          listOf("oauth", "https://api.snyk.io", false),
           120_000L,
         )
       }
@@ -80,7 +81,7 @@ class SaveConfigHandlerExecuteCommandTest {
     every { pluginSettings() } returns settings
 
     val request =
-      TreeViewCommandRequest(
+      ExecuteCommandRequest(
         command = "snyk.login",
         args = listOf("pat", "https://api.eu.snyk.io", true),
       )
@@ -89,15 +90,68 @@ class SaveConfigHandlerExecuteCommandTest {
     handler.dispatchSettingsCommand(payload)
 
     await().atMost(2, TimeUnit.SECONDS).untilAsserted {
-      assertEquals(io.snyk.plugin.services.AuthenticationType.PAT, settings.authenticationType)
+      assertEquals(AuthenticationType.PAT, settings.authenticationType)
       assertEquals("https://api.eu.snyk.io", settings.customEndpointUrl)
       assertTrue(settings.ignoreUnknownCA)
     }
   }
 
   @Test
+  fun `dispatchSettingsCommand saves oauth auth type to plugin settings`() {
+    val settings = SnykApplicationSettingsStateService()
+    every { pluginSettings() } returns settings
+
+    val request =
+      ExecuteCommandRequest(
+        command = "snyk.login",
+        args = listOf("oauth", "https://api.snyk.io", false),
+      )
+    handler.dispatchSettingsCommand(gson.toJson(request))
+
+    await().atMost(2, TimeUnit.SECONDS).untilAsserted {
+      assertEquals(AuthenticationType.OAUTH2, settings.authenticationType)
+      assertEquals("https://api.snyk.io", settings.customEndpointUrl)
+      assertEquals(false, settings.ignoreUnknownCA)
+    }
+  }
+
+  @Test
+  fun `dispatchSettingsCommand saves token auth type to plugin settings`() {
+    val settings = SnykApplicationSettingsStateService()
+    every { pluginSettings() } returns settings
+
+    val request =
+      ExecuteCommandRequest(
+        command = "snyk.login",
+        args = listOf("token", "https://api.snyk.io", false),
+      )
+    handler.dispatchSettingsCommand(gson.toJson(request))
+
+    await().atMost(2, TimeUnit.SECONDS).untilAsserted {
+      assertEquals(AuthenticationType.API_TOKEN, settings.authenticationType)
+    }
+  }
+
+  @Test
+  fun `dispatchSettingsCommand defaults unknown auth method to OAUTH2`() {
+    val settings = SnykApplicationSettingsStateService()
+    every { pluginSettings() } returns settings
+
+    val request =
+      ExecuteCommandRequest(
+        command = "snyk.login",
+        args = listOf("unknown_method", "https://api.snyk.io", false),
+      )
+    handler.dispatchSettingsCommand(gson.toJson(request))
+
+    await().atMost(2, TimeUnit.SECONDS).untilAsserted {
+      assertEquals(AuthenticationType.OAUTH2, settings.authenticationType)
+    }
+  }
+
+  @Test
   fun `dispatchSettingsCommand routes snyk logout to language server`() {
-    val request = TreeViewCommandRequest(command = "snyk.logout", args = emptyList())
+    val request = ExecuteCommandRequest(command = "snyk.logout", args = emptyList())
     val payload = gson.toJson(request)
 
     handler.dispatchSettingsCommand(payload)
@@ -109,7 +163,7 @@ class SaveConfigHandlerExecuteCommandTest {
 
   @Test
   fun `dispatchSettingsCommand ignores empty command`() {
-    val request = TreeViewCommandRequest(command = "", args = emptyList())
+    val request = ExecuteCommandRequest(command = "", args = emptyList())
     val payload = gson.toJson(request)
 
     handler.dispatchSettingsCommand(payload)
@@ -128,9 +182,9 @@ class SaveConfigHandlerExecuteCommandTest {
     var receivedResult: String? = null
 
     val request =
-      TreeViewCommandRequest(
+      ExecuteCommandRequest(
         command = "snyk.login",
-        args = listOf("oauth2", "https://api.snyk.io", false),
+        args = listOf("oauth", "https://api.snyk.io", false),
         callbackId = "__cb_1",
       )
     val payload = gson.toJson(request)

--- a/src/test/kotlin/io/snyk/plugin/ui/jcef/SaveConfigHandlerExecuteCommandTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/jcef/SaveConfigHandlerExecuteCommandTest.kt
@@ -1,0 +1,132 @@
+package io.snyk.plugin.ui.jcef
+
+import com.google.gson.Gson
+import com.intellij.openapi.application.Application
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.project.Project
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import io.snyk.plugin.pluginSettings
+import io.snyk.plugin.services.SnykApplicationSettingsStateService
+import io.snyk.plugin.ui.toolwindow.SnykPluginDisposable
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import org.awaitility.Awaitility.await
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import snyk.common.lsp.LanguageServerWrapper
+
+class SaveConfigHandlerExecuteCommandTest {
+  private lateinit var handler: SaveConfigHandler
+  private val projectMock = mockk<Project>(relaxed = true)
+  private val applicationMock = mockk<Application>(relaxed = true)
+  private val lsWrapperMock = mockk<LanguageServerWrapper>(relaxed = true)
+  private val gson = Gson()
+
+  @Before
+  fun setUp() {
+    unmockkAll()
+    mockkStatic(ApplicationManager::class)
+    mockkStatic("io.snyk.plugin.UtilsKt")
+
+    every { ApplicationManager.getApplication() } returns applicationMock
+    every { applicationMock.getService(SnykPluginDisposable::class.java) } returns
+      SnykPluginDisposable()
+    every { pluginSettings() } returns SnykApplicationSettingsStateService()
+
+    mockkObject(LanguageServerWrapper.Companion)
+    every { LanguageServerWrapper.getInstance(projectMock) } returns lsWrapperMock
+
+    handler = SaveConfigHandler(projectMock, onModified = {})
+  }
+
+  @After
+  fun tearDown() {
+    unmockkAll()
+  }
+
+  @Test
+  fun `dispatchSettingsCommand routes snyk login to language server with auth args`() {
+    val request =
+      TreeViewCommandRequest(
+        command = "snyk.login",
+        args = listOf("oauth2", "https://api.snyk.io", false),
+      )
+    val payload = gson.toJson(request)
+
+    handler.dispatchSettingsCommand(payload)
+
+    await().atMost(2, TimeUnit.SECONDS).untilAsserted {
+      verify {
+        lsWrapperMock.executeCommandWithArgs(
+          "snyk.login",
+          listOf("oauth2", "https://api.snyk.io", false),
+        )
+      }
+    }
+  }
+
+  @Test
+  fun `dispatchSettingsCommand routes snyk logout to language server`() {
+    val request = TreeViewCommandRequest(command = "snyk.logout", args = emptyList())
+    val payload = gson.toJson(request)
+
+    handler.dispatchSettingsCommand(payload)
+
+    await().atMost(2, TimeUnit.SECONDS).untilAsserted {
+      verify { lsWrapperMock.executeCommandWithArgs("snyk.logout", emptyList()) }
+    }
+  }
+
+  @Test
+  fun `dispatchSettingsCommand ignores empty command`() {
+    val request = TreeViewCommandRequest(command = "", args = emptyList())
+    val payload = gson.toJson(request)
+
+    handler.dispatchSettingsCommand(payload)
+
+    await().atMost(2, TimeUnit.SECONDS).untilAsserted {
+      verify(exactly = 0) { lsWrapperMock.executeCommandWithArgs(any(), any()) }
+    }
+  }
+
+  @Test
+  fun `dispatchSettingsCommand invokes callback when callbackId present`() {
+    every { lsWrapperMock.executeCommandWithArgs("snyk.login", any()) } returns "auth-result"
+
+    val latch = CountDownLatch(1)
+    var receivedCallbackId: String? = null
+    var receivedResult: String? = null
+
+    val request =
+      TreeViewCommandRequest(
+        command = "snyk.login",
+        args = listOf("oauth2", "https://api.snyk.io", false),
+        callbackId = "__cb_1",
+      )
+    val payload = gson.toJson(request)
+
+    handler.dispatchSettingsCommand(payload) { callbackId, escaped ->
+      receivedCallbackId = callbackId
+      receivedResult = escaped
+      latch.countDown()
+    }
+
+    assertTrue("Callback should be invoked within timeout", latch.await(2, TimeUnit.SECONDS))
+    assertEquals("__cb_1", receivedCallbackId)
+    assertTrue(receivedResult!!.contains("auth-result"))
+  }
+
+  @Test
+  fun `dispatchSettingsCommand does not throw for malformed json`() {
+    handler.dispatchSettingsCommand("not-valid-json")
+    // should not throw
+  }
+}

--- a/src/test/kotlin/io/snyk/plugin/ui/jcef/SaveConfigHandlerExecuteCommandTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/jcef/SaveConfigHandlerExecuteCommandTest.kt
@@ -68,8 +68,30 @@ class SaveConfigHandlerExecuteCommandTest {
         lsWrapperMock.executeCommandWithArgs(
           "snyk.login",
           listOf("oauth2", "https://api.snyk.io", false),
+          120_000L,
         )
       }
+    }
+  }
+
+  @Test
+  fun `dispatchSettingsCommand saves auth params to plugin settings before forwarding snyk login`() {
+    val settings = SnykApplicationSettingsStateService()
+    every { pluginSettings() } returns settings
+
+    val request =
+      TreeViewCommandRequest(
+        command = "snyk.login",
+        args = listOf("pat", "https://api.eu.snyk.io", true),
+      )
+    val payload = gson.toJson(request)
+
+    handler.dispatchSettingsCommand(payload)
+
+    await().atMost(2, TimeUnit.SECONDS).untilAsserted {
+      assertEquals(io.snyk.plugin.services.AuthenticationType.PAT, settings.authenticationType)
+      assertEquals("https://api.eu.snyk.io", settings.customEndpointUrl)
+      assertTrue(settings.ignoreUnknownCA)
     }
   }
 
@@ -81,7 +103,7 @@ class SaveConfigHandlerExecuteCommandTest {
     handler.dispatchSettingsCommand(payload)
 
     await().atMost(2, TimeUnit.SECONDS).untilAsserted {
-      verify { lsWrapperMock.executeCommandWithArgs("snyk.logout", emptyList()) }
+      verify { lsWrapperMock.executeCommandWithArgs("snyk.logout", emptyList(), 5_000L) }
     }
   }
 
@@ -93,13 +115,13 @@ class SaveConfigHandlerExecuteCommandTest {
     handler.dispatchSettingsCommand(payload)
 
     await().atMost(2, TimeUnit.SECONDS).untilAsserted {
-      verify(exactly = 0) { lsWrapperMock.executeCommandWithArgs(any(), any()) }
+      verify(exactly = 0) { lsWrapperMock.executeCommandWithArgs(any(), any(), any()) }
     }
   }
 
   @Test
   fun `dispatchSettingsCommand invokes callback when callbackId present`() {
-    every { lsWrapperMock.executeCommandWithArgs("snyk.login", any()) } returns "auth-result"
+    every { lsWrapperMock.executeCommandWithArgs("snyk.login", any(), any()) } returns "auth-result"
 
     val latch = CountDownLatch(1)
     var receivedCallbackId: String? = null

--- a/src/test/kotlin/io/snyk/plugin/ui/jcef/TreeViewBridgeHandlerTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/jcef/TreeViewBridgeHandlerTest.kt
@@ -315,4 +315,29 @@ class TreeViewBridgeHandlerTest {
     assertNotNull(request.args)
     assertEquals(null, request.callbackId)
   }
+
+  @Test
+  fun `dispatchCommand should reject non-snyk commands and not call language server`() {
+    val request =
+      TreeViewCommandRequest(command = "workbench.action.terminal.new", args = emptyList())
+    val payload = gson.toJson(request)
+
+    handler.dispatchCommand(payload)
+
+    await().atMost(2, TimeUnit.SECONDS).untilAsserted {
+      verify(exactly = 0) { lsWrapperMock.executeCommandWithArgs(any(), any()) }
+    }
+  }
+
+  @Test
+  fun `dispatchCommand should dispatch snyk dot-prefixed commands`() {
+    val request = TreeViewCommandRequest(command = "snyk.anyCommand", args = emptyList())
+    val payload = gson.toJson(request)
+
+    handler.dispatchCommand(payload)
+
+    await().atMost(2, TimeUnit.SECONDS).untilAsserted {
+      verify { lsWrapperMock.executeCommandWithArgs("snyk.anyCommand", emptyList()) }
+    }
+  }
 }

--- a/src/test/kotlin/io/snyk/plugin/ui/jcef/TreeViewBridgeHandlerTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/jcef/TreeViewBridgeHandlerTest.kt
@@ -83,7 +83,7 @@ class TreeViewBridgeHandlerTest {
   }
 
   @Test
-  fun `dispatchCommand should reject empty command via allowlist`() {
+  fun `dispatchCommand should ignore empty command`() {
     val request = TreeViewCommandRequest(command = "", args = emptyList())
     val payload = gson.toJson(request)
 
@@ -269,24 +269,6 @@ class TreeViewBridgeHandlerTest {
   }
 
   @Test
-  fun `dispatchCommand should reject commands not in the allowlist and invoke error callback`() {
-    val request =
-      TreeViewCommandRequest(command = "snyk.logout", args = emptyList(), callbackId = "__cb_99")
-    val payload = gson.toJson(request)
-
-    val latch = CountDownLatch(1)
-    var receivedResult: String? = null
-    handler.dispatchCommand(payload) { _, result ->
-      receivedResult = result
-      latch.countDown()
-    }
-
-    assertTrue("Callback should be invoked with error", latch.await(2, TimeUnit.SECONDS))
-    assertTrue("Result should contain error", receivedResult!!.contains("error"))
-    verify(exactly = 0) { lsWrapperMock.executeCommandWithArgs(any(), any()) }
-  }
-
-  @Test
   fun `dispatchCommand should reject callbackId with non-alphanumeric characters and not invoke callback`() {
     every { lsWrapperMock.executeCommandWithArgs(any(), any()) } returns "result"
 
@@ -310,32 +292,6 @@ class TreeViewBridgeHandlerTest {
   }
 
   @Test
-  fun `dispatchCommand should accept all allowed tree view commands`() {
-    every { lsWrapperMock.executeCommandWithArgs(any(), any()) } returns "ok"
-
-    val allowedCommands =
-      listOf(
-        "snyk.navigateToRange",
-        "snyk.toggleTreeFilter",
-        "snyk.getTreeViewIssueChunk",
-        "snyk.setNodeExpanded",
-        "snyk.showScanErrorDetails",
-        "snyk.updateFolderConfig",
-      )
-
-    val latch = CountDownLatch(allowedCommands.size)
-
-    for (cmd in allowedCommands) {
-      val request = TreeViewCommandRequest(command = cmd, args = emptyList())
-      handler.dispatchCommand(gson.toJson(request)) { _, _ -> latch.countDown() }
-    }
-
-    await().atMost(2, TimeUnit.SECONDS).untilAsserted {
-      verify(exactly = allowedCommands.size) { lsWrapperMock.executeCommandWithArgs(any(), any()) }
-    }
-  }
-
-  @Test
   fun `buildBridgeScript should contain ideExecuteCommand bridge`() {
     val mockQuery: JBCefJSQuery = mockk(relaxed = true)
     every { mockQuery.inject(any()) } returns "window.cefQuery_inject(payload)"
@@ -348,20 +304,6 @@ class TreeViewBridgeHandlerTest {
     )
     assertTrue("Script should define __ideCallbacks__", script.contains("__ideCallbacks__"))
     assertTrue("Script should contain injected query", script.contains("cefQuery_inject"))
-  }
-
-  @Test
-  fun `ALLOWED_COMMANDS should contain expected commands`() {
-    val expected =
-      setOf(
-        "snyk.navigateToRange",
-        "snyk.toggleTreeFilter",
-        "snyk.getTreeViewIssueChunk",
-        "snyk.setNodeExpanded",
-        "snyk.showScanErrorDetails",
-        "snyk.updateFolderConfig",
-      )
-    assertEquals(expected, TreeViewBridgeHandler.ALLOWED_COMMANDS)
   }
 
   @Test

--- a/src/test/kotlin/io/snyk/plugin/ui/jcef/TreeViewBridgeHandlerTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/jcef/TreeViewBridgeHandlerTest.kt
@@ -58,7 +58,7 @@ class TreeViewBridgeHandlerTest {
   @Test
   fun `dispatchCommand should dispatch command to language server`() {
     val request =
-      TreeViewCommandRequest(
+      ExecuteCommandRequest(
         command = "snyk.toggleTreeFilter",
         args = listOf("severity", "high", true),
       )
@@ -84,7 +84,7 @@ class TreeViewBridgeHandlerTest {
 
   @Test
   fun `dispatchCommand should ignore empty command`() {
-    val request = TreeViewCommandRequest(command = "", args = emptyList())
+    val request = ExecuteCommandRequest(command = "", args = emptyList())
     val payload = gson.toJson(request)
 
     handler.dispatchCommand(payload)
@@ -103,7 +103,7 @@ class TreeViewBridgeHandlerTest {
     var receivedResult: String? = null
 
     val request =
-      TreeViewCommandRequest(
+      ExecuteCommandRequest(
         command = "snyk.getTreeViewIssueChunk",
         args = listOf("req1", "/path", "code", 0, 10),
         callbackId = "__cb_1",
@@ -129,7 +129,7 @@ class TreeViewBridgeHandlerTest {
     val latch = CountDownLatch(1)
     var receivedResult: String? = "not-called"
     val request =
-      TreeViewCommandRequest(
+      ExecuteCommandRequest(
         command = "snyk.navigateToRange",
         args = listOf("/file.kt"),
         callbackId = "__cb_2",
@@ -150,8 +150,7 @@ class TreeViewBridgeHandlerTest {
     every { lsWrapperMock.executeCommandWithArgs(any(), any()) } returns "result"
 
     val callbackInvoked = AtomicBoolean(false)
-    val request =
-      TreeViewCommandRequest(command = "snyk.navigateToRange", args = listOf("/file.kt"))
+    val request = ExecuteCommandRequest(command = "snyk.navigateToRange", args = listOf("/file.kt"))
     val payload = gson.toJson(request)
 
     handler.dispatchCommand(payload) { _, _ -> callbackInvoked.set(true) }
@@ -164,10 +163,10 @@ class TreeViewBridgeHandlerTest {
   }
 
   @Test
-  fun `TreeViewCommandRequest deserialization should work correctly`() {
+  fun `ExecuteCommandRequest deserialization should work correctly`() {
     val json =
       """{"command":"snyk.navigateToRange","args":["/file.kt",{"start":{"line":1,"character":0}}],"callbackId":null}"""
-    val request = gson.fromJson(json, TreeViewCommandRequest::class.java)
+    val request = gson.fromJson(json, ExecuteCommandRequest::class.java)
 
     assertEquals("snyk.navigateToRange", request.command)
     assertEquals(2, request.args.size)
@@ -175,8 +174,8 @@ class TreeViewBridgeHandlerTest {
   }
 
   @Test
-  fun `TreeViewCommandRequest defaults should be correct`() {
-    val request = TreeViewCommandRequest()
+  fun `ExecuteCommandRequest defaults should be correct`() {
+    val request = ExecuteCommandRequest()
 
     assertEquals("", request.command)
     assertEquals(emptyList<Any>(), request.args)
@@ -190,7 +189,7 @@ class TreeViewBridgeHandlerTest {
     val latch = CountDownLatch(1)
     var receivedResult: String? = null
     val request =
-      TreeViewCommandRequest(
+      ExecuteCommandRequest(
         command = "snyk.setNodeExpanded",
         args = listOf("arg1"),
         callbackId = "__cb_err",
@@ -211,7 +210,7 @@ class TreeViewBridgeHandlerTest {
   fun `dispatchCommand should not throw when language server throws and no callback`() {
     every { lsWrapperMock.executeCommandWithArgs(any(), any()) } throws RuntimeException("LS error")
 
-    val request = TreeViewCommandRequest(command = "snyk.setNodeExpanded", args = listOf("arg1"))
+    val request = ExecuteCommandRequest(command = "snyk.setNodeExpanded", args = listOf("arg1"))
     val payload = gson.toJson(request)
 
     // should not throw
@@ -227,7 +226,7 @@ class TreeViewBridgeHandlerTest {
     every { lsWrapperMock.executeCommandWithArgs(any(), any()) } returns "result"
 
     val request =
-      TreeViewCommandRequest(
+      ExecuteCommandRequest(
         command = "snyk.setNodeExpanded",
         args = emptyList(),
         callbackId = "__cb_3",
@@ -253,7 +252,7 @@ class TreeViewBridgeHandlerTest {
       Thread {
           try {
             val request =
-              TreeViewCommandRequest(command = "snyk.setNodeExpanded", args = listOf("arg$i"))
+              ExecuteCommandRequest(command = "snyk.setNodeExpanded", args = listOf("arg$i"))
             handler.dispatchCommand(gson.toJson(request))
           } catch (e: Exception) {
             synchronized(errors) { errors.add(e) }
@@ -274,7 +273,7 @@ class TreeViewBridgeHandlerTest {
 
     val maliciousCallbackId = "'];alert('xss');//"
     val request =
-      TreeViewCommandRequest(
+      ExecuteCommandRequest(
         command = "snyk.setNodeExpanded",
         args = emptyList(),
         callbackId = maliciousCallbackId,
@@ -307,9 +306,9 @@ class TreeViewBridgeHandlerTest {
   }
 
   @Test
-  fun `TreeViewCommandRequest deserialization with missing fields should use defaults`() {
+  fun `ExecuteCommandRequest deserialization with missing fields should use defaults`() {
     val json = """{"command":"snyk.test"}"""
-    val request = gson.fromJson(json, TreeViewCommandRequest::class.java)
+    val request = gson.fromJson(json, ExecuteCommandRequest::class.java)
 
     assertEquals("snyk.test", request.command)
     assertNotNull(request.args)
@@ -319,7 +318,7 @@ class TreeViewBridgeHandlerTest {
   @Test
   fun `dispatchCommand should reject non-snyk commands and not call language server`() {
     val request =
-      TreeViewCommandRequest(command = "workbench.action.terminal.new", args = emptyList())
+      ExecuteCommandRequest(command = "workbench.action.terminal.new", args = emptyList())
     val payload = gson.toJson(request)
 
     handler.dispatchCommand(payload)
@@ -331,7 +330,7 @@ class TreeViewBridgeHandlerTest {
 
   @Test
   fun `dispatchCommand should dispatch snyk dot-prefixed commands`() {
-    val request = TreeViewCommandRequest(command = "snyk.anyCommand", args = emptyList())
+    val request = ExecuteCommandRequest(command = "snyk.anyCommand", args = emptyList())
     val payload = gson.toJson(request)
 
     handler.dispatchCommand(payload)

--- a/src/test/kotlin/snyk/common/lsp/SnykLanguageClientTest.kt
+++ b/src/test/kotlin/snyk/common/lsp/SnykLanguageClientTest.kt
@@ -1,6 +1,7 @@
 package snyk.common.lsp
 
 import com.google.gson.Gson
+import com.intellij.configurationStore.StoreUtil
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.command.WriteCommandAction
@@ -23,10 +24,12 @@ import io.snyk.plugin.events.SnykShowIssueDetailListener
 import io.snyk.plugin.events.SnykTreeViewListener
 import io.snyk.plugin.getDocument
 import io.snyk.plugin.pluginSettings
+import io.snyk.plugin.publishAsync
 import io.snyk.plugin.refreshAnnotationsForFile
 import io.snyk.plugin.services.SnykApplicationSettingsStateService
 import io.snyk.plugin.toVirtualFile
 import io.snyk.plugin.toVirtualFileOrNull
+import io.snyk.plugin.ui.settings.HTMLSettingsPanel
 import io.snyk.plugin.ui.toolwindow.SnykPluginDisposable
 import java.nio.file.Files
 import java.nio.file.Paths
@@ -174,6 +177,31 @@ class SnykLanguageClientTest {
     cut.hasAuthenticated(HasAuthenticatedParam(unexpected, url))
 
     assertNotEquals(unexpected, settings.token)
+  }
+
+  @Test
+  fun `hasAuthenticated calls setAuthToken on HTMLSettingsPanel when panel is open`() {
+    val lsWrapperMock = mockk<LanguageServerWrapper>(relaxed = true)
+    mockkObject(LanguageServerWrapper.Companion)
+    every { LanguageServerWrapper.getInstance(projectMock) } returns lsWrapperMock
+
+    mockkStatic(StoreUtil::class)
+    justRun { StoreUtil.saveSettings(any(), any()) }
+
+    justRun { publishAsync<Any>(any(), any(), any()) }
+
+    val panelMock = mockk<HTMLSettingsPanel>(relaxed = true)
+    HTMLSettingsPanel.instance = panelMock
+
+    try {
+      val token = "test-token-123"
+      val apiUrl = "https://api.snyk.io"
+      cut.hasAuthenticated(HasAuthenticatedParam(token, apiUrl))
+
+      verify { panelMock.setAuthToken(token, apiUrl) }
+    } finally {
+      HTMLSettingsPanel.instance = null
+    }
   }
 
   @Test


### PR DESCRIPTION
## What & Why

The settings page drives authentication via `snyk.login` with `[authMethod, endpoint, insecure]` args. Before forwarding to the LS, the IDE must persist these values locally so they survive a page close. Additionally, `$/snyk.hasAuthenticated` now carries `apiUrl` which is forwarded to the settings panel webview so the settings page can update both fields after auth.

Bridge persist written directly to `pluginSettings()` properties — no `updateConfiguration()` call means no `didChangeConfiguration` loop.

## Changes

**`ExecuteCommandBridge.kt`** (new shared class)
- `LOGIN_TIMEOUT_MS = 120_000L`; `LONG_RUNNING_COMMANDS = setOf("snyk.login")` — login waits up to 2 min for browser OAuth
- Replaces `__ideLogin__`/`__ideLogout__` with `window.__ideExecuteCommand__(cmd, args, callback)` bridge
- Before `ls.executeCommandWithArgs`, when `command == "snyk.login"` and `args.size >= 3`, calls `saveLoginArgs(args)`:
  - Maps `args[0]` → `AuthenticationType` (`"oauth"` → `OAUTH2`, `"pat"` → `PAT`, `"token"` → `API_TOKEN`)
  - Sets `pluginSettings().authenticationType`, `.customEndpointUrl`, `.ignoreUnknownCA`
  - No `updateConfiguration()` call → no `didChangeConfiguration` sent to LS
- `LanguageServerWrapper.executeCommandWithArgs` gains `timeoutMillis: Long = 5_000` param

**`HTMLSettingsPanel.kt`**
- `companion object { @Volatile var instance: HTMLSettingsPanel? = null }` — set in `init`, cleared in `dispose()`
- `setAuthToken(token: String, apiUrl: String?)` — escapes both, executes `window.setAuthToken(safeToken, safeApiUrl)` via JCEF on `invokeLater` with `ModalityState.any()`

**`SnykLanguageClient.kt`**
Calls `HTMLSettingsPanel.instance?.setAuthToken(param.token ?: "", param.apiUrl)` before saving to `pluginSettings()` — settings page webview updates immediately after auth.

**`SaveConfigHandler.kt`**
Removes the `messageBus.subscribe(SnykSettingsListener.SNYK_SETTINGS_TOPIC, ...)` block that pushed token updates to the browser — replaced by the direct `HTMLSettingsPanel.instance?.setAuthToken(...)` call in `SnykLanguageClient`.

## Tests

- `SaveConfigHandlerExecuteCommandTest.kt`: bridge persist test added (sends `snyk.login` with `["pat", "https://api.eu.snyk.io", true]`, asserts `authenticationType == PAT`, `customEndpointUrl`, `ignoreUnknownCA`); all `executeCommandWithArgs` verify calls include timeout arg
- `SnykLanguageClientTest.kt`: `setAuthToken` called on `HTMLSettingsPanel.instance` when panel is open (new test)

## Test plan

- [ ] Settings page: change endpoint + auth method → click Authenticate → IDE saves values → auth succeeds → token and apiUrl appear in settings page
- [ ] Close/reopen settings page → values persist
- [ ] Panel login → auth succeeds → token and apiUrl shown immediately
- [ ] No `didChangeConfiguration` sent when bridge saves auth params
- [ ] Run test suite: `./gradlew test`