### PR TITLE
fix: global scanning mode Auto now persists correctly [IDE-1992]

### DIFF
--- a/src/main/kotlin/io/snyk/plugin/ui/jcef/ConfigurationDataClasses.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/jcef/ConfigurationDataClasses.kt
@@ -62,8 +62,7 @@ data class SaveConfigRequest(
   val activateSnykIac: Boolean? = null,
   @SerializedName(value = "snyk_secrets_enabled", alternate = ["activateSnykSecrets"])
   val activateSnykSecrets: Boolean? = null,
-  @SerializedName(value = "scan_automatic", alternate = ["scanningMode"])
-  val scanningMode: String? = null,
+  @SerializedName("scan_automatic") val scanningMode: Boolean? = null,
 
   // Connection Settings
   @SerializedName("organization") val organization: String? = null,

--- a/src/main/kotlin/io/snyk/plugin/ui/jcef/SaveConfigHandler.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/jcef/SaveConfigHandler.kt
@@ -282,13 +282,11 @@ class SaveConfigHandler(
       }
 
       // Scanning mode
-      val hasScanningMode = (config.scanningMode != null)
-      val scanOnSaveValue = config.scanningMode?.let { mode -> mode == "auto" }
       applyGlobalSetting(
         settings = settings,
         key = LsFolderSettingsKeys.SCAN_AUTOMATIC,
-        isPresent = hasScanningMode,
-        newValue = scanOnSaveValue,
+        isPresent = (config.scanningMode != null),
+        newValue = config.scanningMode,
         currentValue = { settings.scanOnSave },
       ) {
         settings.scanOnSave = it

--- a/src/test/kotlin/io/snyk/plugin/ui/jcef/SaveConfigHandlerTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/jcef/SaveConfigHandlerTest.kt
@@ -88,10 +88,10 @@ class SaveConfigHandlerTest : BasePlatformTestCase() {
     realSettings.scanOnSave = false
     every { pluginSettings() } returns realSettings
 
-    val jsonConfig = """{"scanningMode": "auto"}"""
-    invokeParseAndSaveConfig(jsonConfig)
+    invokeParseAndSaveConfig("""{"scan_automatic": true}""")
 
     assertTrue(realSettings.scanOnSave)
+    assertTrue(realSettings.isExplicitlyChanged(LsFolderSettingsKeys.SCAN_AUTOMATIC))
   }
 
   fun `test parseAndSaveConfig should update organization and endpoint`() {
@@ -556,7 +556,7 @@ class SaveConfigHandlerTest : BasePlatformTestCase() {
             "activateSnykCode": true,
             "activateSnykIac": true,
             "activateSnykSecrets": true,
-            "scanningMode": "auto",
+            "scan_automatic": true,
             "severity_filter_critical": true,
             "severity_filter_high": true,
             "severity_filter_medium": false,
@@ -1227,12 +1227,12 @@ class SaveConfigHandlerTest : BasePlatformTestCase() {
     assertEquals(AuthenticationType.PAT, realSettings.authenticationType)
   }
 
-  fun `test parseAndSaveConfig scanningMode manual sets scanOnSave false and marks SCAN_AUTOMATIC`() {
+  fun `test parseAndSaveConfig scan_automatic false sets scanOnSave false and marks SCAN_AUTOMATIC`() {
     val realSettings = SnykApplicationSettingsStateService()
     realSettings.scanOnSave = true
     every { pluginSettings() } returns realSettings
 
-    invokeParseAndSaveConfig("""{"scanningMode": "manual"}""")
+    invokeParseAndSaveConfig("""{"scan_automatic": false}""")
 
     assertFalse(realSettings.scanOnSave)
     assertTrue(realSettings.isExplicitlyChanged(LsFolderSettingsKeys.SCAN_AUTOMATIC))


### PR DESCRIPTION
### **User description**
## Summary
- `SaveConfigRequest.scanningMode` was typed `String?`, causing Gson to coerce the JSON boolean `true` (sent by the LS settings page) into the string `"true"`. The subsequent comparison `"true" == "auto"` was always false, so selecting **Auto** silently saved as **Manual** every time.
- Fix: change the field type to `Boolean?` so Gson deserializes the wire value natively. Remove the now-unnecessary `alternate = ["scanningMode"]` key and the `mode == "auto"` string-to-boolean conversion in the handler.
- Update all scanning-mode tests to use the real wire format (`{"scan_automatic": true/false}`) instead of the obsolete string alternates that only existed in tests.

## Test plan
- [ ] Build and run the plugin locally
- [ ] Open Snyk settings → Project defaults → set Scanning mode = **Auto**, click OK
- [ ] Reopen settings → Project defaults → Scanning mode should show **Auto**
- [ ] Repeat for **Manual**
- [ ] `SaveConfigHandlerTest` passes (covers `scan_automatic: true/false` and `isExplicitlyChanged`)


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes the persistence of the 'Auto' global scanning mode.

- Corrects the `scanningMode` data type from `String?` to `Boolean?`.

- Updates handler logic and tests to use the boolean type.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ConfigurationDataClasses.kt: scanningMode (Boolean?)"] --> B["SaveConfigHandler.kt: Apply settings logic"];
  B --> C["SaveConfigHandlerTest.kt: Updated test cases"];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ConfigurationDataClasses.kt</strong><dd><code>Update scanning mode data type in SaveConfigRequest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/kotlin/io/snyk/plugin/ui/jcef/ConfigurationDataClasses.kt

<ul><li>Changed the type of the <code>scanningMode</code> field in <code>SaveConfigRequest</code> from <br><code>String?</code> to <code>Boolean?</code>.<br> <li> Removed the <code>alternate = ["scanningMode"]</code> from the <code>scan_automatic</code> <br>serialized name.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-intellij-plugin/pull/835/changes#diff-f6182041b276430b8e0472fd1d76eb89347eefaeec76fb004fda0ae2d2e3a215">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SaveConfigHandler.kt</strong><dd><code>Adapt SaveConfigHandler for boolean scanning mode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/kotlin/io/snyk/plugin/ui/jcef/SaveConfigHandler.kt

<ul><li>Removed logic that converted the string value of <code>scanningMode</code> to a <br>boolean.<br> <li> Updated the <code>applyGlobalSetting</code> call for <code>SCAN_AUTOMATIC</code> to use the <br>direct <code>Boolean?</code> value.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-intellij-plugin/pull/835/changes#diff-7a45bcdcd7158b2995c550f9e10be6c2250c2adceee34b2a2f7fc6c591f843f5">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SaveConfigHandlerTest.kt</strong><dd><code>Update tests for boolean scanning mode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/kotlin/io/snyk/plugin/ui/jcef/SaveConfigHandlerTest.kt

<ul><li>Updated test cases to use <code>{"scan_automatic": true/false}</code> JSON format <br>instead of <code>{"scanningMode": "auto/manual"}</code>.<br> <li> Renamed a test function to reflect the boolean parameter.<br> <li> Added assertions for <code>isExplicitlyChanged</code> on the scanning mode.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-intellij-plugin/pull/835/changes#diff-622128219f9ae8c6bb3755bc900be83782411e0cd27b94762989ea994f6197cd">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

