### PR TITLE
fix(jcef): preserve user overrides when LS sends diff-based saves [IDE-1639]

### DIFF
--- a/src/main/kotlin/io/snyk/plugin/ui/jcef/SaveConfigHandler.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/jcef/SaveConfigHandler.kt
@@ -192,7 +192,6 @@ class SaveConfigHandler(
       isPresent = (config.manageBinariesAutomatically != null),
       newValue = config.manageBinariesAutomatically,
       currentValue = { settings.manageBinariesAutomatically },
-      addPendingResetWhenAbsent = true,
     ) {
       settings.manageBinariesAutomatically = it
     }
@@ -205,7 +204,6 @@ class SaveConfigHandler(
       isPresent = cliPathProvided,
       newValue = resolvedCliPath,
       currentValue = { settings.cliPath },
-      addPendingResetWhenAbsent = true,
     ) {
       settings.cliPath = it
     }
@@ -216,7 +214,6 @@ class SaveConfigHandler(
       isPresent = (config.cliBaseDownloadURL != null),
       newValue = config.cliBaseDownloadURL,
       currentValue = { settings.cliBaseDownloadURL },
-      addPendingResetWhenAbsent = true,
     ) {
       settings.cliBaseDownloadURL = it
     }
@@ -227,7 +224,6 @@ class SaveConfigHandler(
       isPresent = (config.cliReleaseChannel != null),
       newValue = config.cliReleaseChannel,
       currentValue = { settings.cliReleaseChannel },
-      addPendingResetWhenAbsent = true,
     ) {
       settings.cliReleaseChannel = it
     }
@@ -238,7 +234,6 @@ class SaveConfigHandler(
       isPresent = (config.insecure != null),
       newValue = config.insecure,
       currentValue = { settings.ignoreUnknownCA },
-      addPendingResetWhenAbsent = true,
     ) {
       settings.ignoreUnknownCA = it
     }
@@ -499,14 +494,14 @@ class SaveConfigHandler(
     isPresent: Boolean,
     newValue: T?,
     currentValue: () -> Any?,
-    addPendingResetWhenAbsent: Boolean = false,
     assign: (T) -> Unit,
   ) {
+    // Diff-based wire contract: the LS settings UI sends only fields that changed. An absent or
+    // null field therefore means "no change" and MUST NOT clear the existing explicit-change flag
+    // or emit a reset signal. Doing so would silently revoke unrelated user overrides (e.g. the
+    // user's cli_path or proxy_insecure) every time any other field is saved, causing the LS to
+    // fall back to org/system defaults despite the user's local settings still being set.
     if (!isPresent || newValue == null) {
-      settings.clearExplicitlyChanged(key)
-      if (addPendingResetWhenAbsent) {
-        settings.addPendingReset(key)
-      }
       return
     }
 

--- a/src/test/kotlin/io/snyk/plugin/ui/jcef/SaveConfigHandlerTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/jcef/SaveConfigHandlerTest.kt
@@ -813,24 +813,25 @@ class SaveConfigHandlerTest : BasePlatformTestCase() {
     assertEquals(AuthenticationType.API_TOKEN, realSettings.authenticationType)
   }
 
-  fun `test applyGlobalSettings with null field clears explicit change flag`() {
+  fun `test applyGlobalSettings with null field preserves existing explicit change flag`() {
     val realSettings = SnykApplicationSettingsStateService()
     // Pre-mark the key as explicitly changed
     realSettings.markExplicitlyChanged(LsSettingsKeys.AUTOMATIC_DOWNLOAD)
     assertTrue(realSettings.isExplicitlyChanged(LsSettingsKeys.AUTOMATIC_DOWNLOAD))
     every { pluginSettings() } returns realSettings
 
-    // Send config WITHOUT manageBinariesAutomatically (null) to trigger the clear
+    // Send diff-based payload WITHOUT manageBinariesAutomatically -- absence means "no change".
     val jsonConfig = """{"activateSnykOpenSource": true}"""
     invokeParseAndSaveConfig(jsonConfig)
 
-    assertFalse(
-      "AUTOMATIC_DOWNLOAD should be cleared when manageBinariesAutomatically is absent",
+    assertTrue(
+      "AUTOMATIC_DOWNLOAD must remain marked when manageBinariesAutomatically is absent" +
+        " (LS UI sends diff-based updates; absence != user reset)",
       realSettings.isExplicitlyChanged(LsSettingsKeys.AUTOMATIC_DOWNLOAD),
     )
   }
 
-  fun `test applyGlobalSettings with absent fields clears all their flags`() {
+  fun `test applyGlobalSettings with absent fields preserves all existing flags`() {
     val realSettings = SnykApplicationSettingsStateService()
     // Pre-mark several keys as explicitly changed
     val keysToPreMark =
@@ -853,26 +854,26 @@ class SaveConfigHandlerTest : BasePlatformTestCase() {
     }
     every { pluginSettings() } returns realSettings
 
-    // Send empty config (all nullable fields absent) -- all flags should be cleared
+    // Send empty diff -- all previously-asserted user overrides must remain marked.
     val jsonConfig = """{}"""
     invokeParseAndSaveConfig(jsonConfig)
 
     for (key in keysToPreMark) {
-      assertFalse(
-        "Key '$key' should be cleared when its config field is absent",
+      assertTrue(
+        "Key '$key' must remain marked when its config field is absent from diff payload",
         realSettings.isExplicitlyChanged(key),
       )
     }
   }
 
-  fun `test applyGlobalSettings clears flag for absent field but keeps flag for present field`() {
+  fun `test applyGlobalSettings preserves flag for absent field while updating present field`() {
     val realSettings = SnykApplicationSettingsStateService()
     realSettings.manageBinariesAutomatically = true
     realSettings.markExplicitlyChanged(LsSettingsKeys.AUTOMATIC_DOWNLOAD)
     realSettings.markExplicitlyChanged(LsSettingsKeys.CLI_PATH)
     every { pluginSettings() } returns realSettings
 
-    // Send config with manageBinariesAutomatically changed but cliPath absent
+    // Send diff with manageBinariesAutomatically changed, cliPath absent.
     val jsonConfig = """{"manageBinariesAutomatically": false}"""
     invokeParseAndSaveConfig(jsonConfig)
 
@@ -880,9 +881,51 @@ class SaveConfigHandlerTest : BasePlatformTestCase() {
       "AUTOMATIC_DOWNLOAD should remain marked (field present and changed)",
       realSettings.isExplicitlyChanged(LsSettingsKeys.AUTOMATIC_DOWNLOAD),
     )
-    assertFalse(
-      "CLI_PATH should be cleared (field absent)",
+    assertTrue(
+      "CLI_PATH must remain marked when its field is absent from a diff-based payload",
       realSettings.isExplicitlyChanged(LsSettingsKeys.CLI_PATH),
+    )
+  }
+
+  fun `test applyGlobalSettings partial payload does not wipe machine-scoped user overrides`() {
+    // Regression for diff-based payloads: changing one machine-scoped field must not silently
+    // revoke unrelated overrides. Previously, absent fields cleared explicitChanges and queued
+    // pending resets, causing the LS to fall back to org/system defaults despite local settings.
+    val realSettings = SnykApplicationSettingsStateService()
+    realSettings.cliPath = "/usr/local/bin/snyk"
+    realSettings.cliBaseDownloadURL = "https://downloads.snyk.io/fips"
+    realSettings.cliReleaseChannel = "preview"
+    realSettings.ignoreUnknownCA = true
+    realSettings.manageBinariesAutomatically = false
+    realSettings.markExplicitlyChanged(LsSettingsKeys.CLI_PATH)
+    realSettings.markExplicitlyChanged(LsSettingsKeys.BINARY_BASE_URL)
+    realSettings.markExplicitlyChanged(LsSettingsKeys.CLI_RELEASE_CHANNEL)
+    realSettings.markExplicitlyChanged(LsSettingsKeys.PROXY_INSECURE)
+    realSettings.markExplicitlyChanged(LsSettingsKeys.AUTOMATIC_DOWNLOAD)
+    every { pluginSettings() } returns realSettings
+
+    // LS-style diff payload toggling only one unrelated field.
+    invokeParseAndSaveConfig("""{"activateSnykOpenSource": true}""")
+
+    // Values are untouched.
+    assertEquals("/usr/local/bin/snyk", realSettings.cliPath)
+    assertEquals("https://downloads.snyk.io/fips", realSettings.cliBaseDownloadURL)
+    assertEquals("preview", realSettings.cliReleaseChannel)
+    assertTrue(realSettings.ignoreUnknownCA)
+    assertFalse(realSettings.manageBinariesAutomatically)
+
+    // Explicit-change flags are preserved across diff-based saves.
+    assertTrue(realSettings.isExplicitlyChanged(LsSettingsKeys.CLI_PATH))
+    assertTrue(realSettings.isExplicitlyChanged(LsSettingsKeys.BINARY_BASE_URL))
+    assertTrue(realSettings.isExplicitlyChanged(LsSettingsKeys.CLI_RELEASE_CHANNEL))
+    assertTrue(realSettings.isExplicitlyChanged(LsSettingsKeys.PROXY_INSECURE))
+    assertTrue(realSettings.isExplicitlyChanged(LsSettingsKeys.AUTOMATIC_DOWNLOAD))
+
+    // No spurious reset signals queued for the absent machine-scoped keys.
+    val resets = realSettings.consumePendingResets()
+    assertTrue(
+      "No pending resets should be queued for absent fields in a diff payload, got: $resets",
+      resets.isEmpty(),
     )
   }
 
@@ -901,50 +944,35 @@ class SaveConfigHandlerTest : BasePlatformTestCase() {
     assertEquals("preview", realSettings.cliReleaseChannel)
   }
 
-  fun `test applyGlobalSettings with null cliReleaseChannel clears CLI_RELEASE_CHANNEL`() {
+  fun `test applyGlobalSettings with null cliReleaseChannel preserves CLI_RELEASE_CHANNEL flag`() {
     val realSettings = SnykApplicationSettingsStateService()
     realSettings.markExplicitlyChanged(LsSettingsKeys.CLI_RELEASE_CHANNEL)
     assertTrue(realSettings.isExplicitlyChanged(LsSettingsKeys.CLI_RELEASE_CHANNEL))
     every { pluginSettings() } returns realSettings
 
-    // Send config WITHOUT cliReleaseChannel (null) to trigger the clear
+    // Diff-based payload with cliReleaseChannel absent must not clear the existing flag.
     val jsonConfig = """{"activateSnykOpenSource": true}"""
     invokeParseAndSaveConfig(jsonConfig)
 
-    assertFalse(
-      "CLI_RELEASE_CHANNEL should be cleared when cliReleaseChannel is absent",
+    assertTrue(
+      "CLI_RELEASE_CHANNEL must remain marked when cliReleaseChannel is absent from diff",
       realSettings.isExplicitlyChanged(LsSettingsKeys.CLI_RELEASE_CHANNEL),
     )
   }
 
-  fun `test applyGlobalSettings with null field adds pending reset`() {
+  fun `test applyGlobalSettings with absent machine-scoped fields does not queue pending resets`() {
     val realSettings = SnykApplicationSettingsStateService()
     every { pluginSettings() } returns realSettings
 
-    // Send config WITHOUT manageBinariesAutomatically (null) to trigger pending reset
+    // Diff-based payload omits all machine-scoped fields; no resets should be queued, otherwise
+    // the LS would drop the user's local cli_path/proxy_insecure/etc. on every unrelated save.
     val jsonConfig = """{"activateSnykOpenSource": true}"""
     invokeParseAndSaveConfig(jsonConfig)
 
     val resets = realSettings.consumePendingResets()
     assertTrue(
-      "AUTOMATIC_DOWNLOAD should be in pending resets when field is absent",
-      resets.contains(LsSettingsKeys.AUTOMATIC_DOWNLOAD),
-    )
-    assertTrue(
-      "CLI_PATH should be in pending resets when field is absent",
-      resets.contains(LsSettingsKeys.CLI_PATH),
-    )
-    assertTrue(
-      "BINARY_BASE_URL should be in pending resets when field is absent",
-      resets.contains(LsSettingsKeys.BINARY_BASE_URL),
-    )
-    assertTrue(
-      "CLI_RELEASE_CHANNEL should be in pending resets when field is absent",
-      resets.contains(LsSettingsKeys.CLI_RELEASE_CHANNEL),
-    )
-    assertTrue(
-      "PROXY_INSECURE should be in pending resets when field is absent",
-      resets.contains(LsSettingsKeys.PROXY_INSECURE),
+      "No machine-scoped key should be in pending resets when its field is absent, got: $resets",
+      resets.isEmpty(),
     )
   }
 


### PR DESCRIPTION
### **User description**
## Problem

The Language Server settings UI sends **diff-based payloads** (only fields whose values changed). `SaveConfigHandler.applyGlobalSetting` previously treated an absent or null field as a *user reset*: it called `clearExplicitlyChanged(key)` and (for the five machine-scoped CLI keys) `addPendingReset(key)`.

That conflated *"field not in diff"* with *"user cleared the override"*. Saving any one setting would silently revoke unrelated user overrides — `cli_path`, `proxy_insecure`, `automatic_download`, `binary_base_url`, `cli_release_channel`. On the next `workspace/didChangeConfiguration`, the IDE stopped asserting those values, and the LS fell back to org/system defaults despite the user's local IDE settings still being set.

## Fix

Make absence a no-op in `applyGlobalSetting`:

- If the field is absent or null, leave both `explicitChanges` and `pendingResets` untouched.
- If the field is present, retain the existing diff-based marking semantics (`markExplicitlyChanged` when value differs, `clearExplicitlyChanged` when value matches, always assign the new value).
- Drop the now-unused `addPendingResetWhenAbsent` parameter from the helper signature.

The `addPendingReset` / `consumePendingResets` API on `SnykApplicationSettingsStateService` is preserved for any future explicit reset flow.

## Tests

- Updated five tests that asserted the old absent-clears semantics so they assert the corrected behavior.
- Added regression test ``test applyGlobalSettings partial payload does not wipe machine-scoped user overrides`` that seeds five machine-scoped overrides, sends a diff-style single-field payload, and verifies values, explicit-change flags, and absence of spurious pending resets are preserved.

## Verification

- `SaveConfigHandlerTest`: 54 / 54 pass.
- `SnykApplicationSettingsStateServiceTest`: 27 / 27 pass.
- `LanguageServerWrapperTest`: 62 / 62 pass.
- Full `./gradlew koverXMLReport`: 589 tests, 0 failures.
- `./gradlew ktlintCheck spotlessApply`: clean.
- `./gradlew verifyPlugin`: passed.

Base: \`feat/IDE-1639\`.


___

### **PR Type**
bug_fix, tests


___

### **Description**
- Fixes silent revocation of user overrides.

- Correctly handles diff-based settings payloads.

- Preserves existing settings when fields are absent.

- Updates and adds tests for verification.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  LS_Sends_Diff_Payload --> ApplyGlobalSetting
  ApplyGlobalSetting -- Field Absent/Null --> NoOp("No operation (preserves overrides)")
  ApplyGlobalSetting -- Field Present/NonNull --> UpdateLogic("Update value and explicit flags")
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SaveConfigHandler.kt</strong><dd><code>Adjust `applyGlobalSetting` for diff-based payloads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/kotlin/io/snyk/plugin/ui/jcef/SaveConfigHandler.kt

<ul><li>Removed the <code>addPendingResetWhenAbsent</code> parameter and associated logic.<br> <li> Modified <code>applyGlobalSetting</code> to treat absent or null fields as a <br>no-operation.<br> <li> This prevents unintended clearing of user overrides and pending resets <br>when settings are updated via diff-based payloads.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-intellij-plugin/pull/816/changes#diff-7a45bcdcd7158b2995c550f9e10be6c2250c2adceee34b2a2f7fc6c591f843f5">+5/-10</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SaveConfigHandlerTest.kt</strong><dd><code>Update tests for preserved user overrides</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/kotlin/io/snyk/plugin/ui/jcef/SaveConfigHandlerTest.kt

<ul><li>Renamed tests to accurately reflect the preservation of explicit <br>change flags for absent fields.<br> <li> Updated assertions to verify that flags are preserved, not cleared, <br>when fields are absent in diff payloads.<br> <li> Added a new regression test (<code>test applyGlobalSettings partial payload </code><br><code>does not wipe machine-scoped user overrides</code>) to specifically cover <br>scenarios with partial payloads.<br> <li> Modified tests to confirm that no pending resets are queued for absent <br>machine-scoped fields.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-intellij-plugin/pull/816/changes#diff-622128219f9ae8c6bb3755bc900be83782411e0cd27b94762989ea994f6197cd">+64/-36</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

