### PR TITLE
test(auth): persist refreshed OAuth token [IDE-1900]

### DIFF
--- a/src/test/kotlin/snyk/common/lsp/SnykLanguageClientTest.kt
+++ b/src/test/kotlin/snyk/common/lsp/SnykLanguageClientTest.kt
@@ -236,6 +236,28 @@ class SnykLanguageClientTest {
   }
 
   @Test
+  fun `hasAuthenticated persists refreshed OAuth token and force saves settings`() {
+    val lsWrapperMock = mockk<LanguageServerWrapper>(relaxed = true)
+    mockkObject(LanguageServerWrapper.Companion)
+    every { LanguageServerWrapper.getInstance(projectMock) } returns lsWrapperMock
+
+    mockkStatic(StoreUtil::class)
+    justRun { StoreUtil.saveSettings(any(), any()) }
+    justRun { publishAsync<Any>(any(), any(), any()) }
+
+    settings.token =
+      """{"access_token":"old","refresh_token":"old-refresh","expiry":"2026-05-06T10:00:00Z"}"""
+    val refreshedToken =
+      """{"access_token":"fresh","refresh_token":"fresh-refresh","expiry":"2026-05-06T11:00:00Z"}"""
+
+    cut.hasAuthenticated(HasAuthenticatedParam(refreshedToken, ""))
+
+    assertEquals(refreshedToken, settings.token)
+    verify(exactly = 1) { lsWrapperMock.cancelPreviousLogin() }
+    verify(exactly = 1) { StoreUtil.saveSettings(applicationMock, true) }
+  }
+
+  @Test
   fun `addTrustedPaths should not run when disposed`() {
     every { applicationMock.isDisposed } returns true
     every { projectMock.isDisposed } returns true


### PR DESCRIPTION
### **User description**
### Description

Adds IntelliJ regression coverage for `$/snyk.hasAuthenticated` handling when the language server sends a refreshed OAuth JSON token. The test verifies the plugin persists the non-empty refreshed token and force-saves settings so rotated refresh tokens survive IDE restarts.

This complements the LS-side IDE-1900 fix in snyk-ls.

### Checklist

- [x] Read and understood the [Code of Conduct](https://github.com/snyk/snyk-intellij-plugin/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/snyk-intellij-plugin/blob/master/CONTRIBUTING.md).
- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [x] README.md updated, if user-facing

### Screenshots / GIFs

No UI changes.

### Verification

- `./gradlew test --tests "snyk.common.lsp.SnykLanguageClientTest.hasAuthenticated persists refreshed OAuth token and force saves settings" --info`
- pre-push hook: `verifyPlugin`
- pre-push hook: `test`


___

### **PR Type**
tests


___

### **Description**
- Added test for OAuth token persistence.

- Verifies saving refreshed tokens.

- Ensures settings are force-saved.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SnykLanguageClientTest.kt</strong><dd><code>Test for OAuth token persistence and settings save</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/kotlin/snyk/common/lsp/SnykLanguageClientTest.kt

<ul><li>Added a new test method <code>hasAuthenticated persists refreshed OAuth </code><br><code>token and force saves settings</code>.<br> <li> This test verifies that <code>hasAuthenticated</code> correctly persists a <br>refreshed OAuth token.<br> <li> It also ensures that the IDE settings are force-saved, so rotated <br>refresh tokens survive IDE restarts.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-intellij-plugin/pull/821/changes#diff-280846bfaa62f843b7da34110e6fcb4ff40d48f243505f6bc887b4d46a32ac84">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

