### PR TITLE
feat: gate LS launch on CLI protocol version [IDE-1978]

### DIFF
--- a/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
@@ -1,11 +1,13 @@
 package snyk.common.lsp
 
 import com.google.gson.Gson
+import com.intellij.notification.NotificationAction
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
@@ -24,6 +26,7 @@ import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.publishAsync
 import io.snyk.plugin.runInBackground
 import io.snyk.plugin.services.SnykApplicationSettingsStateService
+import io.snyk.plugin.settings.SnykProjectSettingsConfigurable
 import io.snyk.plugin.toLanguageServerURI
 import io.snyk.plugin.ui.SnykBalloonNotificationHelper
 import io.snyk.plugin.ui.toolwindow.SnykPluginDisposable
@@ -95,6 +98,7 @@ import snyk.trust.WorkspaceTrustService
 import snyk.trust.confirmScanningAndSetWorkspaceTrustedStateIfNeeded
 
 private const val INITIALIZATION_TIMEOUT = 20L
+private const val PROTOCOL_VERSION_CHECK_TIMEOUT_SECONDS = 10L
 
 @Service(Service.Level.PROJECT)
 class LanguageServerWrapper(private val project: Project) : Disposable {
@@ -108,6 +112,7 @@ class LanguageServerWrapper(private val project: Project) : Disposable {
   private var authenticatedUser: Map<String, String>? = null
   private var initializeResult: InitializeResult? = null
   private var cliNotFoundWarningDisplayed: Boolean = false
+  private var protocolVersionWarningDisplayed: Boolean = false
   private val gson = Gson()
   private var loginFuture: CompletableFuture<Any>? = null
 
@@ -165,6 +170,28 @@ class LanguageServerWrapper(private val project: Project) : Disposable {
         logger.warn("Failed to set executable permission on CLI: ${e.message}")
         return
       }
+    }
+
+    if (!verifyCliProtocolVersion()) {
+      val required = pluginSettings().requiredLsProtocolVersion
+      val message =
+        "Snyk CLI at $cliPath does not support the required Language Server protocol " +
+          "version ($required). The Snyk Language Server will not be started. " +
+          "Please update the Snyk CLI."
+      logger.warn(message)
+      if (!protocolVersionWarningDisplayed) {
+        val openSettingsAction =
+          NotificationAction.createSimpleExpiring("Open Snyk settings") {
+            ApplicationManager.getApplication().invokeLater {
+              if (project.isDisposed) return@invokeLater
+              ShowSettingsUtil.getInstance()
+                .showSettingsDialog(project, SnykProjectSettingsConfigurable::class.java)
+            }
+          }
+        SnykBalloonNotificationHelper.showWarn(message, project, openSettingsAction)
+        protocolVersionWarningDisplayed = true
+      }
+      return
     }
 
     try {
@@ -236,6 +263,50 @@ class LanguageServerWrapper(private val project: Project) : Disposable {
       logger.error("Initialization of Snyk Language Server for ${project.name} failed", e)
       isInitialized = false
       if (processIsAlive()) process.destroyForcibly()
+    }
+  }
+
+  /**
+   * Invokes the CLI binary with `language-server --protocolVersion` and verifies the printed
+   * protocol version matches the plugin's required Language Server protocol version. The check is
+   * fail-closed: any error (timeout, non-zero exit, missing flag, parse failure) causes this method
+   * to return false so that the LS will not be started.
+   */
+  internal fun verifyCliProtocolVersion(): Boolean {
+    val ps = pluginSettings()
+    val required = ps.requiredLsProtocolVersion
+    return try {
+      val processBuilder = ProcessBuilder(cliPath, "language-server", "--protocolVersion")
+      processBuilder.redirectErrorStream(false)
+      val p = processBuilder.start()
+      val output = p.inputStream.bufferedReader().use { it.readText() }
+      val finished = p.waitFor(PROTOCOL_VERSION_CHECK_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+      if (!finished) {
+        p.destroyForcibly()
+        logger.warn(
+          "CLI protocol version check timed out after $PROTOCOL_VERSION_CHECK_TIMEOUT_SECONDS seconds"
+        )
+        return false
+      }
+      val exit = p.exitValue()
+      if (exit != 0) {
+        logger.warn("CLI protocol version check exited with code $exit, output='$output'")
+        return false
+      }
+      val parsed = output.trim().toIntOrNull()
+      if (parsed == null) {
+        logger.warn("CLI protocol version check returned non-integer output: '$output'")
+        return false
+      }
+      ps.currentLSProtocolVersion = parsed
+      val matches = parsed == required
+      if (!matches) {
+        logger.warn("CLI protocol version mismatch: cli=$parsed required=$required")
+      }
+      matches
+    } catch (e: Exception) {
+      logger.warn("Failed to invoke CLI for protocol version check: ${e.message}", e)
+      false
     }
   }
 

--- a/src/test/kotlin/snyk/common/lsp/LanguageServerWrapperTest.kt
+++ b/src/test/kotlin/snyk/common/lsp/LanguageServerWrapperTest.kt
@@ -26,12 +26,14 @@ import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertNotNull
 import junit.framework.TestCase.assertTrue
 import junit.framework.TestCase.fail
+import org.apache.commons.lang3.SystemUtils
 import org.eclipse.lsp4j.DidChangeConfigurationParams
 import org.eclipse.lsp4j.ExecuteCommandParams
 import org.eclipse.lsp4j.InitializeParams
 import org.eclipse.lsp4j.WorkspaceFolder
 import org.eclipse.lsp4j.services.LanguageServer
 import org.junit.After
+import org.junit.Assume.assumeFalse
 import org.junit.Before
 import org.junit.Test
 import snyk.common.lsp.analytics.ScanDoneEvent
@@ -981,6 +983,94 @@ class LanguageServerWrapperTest {
       outputConfig?.settings?.get(LsFolderSettingsKeys.BASE_BRANCH)?.changed,
     )
   }
+
+  @Test
+  fun `verifyCliProtocolVersion returns true when CLI prints required version`() {
+    assumeFalse("Mock CLI scripts are POSIX shell scripts", SystemUtils.IS_OS_WINDOWS)
+    val scenarios =
+      listOf(
+        VerifyProtocolScenario(
+          name = "exact match",
+          script = "echo ${settings.requiredLsProtocolVersion}",
+          expected = true,
+        ),
+        VerifyProtocolScenario(
+          name = "exact match with trailing newline whitespace",
+          script = "printf '${settings.requiredLsProtocolVersion}\\n'",
+          expected = true,
+        ),
+        VerifyProtocolScenario(
+          name = "exact match with surrounding whitespace",
+          script = "printf '  ${settings.requiredLsProtocolVersion}  \\n'",
+          expected = true,
+        ),
+        VerifyProtocolScenario(name = "version mismatch", script = "echo 1", expected = false),
+        VerifyProtocolScenario(
+          name = "non-integer output",
+          script = "echo not-a-number",
+          expected = false,
+        ),
+        VerifyProtocolScenario(name = "empty output", script = "true", expected = false),
+        VerifyProtocolScenario(
+          name = "non-zero exit code",
+          script = "echo ${settings.requiredLsProtocolVersion}\nexit 2",
+          expected = false,
+        ),
+      )
+    for (scenario in scenarios) {
+      val scriptFile =
+        java.io.File.createTempFile("snyk-cli-mock-", ".sh").apply {
+          writeText("#!/bin/sh\n${scenario.script}\n")
+          setExecutable(true)
+          deleteOnExit()
+        }
+      try {
+        every { getCliFile() } returns scriptFile
+
+        val result = cut.verifyCliProtocolVersion()
+
+        assertEquals("scenario '${scenario.name}'", scenario.expected, result)
+      } finally {
+        scriptFile.delete()
+      }
+    }
+  }
+
+  @Test
+  fun `verifyCliProtocolVersion returns false when CLI binary cannot be executed`() {
+    val nonExistent = java.io.File("/nonexistent/snyk-cli-${UUID.randomUUID()}")
+    every { getCliFile() } returns nonExistent
+
+    val result = cut.verifyCliProtocolVersion()
+
+    assertFalse(result)
+  }
+
+  @Test
+  fun `verifyCliProtocolVersion updates currentLSProtocolVersion when CLI returns integer`() {
+    assumeFalse("Mock CLI scripts are POSIX shell scripts", SystemUtils.IS_OS_WINDOWS)
+    val scriptFile =
+      java.io.File.createTempFile("snyk-cli-mock-", ".sh").apply {
+        writeText("#!/bin/sh\necho 7\n")
+        setExecutable(true)
+        deleteOnExit()
+      }
+    try {
+      every { getCliFile() } returns scriptFile
+
+      cut.verifyCliProtocolVersion()
+
+      assertEquals(7, settings.currentLSProtocolVersion)
+    } finally {
+      scriptFile.delete()
+    }
+  }
+
+  private data class VerifyProtocolScenario(
+    val name: String,
+    val script: String,
+    val expected: Boolean,
+  )
 
   private fun simulateRunningLS() {
     cut.languageClient = mockk(relaxed = true)


### PR DESCRIPTION
### **User description**
### Description

Gate the Snyk Language Server launch on a CLI protocol-version check.

Before launching the LS process, `LanguageServerWrapper.initialize()` now executes the configured CLI binary with `language-server --protocolVersion`, parses the printed integer, and compares it against `pluginSettings().requiredLsProtocolVersion`.

- Match: LS launches as before.
- Mismatch / missing flag / non-zero exit / parse error / timeout: LS is **not** started, a warning is logged, and a **balloon notification** is shown with an **"Open Snyk settings"** action that takes the user directly to the Snyk settings dialog.
- The balloon is only shown once per wrapper instance to avoid notification spam.
- The existing post-`initialize` `ensureLanguageServerProtocolVersion` check is retained as a fallback.
- Side effect: `currentLSProtocolVersion` is updated when the CLI returns a parseable integer.

The CLI-side `--protocolVersion` flag is being added in parallel.

#### Reason
New versions of the IDE would start language server instances without checking, potentially overwriting old configurations because of protocol version mismatches. In the language server logic, the protocol version is only checked after configuration is written. 

This is why the plugin now checks with a new parameter, which protocol version a language server supports. If this is not identical, language server is not launched by IntelliJ.

### Checklist

- [x] Read and understood the [Code of Conduct](https://github.com/snyk/snyk-intellij-plugin/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/snyk-intellij-plugin/blob/master/CONTRIBUTING.md).
- [x] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_n/a — backend-only behavior change; balloon uses the standard `SnykBalloonNotificationHelper.showWarn` styling._


___

### **PR Type**
Enhancement


___

### **Description**
- Gate Snyk Language Server launch on CLI protocol version.

- Handle version mismatches with user notifications.

- Update `currentLSProtocolVersion` setting from CLI output.

- Add comprehensive tests for the new logic.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CLI["Snyk CLI Binary"] --> Check["CLI Protocol Version Check"]
  Check -- "Match" --> LS["Snyk Language Server"]
  Check -- "Mismatch" --> Notify["User Notification & Settings"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement, error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LanguageServerWrapper.kt</strong><dd><code>Add CLI protocol version check and gating logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt

<ul><li>Implement <code>verifyCliProtocolVersion</code> to check CLI's protocol support.<br> <li> Gate LS initialization based on protocol version match.<br> <li> Show balloon notification and open settings on mismatch.<br> <li> Update <code>currentLSProtocolVersion</code> setting from CLI output.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-intellij-plugin/pull/819/changes#diff-7ab8b7f2e05d19f7d673c7978b0e9108af49a56d83c6c854676dac76eb4ec377">+71/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LanguageServerWrapperTest.kt</strong><dd><code>Add tests for protocol version check functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/kotlin/snyk/common/lsp/LanguageServerWrapperTest.kt

<ul><li>Add tests for <code>verifyCliProtocolVersion</code> success cases.<br> <li> Include tests for various failure scenarios (mismatch, invalid output, <br>exit codes).<br> <li> Test handling of non-executable CLI binaries.<br> <li> Verify <code>currentLSProtocolVersion</code> update.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-intellij-plugin/pull/819/changes#diff-00f3f6aa0e06837878a80b44f86354478d04c5cad631b47caa1298826bd33ce3">+90/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

