### PR TITLE
fix(settings): persist per-folder unmanaged-mode toggle [IDE-2089]

### DIFF
--- a/src/main/kotlin/io/snyk/plugin/ui/jcef/ConfigurationDataClasses.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/jcef/ConfigurationDataClasses.kt
@@ -140,6 +140,8 @@ data class FolderConfigData(
   val severityFilterLow: Boolean? = null,
   @SerializedName(value = "snyk_oss_enabled", alternate = ["snykOssEnabled"])
   val snykOssEnabled: Boolean? = null,
+  @SerializedName(value = "snyk_oss_unmanaged_enabled", alternate = ["snykOssUnmanagedEnabled"])
+  val snykOssUnmanagedEnabled: Boolean? = null,
   @SerializedName(value = "snyk_code_enabled", alternate = ["snykCodeEnabled"])
   val snykCodeEnabled: Boolean? = null,
   @SerializedName(value = "snyk_iac_enabled", alternate = ["snykIacEnabled"])

--- a/src/main/kotlin/io/snyk/plugin/ui/jcef/SaveConfigHandler.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/jcef/SaveConfigHandler.kt
@@ -679,6 +679,16 @@ class SaveConfigHandler(
             it,
           )
       }
+      folderConfig.snykOssUnmanagedEnabled?.let {
+        updated =
+          applyFolderSetting(
+            updated,
+            settings,
+            folderPath,
+            LsFolderSettingsKeys.SNYK_OSS_UNMANAGED_ENABLED,
+            it,
+          )
+      }
       folderConfig.snykCodeEnabled?.let {
         updated =
           applyFolderSetting(

--- a/src/main/kotlin/snyk/common/lsp/settings/LanguageServerSettingsKeys.kt
+++ b/src/main/kotlin/snyk/common/lsp/settings/LanguageServerSettingsKeys.kt
@@ -34,6 +34,7 @@ object LsFolderSettingsKeys {
   // Product enablement (folder-scope)
   const val SNYK_CODE_ENABLED = "snyk_code_enabled"
   const val SNYK_OSS_ENABLED = "snyk_oss_enabled"
+  const val SNYK_OSS_UNMANAGED_ENABLED = "snyk_oss_unmanaged_enabled"
   const val SNYK_IAC_ENABLED = "snyk_iac_enabled"
   const val SNYK_SECRETS_ENABLED = "snyk_secrets_enabled"
 

--- a/src/test/kotlin/io/snyk/plugin/ui/jcef/SaveConfigHandlerTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/jcef/SaveConfigHandlerTest.kt
@@ -1051,6 +1051,7 @@ class SaveConfigHandlerTest : BasePlatformTestCase() {
               "severity_filter_medium" to true,
               "severity_filter_low" to false,
               "snyk_oss_enabled" to true,
+              "snyk_oss_unmanaged_enabled" to true,
               "snyk_code_enabled" to false,
               "snyk_iac_enabled" to true,
               "snyk_secrets_enabled" to false,
@@ -1082,6 +1083,7 @@ class SaveConfigHandlerTest : BasePlatformTestCase() {
     assertEquals(true, s[LsFolderSettingsKeys.SCAN_AUTOMATIC]?.value)
     assertEquals(false, s[LsFolderSettingsKeys.SCAN_NET_NEW]?.value)
     assertEquals(true, s[LsFolderSettingsKeys.SNYK_OSS_ENABLED]?.value)
+    assertEquals(true, s[LsFolderSettingsKeys.SNYK_OSS_UNMANAGED_ENABLED]?.value)
     assertEquals(false, s[LsFolderSettingsKeys.SNYK_CODE_ENABLED]?.value)
     assertEquals(42, s[LsFolderSettingsKeys.RISK_SCORE_THRESHOLD]?.value)
   }


### PR DESCRIPTION
## Summary
- Settings panel's *Use unmanaged mode for this folder* checkbox under Snyk Open Source was silently dropped on save.
- Root cause: the panel→LS bridge uses an explicit field allowlist in three places, and none of them knew about \`snyk_oss_unmanaged_enabled\`. Gson dropped the field, the save handler had nothing to forward, and the LS never received the change — so the toggle never persisted while every other scanner toggle did.
- Fix: declare the field on \`FolderConfigData\`, add the matching \`LsFolderSettingsKeys.SNYK_OSS_UNMANAGED_ENABLED\` constant, and forward it from \`SaveConfigHandler\` exactly like \`snykOssEnabled\`.
- Extended the comprehensive \`SaveConfigHandlerTest\` payload to include the new field and assert it round-trips into the stored folder settings.

Sibling repos audited at the same time:

| Plugin | Folder-config save path | Needs change |
|---|---|---|
| IntelliJ | hardcoded per-field allowlist | **yes (this PR)** |
| VS Code | generic \`FolderConfig.setSetting(key, value)\` pass-through | no |
| Eclipse | generic \`LspFolderConfig.withSetting(key, value, true)\` pass-through | no |
| Visual Studio | \`FolderConfigData\` defines no per-folder scanner toggles at all | pre-existing wider gap, not IDE-2089's scope |

Jira: [IDE-2089](https://snyk.atlassian.net/browse/IDE-2089)

## Test plan
- [x] \`./gradlew :test --tests "io.snyk.plugin.ui.jcef.SaveConfigHandlerTest"\` (passes locally, --rerun-tasks)
- [ ] Manual: toggle the unmanaged checkbox in the per-folder Snyk Open Source section, click Save, reopen settings, confirm the checkbox stays checked and the LS receives \`snyk_oss_unmanaged_enabled\` in the next \`workspace/didChangeConfiguration\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[IDE-2089]: https://snyksec.atlassian.net/browse/IDE-2089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ