### PR TITLE
fix(jcef): register submit-ignore handler for Secrets product [IDE-1639]

### DIFF
--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/SuggestionDescriptionPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/SuggestionDescriptionPanel.kt
@@ -109,6 +109,10 @@ class SuggestionDescriptionPanel(val project: Project, private val issue: ScanIs
         val submitIgnoreRequestHandler = SubmitIgnoreRequestHandler(project)
         loadHandlerGenerators += { submitIgnoreRequestHandler.submitIgnoreRequestCommand(it) }
       }
+      ScanIssue.SECRETS -> {
+        val submitIgnoreRequestHandler = SubmitIgnoreRequestHandler(project)
+        loadHandlerGenerators += { submitIgnoreRequestHandler.submitIgnoreRequestCommand(it) }
+      }
       ScanIssue.INFRASTRUCTURE_AS_CODE -> {
         val applyIgnoreInFileHandler = IgnoreInFileHandler(project)
         loadHandlerGenerators += { applyIgnoreInFileHandler.generateIgnoreInFileCommand(it) }

--- a/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SuggestionDescriptionPanelFromLSSecretsTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SuggestionDescriptionPanelFromLSSecretsTest.kt
@@ -1,0 +1,86 @@
+@file:Suppress("FunctionName")
+
+package io.snyk.plugin.ui.toolwindow
+
+import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiFile
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.intellij.ui.jcef.JBCefBrowser
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.snyk.plugin.Severity
+import io.snyk.plugin.SnykFile
+import io.snyk.plugin.resetSettings
+import io.snyk.plugin.ui.jcef.JCEFUtils
+import io.snyk.plugin.ui.jcef.LoadHandlerGenerator
+import io.snyk.plugin.ui.toolwindow.panels.SuggestionDescriptionPanel
+import io.snyk.plugin.waitForPanelInit
+import java.nio.file.Paths
+import javax.swing.JLabel
+import snyk.UIComponentFinder.getJLabelByText
+import snyk.common.annotator.SnykCodeAnnotator
+import snyk.common.lsp.ScanIssue
+
+class SuggestionDescriptionPanelFromLSSecretsTest : BasePlatformTestCase() {
+  private lateinit var cut: SuggestionDescriptionPanel
+  private val fileName = "app.js"
+  private lateinit var snykFile: SnykFile
+  private lateinit var issue: ScanIssue
+
+  private lateinit var file: VirtualFile
+  private lateinit var psiFile: PsiFile
+
+  override fun getTestDataPath(): String {
+    val resource = SnykCodeAnnotator::class.java.getResource("/test-fixtures/code/annotator")
+    requireNotNull(resource) { "Make sure that the resource $resource exists!" }
+    return Paths.get(resource.toURI()).toString()
+  }
+
+  override fun setUp() {
+    unmockkAll()
+    super.setUp()
+    resetSettings(project)
+
+    file = myFixture.copyFileToProject(fileName)
+    psiFile = WriteAction.computeAndWait<PsiFile, Throwable> { psiManager.findFile(file)!! }
+    snykFile = SnykFile(psiFile.project, psiFile.virtualFile)
+
+    issue = mockk<ScanIssue>()
+    every { issue.getSeverityAsEnum() } returns Severity.CRITICAL
+    every { issue.title() } returns "title"
+    every { issue.issueNaming() } returns "issueNaming"
+    every { issue.cwes() } returns emptyList()
+    every { issue.cves() } returns emptyList()
+    every { issue.cvssV3() } returns null
+    every { issue.cvssScore() } returns null
+    every { issue.id() } returns "id"
+    every { issue.id } returns "test-issue-id"
+    every { issue.filterableIssueType } returns ScanIssue.SECRETS
+    every { issue.additionalData.message } returns "Test message"
+  }
+
+  fun `test SECRETS issue registers SubmitIgnoreRequestHandler so the create-ignore form submit works`() {
+    val mockJBCefBrowserComponent = JLabel("<html>HTML message</html>")
+    val mockJBCefBrowser: JBCefBrowser = mockk(relaxed = true)
+    every { mockJBCefBrowser.component } returns mockJBCefBrowserComponent
+
+    val handlersSlot = slot<List<LoadHandlerGenerator>>()
+    mockkObject(JCEFUtils)
+    every { JCEFUtils.getJBCefBrowserIfSupported(any(), capture(handlersSlot)) } returns
+      mockJBCefBrowser
+
+    every { issue.details(project) } returns "<html>HTML message</html>"
+    cut = SuggestionDescriptionPanel(project, issue)
+    waitForPanelInit(cut)
+
+    assertNotNull(getJLabelByText(cut, "<html>HTML message</html>"))
+    assertTrue(
+      "SECRETS issue must wire at least one load handler so the submit-ignore JS bridge is registered",
+      handlersSlot.captured.isNotEmpty(),
+    )
+  }
+}


### PR DESCRIPTION
### **User description**
## Cause

The Language Server embeds the same ignore form (with the
`\${ideSubmitIgnoreRequest}` placeholder) for both Code Security and
Secrets issues, but `SuggestionDescriptionPanel` only registered
`SubmitIgnoreRequestHandler` for `ScanIssue.CODE_SECURITY`.

As a result, clicking *Submit ignore* on a Secrets issue calls an
undefined `window.submitIgnoreRequest` and silently fails. The button
appears to do nothing.

## Fix

Wire `SubmitIgnoreRequestHandler` for `ScanIssue.SECRETS` as well so
the JS bridge is injected and the form actually reaches
`snyk.submitIgnoreRequest` on the language server.

## Test

`SuggestionDescriptionPanelFromLSSecretsTest` captures the
`loadHandlerGenerators` list passed to
`JCEFUtils.getJBCefBrowserIfSupported` for a SECRETS issue and asserts
at least one handler is registered. Verified the test fails on the
unfixed code and passes with the fix.

## Verified

- ./gradlew ktlintCheck spotlessApply
- ./gradlew koverXMLReport
- ./gradlew verifyPlugin


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix broken "Submit ignore" for Secrets issues.

- Add a dedicated test for Secrets ignore handling.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  SuggestionDescriptionPanel -- handles --> ScanIssueSECRETS
  ScanIssueSECRETS -- registers --> SubmitIgnoreRequestHandler
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SuggestionDescriptionPanel.kt</strong><dd><code>Add Secrets submit ignore handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/SuggestionDescriptionPanel.kt

<ul><li>Added a new <code>when</code> case for <code>ScanIssue.SECRETS</code>.<br> <li> Registered <code>SubmitIgnoreRequestHandler</code> to enable the "Submit ignore" <br>functionality for Secrets issues.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-intellij-plugin/pull/818/changes#diff-033c470521688e04521a0bf9e02c93b1585f1dcf3f65d0c021a6a8e859c43560">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SuggestionDescriptionPanelFromLSSecretsTest.kt</strong><dd><code>Test Secrets submit ignore handler registration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/kotlin/io/snyk/plugin/ui/toolwindow/SuggestionDescriptionPanelFromLSSecretsTest.kt

<ul><li>Created a new test class to specifically target Secrets issues.<br> <li> Verified that the <code>SubmitIgnoreRequestHandler</code> is correctly registered <br>for Secrets issues, ensuring the JS bridge is available.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-intellij-plugin/pull/818/changes#diff-1ad57c17bf91426d19ad5d6dba6246884a876190c5fb697ed58e77b0c57a0cad">+86/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

