### PR TITLE
fix: keep Secrets root in HTML tree after clean results [IDE-1809]

### DIFF
--- a/src/main/resources/html/TreeViewInit.html
+++ b/src/main/resources/html/TreeViewInit.html
@@ -81,6 +81,15 @@
       </div>
       <div class="tree-node-children"></div>
     </div>
+
+    <div class="tree-node" data-node-id="product-secrets">
+      <div class="tree-node-row">
+        <span class="tree-chevron"></span>
+        <span class="product-icon"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 64 64"><path fill="url(#paint_treeinit_secrets_a)" d="M29.147 4.054c.229-.072.475-.072.705 0l22.324 6.991c.464.144.804.59.822 1.07V25h-7.756l-2.535-2.535A5 5 0 0 0 39.172 21H28a5 5 0 0 0-5 5v24a5 5 0 0 0 5 5h12.015c-4.404 3.48-8.674 4.986-10.516 4.986C25 59.986 6 51 6 26.193V12.114c.018-.479.358-.925.822-1.069z"/><path fill="url(#paint_treeinit_secrets_b)" fill-rule="evenodd" d="M39.172 24a2 2 0 0 1 1.414.586l2.828 2.828a2 2 0 0 0 1.414.586H56a2 2 0 0 1 2 2v20a2 2 0 0 1-2 2H28a2 2 0 0 1-2-2V26a2 2 0 0 1 2-2zM42 33a4 4 0 0 0-2 7.463V45a2 2 0 1 0 4 0v-4.537A4 4 0 0 0 42 33" clip-rule="evenodd"/><defs><linearGradient id="paint_treeinit_secrets_a" x1="12.785" x2="70.164" y1="4" y2="17.569" gradientUnits="userSpaceOnUse"><stop stop-color="#9043c6"/><stop offset="1" stop-color="#145deb"/></linearGradient><linearGradient id="paint_treeinit_secrets_b" x1="58" x2="30.248" y1="52" y2="20.283" gradientUnits="userSpaceOnUse"><stop stop-color="#e555ac"/><stop offset="1" stop-color="#f99048"/></linearGradient></defs></svg></span>
+        <span class="tree-label"><strong>Secrets</strong></span>
+      </div>
+      <div class="tree-node-children"></div>
+    </div>
   </div>
 </body>
 </html>

--- a/src/test/kotlin/io/snyk/plugin/ui/toolwindow/panels/HtmlTreePanelTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/toolwindow/panels/HtmlTreePanelTest.kt
@@ -146,6 +146,18 @@ class HtmlTreePanelTest : LightPlatform4TestCase() {
   }
 
   @Test
+  fun `init HTML should include Secrets product root with other products`() {
+    val html =
+      HtmlTreePanel::class.java.classLoader.getResource(HtmlTreePanel.HTML_INIT_FILE)!!.readText()
+
+    assertTrue(html.contains("data-node-id=\"product-oss\""))
+    assertTrue(html.contains("data-node-id=\"product-code\""))
+    assertTrue(html.contains("data-node-id=\"product-iac\""))
+    assertTrue(html.contains("data-node-id=\"product-secrets\""))
+    assertTrue(html.contains("<strong>Secrets</strong>"))
+  }
+
+  @Test
   fun `getFormattedHtml should replace all placeholders in init HTML`() {
     val html =
       HtmlTreePanel::class.java.classLoader.getResource(HtmlTreePanel.HTML_INIT_FILE)!!.readText()

--- a/src/test/kotlin/io/snyk/plugin/ui/toolwindow/panels/HtmlTreePanelTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/toolwindow/panels/HtmlTreePanelTest.kt
@@ -146,7 +146,7 @@ class HtmlTreePanelTest : LightPlatform4TestCase() {
   }
 
   @Test
-  fun `init HTML should include Secrets product root with other products`() {
+  fun `init HTML should include all four products`() {
     val html =
       HtmlTreePanel::class.java.classLoader.getResource(HtmlTreePanel.HTML_INIT_FILE)!!.readText()
 
@@ -154,6 +154,9 @@ class HtmlTreePanelTest : LightPlatform4TestCase() {
     assertTrue(html.contains("data-node-id=\"product-code\""))
     assertTrue(html.contains("data-node-id=\"product-iac\""))
     assertTrue(html.contains("data-node-id=\"product-secrets\""))
+    assertTrue(html.contains("<strong>Open Source</strong>"))
+    assertTrue(html.contains("<strong>Code Security</strong>"))
+    assertTrue(html.contains("<strong>Infrastructure As Code</strong>"))
     assertTrue(html.contains("<strong>Secrets</strong>"))
   }
 


### PR DESCRIPTION
### Description

Fixes [IDE-1809](https://snyksec.atlassian.net/browse/IDE-1809).

**Problem:** After **Clean All Results**, the HTML tree view reloaded `TreeViewInit.html`, which only listed Open Source, Code Security, and IaC. The Secrets row disappeared until the next LS tree update.

**Change:** Add a fourth product root (Secrets, same order/icon/label as language server) to `TreeViewInit.html`. Add `HtmlTreePanelTest` asserting all four `data-node-id` roots exist.

Are we ok to always show the Secrets node?

### Checklist

- [x] Read and understood the [Code of Conduct](https://github.com/snyk/snyk-intellij-plugin/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/snyk-intellij-plugin/blob/master/CONTRIBUTING.md).
- [x] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated (changelog lives in GitHub releases per repo README)
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Secrets row now remains visible after Clean All Results (same skeleton as OSS/Code/IaC)._

Made with [Cursor](https://cursor.com)

[IDE-1809]: https://snyksec.atlassian.net/browse/IDE-1809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ