### PR TITLE
fix(build): run MockK tests and coverage in the dev container via JaCoCo backend

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,11 @@ repos:
         pass_filenames: false
       - id: test
         name: test
-        entry: ./gradlew test
+        # Delegates to scripts/pre-push-test.sh, which resolves JAVA_HOME robustly
+        # (immune to dangling symlinks in the dev-container) and runs
+        # ./gradlew test. JaCoCo is the coverage backend unconditionally — no flags
+        # are needed. See ADR-2 in docs/requirements/architecture.md.
+        entry: bash scripts/pre-push-test.sh
         language: system
         stages: [pre-push]
         pass_filenames: false

--- a/AGENT.md
+++ b/AGENT.md
@@ -40,7 +40,7 @@ alwaysApply: true
 - I REPEAT: USE TDD
 - always write and update test cases before writing the implementation (Test Driven Development). iterate until they pass.
 - after changing .kt or .java files, run `./gradlew spotlessCheck ktlintCheck` to check formatting and lint. only continue, once they pass.
-- always verify if fixes worked by running `./gradlew test`
+- always verify if fixes worked by running the appropriate test command (see below)
 - do atomic commits, see committing section for details. ask before committing an atomic commit.
 - update current status in the implementation plan (in progress work, finished work, next steps)
 - Maintain existing code patterns and conventions
@@ -48,7 +48,13 @@ alwaysApply: true
 - Re-use mocks.
 - don't change code that does not need to be changed. only do the minimum changes.
 - don't comment what is done, instead comment why something is done if the code is not clear
-- use `./gradlew test` to run tests.
+- **Running tests** — `./gradlew test` everywhere (CI and in-container). No flags needed.
+  JaCoCo is the coverage backend unconditionally; it coexists with MockK's ByteBuddy
+  instrumentation without conflict (see ADR-2 in `docs/requirements/architecture.md`).
+  The ByteBuddy agent is preloaded automatically via `build.gradle.kts`.
+  In the Docker Desktop dev-container, set `JAVA_HOME` to your JDK before running:
+  `JAVA_HOME=/path/to/your/jdk ./gradlew test`
+  The pre-push hook resolves `JAVA_HOME` robustly — no manual configuration needed for hooks.
 - achieve 80% of test coverage. use `./gradlew koverXmlReport`
 - if files are not used or needed anymore, delete them instead of deprecating them.
 - ask the human, whether to maintain backwards compatibility or not
@@ -75,7 +81,7 @@ alwaysApply: true
 - NEVER amend commits, keep a history so we can revert atomic commits
 - NEVER NEVER NEVER skip the commit hooks
 - I REPEAT: NEVER USE --no-verify. DO NOT DO IT. NEVER. THIS IS CRITICAL, DO NOT DO IT.
-- run ./gradlew test before committing and fix the issues. don't run targeted tests, run the full suite (which may take >10min)
+- run the full test suite before committing and fix the issues (may take >10min). Use `./gradlew test` (no flags needed; see coding_guidelines above). Don't run targeted tests, run the full suite.
 - test failures prevent committing, regardless if caused by our changes. they MUST be fixed, even if they existed before. 
 - deactivating tests is NEVER ALLOWED.
 - check with Kover (`./gradlew koverXmlReport`) that coverage of changed files is 80%+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,31 @@ Should be mostly done trough [IntelliJ Platform Testing Framework](https://plugi
 
 Mocks are [not recommended](https://plugins.jetbrains.com/docs/intellij/testing-plugins.html#mocks) by Jetbrains, but we heavily (and successfully) use Mockk framework. Just be careful not to mock whole world and make sure you're testing real functionality and not mocked one.
 
+#### Running tests in the Docker Desktop dev-container
+
+The Docker Desktop LinuxKit VM has one known constraint: **HotSpot dynamic attach is
+non-functional.** MockK uses a JVM self-attach at init to obtain an `Instrumentation` handle for
+final-class mocking and `mockkStatic`. The build pre-loads the ByteBuddy agent automatically
+(via `jvmArgumentProviders` in `build.gradle.kts`), so no self-attach is needed and no extra
+flag is required.
+
+**JaCoCo is used as the coverage backend unconditionally** (CI and in-container). JaCoCo
+coexists with MockK's ByteBuddy instrumentation without conflict; no flag is needed to disable
+it. Coverage is available locally via `./gradlew koverXmlReport` after `./gradlew test`.
+
+In-container run (set `JAVA_HOME` to your JDK — the exact path varies by installation):
+
+```bash
+JAVA_HOME=/path/to/your/jdk ./gradlew test
+```
+
+Outside the container, run plain `./gradlew test` (set `JAVA_HOME` if your shell's `JAVA_HOME`
+points to a dangling symlink).
+
+The ByteBuddy agent is preloaded automatically — no additional flags are needed.
+The pre-push hook (`scripts/pre-push-test.sh`) resolves `JAVA_HOME` robustly from the running
+JVM and runs `./gradlew test` — no flags, no container detection needed.
+
 ### Running the extension
 
 - From the toolbar click `Run` -> `Run`

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -130,6 +130,14 @@ ktlint { ignoreFailures.set(false) }
 
 // Configure Kover for code coverage
 kover {
+  // Use JaCoCo as the coverage backend everywhere (CI and in-container dev).
+  // The native Kover agent conflicts with MockK's ByteBuddy inline instrumentation: both agents
+  // retransform the same classes, causing "class redefinition failed: attempted to delete a
+  // method" (UnsupportedOperationException). JaCoCo does not retransform at instrumentation time
+  // and coexists with ByteBuddy without conflict. Validated: JaCoCo overall coverage = 52.03%
+  // (vs native Kover 54.26%), well above the 40% gate; CI Test job passes. Using the same backend
+  // in CI and in-container makes coverage numbers consistent — no flags, no env-conditional logic.
+  useJacoco("0.8.14")
   reports {
     total {
       xml {
@@ -170,6 +178,41 @@ tasks {
   withType<Test> {
     maxHeapSize = "4096m"
     testLogging { exceptionFormat = TestExceptionFormat.FULL }
+    // Preload the ByteBuddy agent at test-JVM startup so MockK never needs runtime self-attach.
+    // This is unconditional and harmless under the JaCoCo backend (JaCoCo uses class-file
+    // transformation at load time, not retransformation, so it does not conflict with ByteBuddy).
+    // In the Docker Desktop LinuxKit VM, HotSpot dynamic attach is non-functional; preloading the
+    // agent (which MockK would otherwise install via self-attach) makes final-class mocking and
+    // mockkStatic work in-container without any flag. Uses jvmArgumentProviders (not jvmArgs) for
+    // lazy/execution-time resolution of the classpath (resolved at execution time, not at
+    // configuration time, avoiding configuration-phase failures). Sources the jar dynamically from
+    // the resolved test classpath so the version tracks MockK bumps automatically
+    // (byte-buddy-agent is transitive via mockk-agent-jvm).
+    val testClasspath = classpath
+    jvmArgumentProviders.add(
+      CommandLineArgumentProvider {
+        val classpathFiles = testClasspath.files
+        val hasMockk = classpathFiles.any { it.name.startsWith("mockk-") }
+        // Only enforce the byte-buddy-agent requirement when MockK is on the classpath:
+        // withType<Test> applies to all Test-typed tasks (including future tasks such as
+        // testIdeUi) whose classpath may not include MockK or byte-buddy-agent at all.
+        // When MockK is absent the agent is not needed; return an empty list so such tasks
+        // are unaffected. When MockK IS present, a missing or duplicate byte-buddy-agent
+        // indicates a real dependency regression and we fail loudly.
+        if (!hasMockk) {
+          return@CommandLineArgumentProvider emptyList()
+        }
+        val agentJars = classpathFiles.filter { it.name.startsWith("byte-buddy-agent-") }
+        if (agentJars.size != 1) {
+          throw GradleException(
+            "Expected exactly one byte-buddy-agent-*.jar on the test classpath " +
+              "but found ${agentJars.size}: ${agentJars.map { it.name }}. " +
+              "Check if io.mockk:mockk-agent-jvm still pulls in net.bytebuddy:byte-buddy-agent."
+          )
+        }
+        listOf("-javaagent:${agentJars.single().absolutePath}")
+      }
+    )
   }
 
   // Configure the PatchPluginXml task

--- a/docs/plans/PLAN.md
+++ b/docs/plans/PLAN.md
@@ -1,0 +1,47 @@
+# snyk-intellij-plugin — Implementation & Roadmap
+
+**Last updated:** 2026-06-29
+**Repo:** github.com/snyk/snyk-intellij-plugin
+
+> Single source of truth for completed, in-progress, and pending work.
+> Sub-plans linked below carry per-PR specs. Full durable specs live in the engineering brain
+> (private — Bastian only).
+
+## Status legend
+
+| Symbol | Meaning |
+|--------|---------|
+| done | Merged to `master` |
+| wip | In progress |
+| planned | Planned - not started |
+| dropped | Cancelled / deferred |
+
+## Completed work
+
+<!-- add entries here as PRs merge -->
+
+---
+
+## In progress
+
+<!-- active branch work -->
+
+---
+
+## Pending
+
+### Dev-container MockK / ByteBuddy test fix
+
+**Sub-plan:** [container-mockk-bytebuddy-agent.md](container-mockk-bytebuddy-agent.md)
+
+| PR | Title | Items | Notes |
+|----|-------|-------|-------|
+| wip PR-1 | ByteBuddy preload + JaCoCo backend (unconditional) | `build.gradle.kts`: keep `withType<Test>` agent preload + `useJacoco("0.8.14")` unconditionally in `kover { }` (no flag); simplify `scripts/pre-push-test.sh` (no container detection); update docs, ADR-2 | Makes `./gradlew test` pass everywhere (CI and in-container) with no flags. JaCoCo coexists with MockK's ByteBuddy — no retransform conflict. Local in-container coverage available via `./gradlew koverXmlReport`. Supersedes the `-PdisableKoverInstrumentation` flag approach (ADR-2). |
+
+---
+
+## Architecture reference
+
+| Document | Purpose |
+|----------|---------|
+| [../../ARCHITECTURE.md](../../ARCHITECTURE.md) | Plugin architecture overview |

--- a/docs/plans/container-mockk-bytebuddy-agent.md
+++ b/docs/plans/container-mockk-bytebuddy-agent.md
@@ -1,0 +1,102 @@
+<!-- sub-plan: linked from docs/plans/PLAN.md -->
+
+# ByteBuddy preload + JaCoCo backend (unconditional) so MockK tests run in the dev container
+
+**Ticket:** none assigned
+**Branch:** `fix/container-mockk-bytebuddy-agent` (from `master`)
+**Status:** In progress — JaCoCo-everywhere approach (ADR-2; supersedes flag-gated ADR-1)
+**Last updated:** 2026-06-29
+
+> Full durable spec (test scenarios, risks, decision log) and ADR-1 live in the engineering brain.
+> This file is the committed, repo-visible per-PR summary linked from `docs/plans/PLAN.md`.
+
+## Problem (customer outcome)
+
+A developer in the Docker Desktop dev-container cannot run `./gradlew test` locally: MockK-based
+tests fail at initialization, forcing `SKIP=test` on push. CI runs the same suite green because it
+runs on GitHub-hosted runner VMs, not the dev-container's LinuxKit VM. This change makes the
+in-container suite initialize and pass **without changing CI behaviour or coverage**.
+
+## Root cause (validated) — two independent failures
+
+1. **Attach (fixed by the agent preload, already on the branch):** in the LinuxKit VM, HotSpot dynamic
+   attach is non-functional (the attach-listener socket is never created). MockK uses a runtime JVM
+   self-attach (via ByteBuddy) at init to get a retransformation-capable `Instrumentation` handle, so
+   MockK init throws `AttachNotSupportedException`. Fixed by preloading the ByteBuddy agent.
+2. **Retransform (this change):** the residual failures are
+   `UnsupportedOperationException: class redefinition failed: attempted to delete a method` on
+   `mockkStatic` / final-class retransforms. **Root cause: the Kover coverage java-agent conflicts with
+   MockK's ByteBuddy inline instrumentation in the same test JVM.** Proven: disabling Kover
+   instrumentation in-container took `UtilsKtTest` from 12/16 failing to 1/16 (the remaining one an
+   ordinary assertion), and a `mockkStatic` test built successfully — on the same bundled JBR.
+
+It is **NOT** caused by JBR, **NOT** by Linux/ARM, and **NOT** by the byte-buddy version. A runtime
+switch off JBR is **impossible** (the IntelliJ Platform Gradle Plugin pins the bundled JBR for the
+test task; a Corretto launcher override is silently ignored). Disproven dead ends — do NOT add:
+`java.io.tmpdir` changes, `-Djdk.attach.allowAttachSelf=true`, `-XX:+StartAttachListener`,
+`SYS_PTRACE`, a non-JBR runtime, or treating byte-buddy 1.15.x vs 1.14.17 as the cause.
+
+## Fix
+
+**Part A — ByteBuddy preload (already on the branch; keep).** In `build.gradle.kts`
+`tasks { withType<Test> { ... } }`, preload the ByteBuddy agent via `jvmArgumentProviders` (a
+`CommandLineArgumentProvider`), sourcing `byte-buddy-agent-*.jar` **dynamically by filename** from the
+resolved test classpath (transitive via `io.mockk:mockk-agent-jvm` -> `net.bytebuddy:byte-buddy-agent`;
+version unpinned, currently 1.15.11). Match the trailing hyphen so the core `byte-buddy-<ver>.jar` is
+never selected; fail the build loudly on a !=1 match. Unconditional on all platforms (preload is a
+harmless superset of runtime attach, so CI stays identical); `withType<Test>` covers extra test tasks.
+
+**Part B — JaCoCo backend unconditional (supersedes flag-gated opt-out, ADR-2).** In the existing
+`kover { }` block, replace the conditional `disableKoverInstrumentation` guard with an unconditional
+`useJacoco("0.8.14")` as the first statement. JaCoCo instruments at class-load time (not
+retransformation), so it does not conflict with MockK's ByteBuddy inline instrumentation.
+Validated: JaCoCo overall coverage = 52.03% on CI (vs native Kover 54.26%), well above the 40%
+gate. CI and in-container now use the same backend — no flags, no container detection.
+
+```kotlin
+kover {
+  useJacoco("0.8.14")
+  reports { /* unchanged — onCheck = true stays */ }
+}
+```
+
+Local in-container run (set JAVA_HOME to your JDK):
+`JAVA_HOME=/path/to/your/jdk ./gradlew test`
+Coverage: `./gradlew koverXmlReport` → `build/reports/kover/report.xml`.
+
+**Part C — byte-buddy force.** The `resolutionStrategy.force(...byte-buddy...:1.14.17)` that was on
+this branch was NOT the retransform fix (the failure persisted with it). Empirically verified: tests
+pass identically whether byte-buddy is forced to 1.14.17 or resolved naturally to 1.15.11 (via
+MockK's transitive dependency). The force and its misleading "JBR retransform" comment have been
+reverted.
+
+## Tests (outside-in)
+
+| ID | Layer | Assertion |
+|----|-------|-----------|
+| ACC-001 | Acceptance | A final-class MockK test passes in-container via `./gradlew test` (no flag); **no** `AttachNotSupportedException` AND **no** `attempted to delete a method` |
+| ACC-002 | Acceptance | A `mockkStatic` test passes in-container with no flag |
+| ACC-003 | Acceptance | Full `./gradlew test` suite green in-container with no flag; no test skipping needed |
+| INT-001 | Integration | Effective test JVM args contain exactly one `-javaagent:byte-buddy-agent-*.jar` resolving to an existing file (RED if the line is removed) |
+| INT-002 | Integration | Resolver selects the agent jar (not the core jar); fails loudly on a !=1 match (RED if pattern matches `byte-buddy`) |
+| INT-003 | Integration | Test JVM receives the `jacoco-coverage-agent` arg AND no `kover-jvm-agent-*.jar` (RED if JaCoCo backend is removed) |
+| INT-004 | Integration | `./gradlew koverXmlReport` produces `build/reports/kover/report.xml` with no flag |
+| MAN-001 | Manual/CI | CI `test` job stays green on ubuntu/macos/windows AND still produces the Kover/JaCoCo report |
+
+RED-first reference: the native Kover backend (pre-ADR-2) produced `attempted to delete a method`
+in-container. The JaCoCo backend eliminates this. CI failure (pre-fix) was the confirmed red state.
+
+## Out of scope / non-goals
+
+- No `jdk.attach.*` / `StartAttachListener` flags, no `SYS_PTRACE`, no runtime switch off JBR (all
+  disproven / impossible).
+- No machine-specific JAVA_HOME baked into the build (would break CI/other devs).
+- No new Kotlin/Java source; this is a build-config + docs + pre-push-hook change.
+- Local in-container coverage is now available via `./gradlew koverXmlReport` (JaCoCo backend).
+  The FOLLOW-UP from ADR-1 is resolved by ADR-2.
+
+## Effort
+
+| PR | Scope | Agent dev | Review | Manual | Total |
+|----|-------|-----------|--------|--------|-------|
+| PR-1 | JaCoCo backend (unconditional) + keep agent preload + isCliInstalled exec-bit fix + docs/pre-push-hook + verification | 0.5d | 1.0d | 0.5d | 2.0d |

--- a/docs/requirements/architecture.md
+++ b/docs/requirements/architecture.md
@@ -1,0 +1,62 @@
+# Architecture Decisions
+
+## Resolve Kover↔MockK java-agent conflict (keep tests on JBR) for the Linux-ARM dev container
+
+- **Ticket:** container-mockk-bytebuddy-agent
+- **Date:** 2026-06-29
+- **Status:** Accepted
+
+```mermaid
+flowchart TB
+    subgraph TestJVM["Test JVM (bundled JBR 21, aarch64 — pinned by IntelliJ Platform Gradle Plugin)"]
+        A1["coroutines-javaagent.jar"]
+        A2["byte-buddy-agent.jar (MockK preload — CP-1)"]
+        A3["kover-jvm-agent.jar (coverage)"]
+    end
+    A3 -. "retransform conflict:<br/>'class redefinition failed:<br/>attempted to delete a method'" .-> A2
+    A2 --> X["mockkStatic / final-class mocks FAIL (~404 tests)"]
+
+    subgraph Fix["Decision: gate Kover instrumentation off by explicit flag"]
+        G{"opt-out flag set?"}
+        G -->|"No (CI: clean ktlintCheck spotlessCheck check)"| K1["Kover ON — coverage report unchanged"]
+        G -->|"Yes (LinuxKit dev container + pre-push)"| K2["Kover agent absent from test JVM<br/>→ MockK retransform succeeds on JBR"]
+    end
+
+    X -. "fixed by" .-> Fix
+```
+
+**Decision.** Keep the Gradle `test` task on the IntelliJ-Platform-mandated bundled JBR and make MockK-based tests pass in the Docker Desktop (LinuxKit, Linux-ARM) dev container by **removing the Kover coverage java-agent from the test JVM only where it conflicts**, via an explicit, default-off opt-out flag in the existing `kover { }` block of `build.gradle.kts`. The proven root cause is not the JVM and not the byte-buddy version: the test JVM runs three java-agents, and the Kover coverage agent conflicts with MockK's ByteBuddy inline instrumentation, producing `UnsupportedOperationException: class redefinition failed: attempted to delete a method` on `mockkStatic` / final-class retransforms. Disabling Kover instrumentation (nothing else) took `UtilsKtTest` from 12/16 failing to 1/16 (the one being an ordinary `AssertionFailedError`, no instrumentation error) and made `IgnoreServiceTest` (a `mockkStatic` user) build successfully — all on the same JBR. The runtime-switch alternatives (run on Corretto/Temurin; split JCEF vs non-JCEF test tasks; pick a newer JBR; OS/arch-conditional JVM) were rejected: the IntelliJ Platform Gradle Plugin 2.5.0 resolves the test runtime through `JavaRuntimePathResolver`, which always selects the bundled JBR and only honours a Java Toolchain whose vendor is "JetBrains", so a Corretto `javaLauncher` override is silently ignored (verified — the launcher resolved back to `JetBrains s.r.o.`); and the failure is the agent conflict, not the runtime, so no JVM change can fix it. The byte-buddy `resolutionStrategy.force("1.14.17")` currently on the branch is not load-bearing (the failure persisted with it applied) and its correctness is left for the coder to re-verify once Kover is out of the test JVM. CI safety is structural: the opt-out defaults to off, CI never sets the flag, so CI's agent set, coverage (`onCheck = true`), and test outcomes on ubuntu/macos/windows are byte-for-byte unchanged; only the opting-in LinuxKit container diverges, mirroring the existing local/CI asymmetry rather than adding a new one. The disproven dead ends remain forbidden (`jdk.attach.*`, `StartAttachListener`, `SYS_PTRACE`, `java.io.tmpdir` changes, switching the test runtime off JBR). Full record: brain ADR-1 (`adr-1-kover-mockk-agent-conflict.md`).
+
+---
+
+## ADR-2: Use JaCoCo as the coverage backend unconditionally (supersedes ADR-1 flag-gating)
+
+- **Ticket:** container-mockk-bytebuddy-agent / container-local-coverage-jacoco
+- **Date:** 2026-06-30
+- **Status:** Accepted — supersedes the `-PdisableKoverInstrumentation` flag-gating in ADR-1
+
+**Context.** ADR-1 resolved the native-Kover↔MockK retransform conflict by introducing a
+`-PdisableKoverInstrumentation` flag that removed the Kover agent in-container. This required
+container detection logic in `scripts/pre-push-test.sh`, a flag in AGENT.md and CONTRIBUTING.md,
+and left in-container devs without local coverage data. A follow-up investigation confirmed that
+switching the Kover backend to JaCoCo eliminates the conflict entirely: JaCoCo instruments at
+class-load time (not retransformation), so it does not conflict with MockK's ByteBuddy inline
+instrumentation.
+
+**Decision.** Use JaCoCo as the Kover coverage backend unconditionally via `useJacoco("0.8.14")`
+in the `kover { }` block. No flag, no container detection, no env-conditional logic. The ByteBuddy
+agent preload (from ADR-1, Part A) is retained — it is still needed in-container where HotSpot
+dynamic attach is broken, and is harmless under JaCoCo everywhere else.
+
+**Validation.** Measured on CI: JaCoCo overall coverage = 52.03% (native Kover = 54.26%).
+The difference is within normal instrumentation variance. Both are well above the 40% gate.
+The CI Test job passes. CI and in-container now use the same backend, making coverage numbers
+consistent across environments.
+
+**Consequences.**
+- No flags: `./gradlew test` works everywhere (CI and in-container) without any property.
+- Local in-container coverage is now available: `./gradlew koverXmlReport` produces
+  `build/reports/kover/report.xml` backed by JaCoCo.
+- `scripts/pre-push-test.sh` is simplified: no container detection, no flags.
+- The disproven dead ends from ADR-1 remain forbidden.
+- The `-PdisableKoverInstrumentation` and `-PkoverUseJacoco` properties are removed.

--- a/scripts/pre-push-test.sh
+++ b/scripts/pre-push-test.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# pre-push-test.sh — wrapper invoked by the pre-push hook for the "test" stage.
+#
+# JaCoCo is used as the coverage backend unconditionally (no flags needed). The ByteBuddy agent
+# is preloaded automatically via build.gradle.kts jvmArgumentProviders. No container detection
+# or coverage-flag logic is needed here.
+#
+# JAVA_HOME: resolved robustly from the running JVM when java is on PATH (immune to dangling
+# symlinks in the Docker Desktop dev-container). No-op when java is absent (native devs who
+# already have a correct JAVA_HOME set).
+
+set -euo pipefail
+
+# Resolve JAVA_HOME from the running JVM — immune to symlinks and wrapper scripts.
+# Guarded so it is a no-op when java is not on PATH (native developers already have JAVA_HOME).
+if command -v java >/dev/null 2>&1; then
+  _jh="$(java -XshowSettings:properties -version 2>&1 | awk -F'= ' '/[[:space:]]java\.home[[:space:]]*=/{print $2; exit}')"
+  if [ -n "$_jh" ] && [ -x "$_jh/bin/java" ]; then
+    export JAVA_HOME="$_jh"
+  else
+    echo "pre-push-test.sh: WARNING: could not derive JAVA_HOME from java; using existing JAVA_HOME=${JAVA_HOME:-<unset>}" >&2
+  fi
+fi
+
+exec ./gradlew test "$@"

--- a/src/main/kotlin/io/snyk/plugin/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/Utils.kt
@@ -50,11 +50,13 @@ import io.snyk.plugin.ui.toolwindow.SnykToolWindowPanel
 import java.io.File
 import java.io.File.separator
 import java.io.FileNotFoundException
+import java.io.IOException
 import java.net.URI
 import java.net.URLDecoder
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.nio.file.attribute.PosixFilePermission
 import java.security.MessageDigest
 import java.util.Objects.nonNull
 import java.util.SortedSet
@@ -105,8 +107,30 @@ fun getCliFile() = File(pluginSettings().cliPath)
 fun isCliInstalled(): Boolean {
   if (ApplicationManager.getApplication().isUnitTestMode) return true
   val cliFile = getCliFile()
-  return cliFile.exists() && cliFile.canExecute()
+  // Both checks are intentional: File.canExecute() uses access(X_OK), which returns a FALSE
+  // POSITIVE on Docker Desktop's FUSE/virtiofs filesystem (reports a non-executable file as
+  // executable). Files.getPosixFilePermissions reads the actual permission bits and is
+  // authoritative.
+  // hasExecutableBit() is ANDed to VETO canExecute()'s false positive — && is correct, not ||.
+  return cliFile.exists() && cliFile.canExecute() && cliFile.hasExecutableBit()
 }
+
+private fun File.hasExecutableBit(): Boolean =
+  try {
+    val perms = Files.getPosixFilePermissions(toPath())
+    PosixFilePermission.OWNER_EXECUTE in perms ||
+      PosixFilePermission.GROUP_EXECUTE in perms ||
+      PosixFilePermission.OTHERS_EXECUTE in perms
+  } catch (_: UnsupportedOperationException) {
+    true // non-POSIX (Windows): defer to canExecute(), already AND-ed above
+  } catch (_: IOException) {
+    // Cannot confirm the execute bit: canExecute() is unreliable (false positive) on this FS,
+    // so we cannot trust it alone. Treat the CLI as not installed — a recoverable outcome
+    // (triggers re-download) rather than risking a stale or broken binary being used.
+    false
+  } catch (_: SecurityException) {
+    true // SecurityManager denied attribute read; exists() && canExecute() passed, so defer to them
+  }
 
 fun pluginSettings(): SnykApplicationSettingsStateService =
   ApplicationManager.getApplication().service()

--- a/src/test/kotlin/io/snyk/plugin/UtilsKtTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/UtilsKtTest.kt
@@ -13,6 +13,8 @@ import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.verify
 import java.io.File
+import java.nio.file.Files
+import java.nio.file.NoSuchFileException
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import junit.framework.TestCase.assertEquals
@@ -394,6 +396,76 @@ class UtilsKtTest {
 
     assertTrue("Navigation should complete within timeout", latch.await(2, TimeUnit.SECONDS))
     verify { navigatable.navigate(false) }
+  }
+
+  @Test
+  fun `isCliInstalled returns false when getPosixFilePermissions throws IOException`() {
+    unmockkAll()
+    val appMock = mockk<com.intellij.openapi.application.Application>(relaxed = true)
+    mockkStatic(ApplicationManager::class)
+    every { ApplicationManager.getApplication() } returns appMock
+    every { appMock.isUnitTestMode } returns false
+
+    val tempFile = File.createTempFile("snyk-cli-iotest", "")
+    try {
+      tempFile.setExecutable(true)
+      mockkStatic(::getCliFile)
+      every { getCliFile() } returns tempFile
+
+      mockkStatic(Files::class)
+      every { Files.getPosixFilePermissions(any()) } throws NoSuchFileException("gone")
+
+      assertFalse(isCliInstalled())
+    } finally {
+      tempFile.delete()
+    }
+  }
+
+  @Test
+  fun `isCliInstalled returns true when getPosixFilePermissions throws SecurityException`() {
+    unmockkAll()
+    val appMock = mockk<com.intellij.openapi.application.Application>(relaxed = true)
+    mockkStatic(ApplicationManager::class)
+    every { ApplicationManager.getApplication() } returns appMock
+    every { appMock.isUnitTestMode } returns false
+
+    val tempFile = File.createTempFile("snyk-cli-sectest", "")
+    try {
+      tempFile.setExecutable(true)
+      mockkStatic(::getCliFile)
+      every { getCliFile() } returns tempFile
+
+      mockkStatic(Files::class)
+      every { Files.getPosixFilePermissions(any()) } throws SecurityException("denied")
+
+      assertTrue(isCliInstalled())
+    } finally {
+      tempFile.delete()
+    }
+  }
+
+  @Test
+  fun `isCliInstalled returns true when getPosixFilePermissions throws UnsupportedOperationException`() {
+    unmockkAll()
+    val appMock = mockk<com.intellij.openapi.application.Application>(relaxed = true)
+    mockkStatic(ApplicationManager::class)
+    every { ApplicationManager.getApplication() } returns appMock
+    every { appMock.isUnitTestMode } returns false
+
+    val tempFile = File.createTempFile("snyk-cli-nonposix", "")
+    try {
+      tempFile.setExecutable(true)
+      mockkStatic(::getCliFile)
+      every { getCliFile() } returns tempFile
+
+      mockkStatic(Files::class)
+      every { Files.getPosixFilePermissions(any()) } throws
+        UnsupportedOperationException("non-posix")
+
+      assertTrue(isCliInstalled())
+    } finally {
+      tempFile.delete()
+    }
   }
 
   interface TestListener {


### PR DESCRIPTION
### **User description**
## Summary

Makes `./gradlew test` (and coverage) run on CI **and** in the Docker Desktop dev container with **no flags**, via two unconditional build changes plus a CLI-detection hardening:

- **JaCoCo as the Kover coverage backend** (`useJacoco("0.8.14")`). The native Kover agent retransforms the same classes MockK instruments via ByteBuddy inline mocking, producing `class redefinition failed: attempted to delete a method`. JaCoCo instruments at class-load time (no retransformation) and coexists with ByteBuddy. Measured JaCoCo overall coverage **52.03%** (vs native Kover 54.26%), above the 40% gate.
- **Preload the ByteBuddy agent** into all `Test` tasks via `jvmArgumentProviders` (sourced from the resolved test classpath, MockK-guarded, fail-loud if `byte-buddy-agent` count != 1). In the LinuxKit dev container HotSpot dynamic attach is non-functional, so MockK's runtime self-attach fails; preloading removes the need for it. Drops the prior `-P` flag machinery; the pre-push hook resolves `JAVA_HOME` robustly and runs `./gradlew test` with no flags.
- **Harden `isCliInstalled()`**: `File.canExecute()` (`access(X_OK)`) returns a **false positive** on the dev-container FUSE/virtiofs filesystem (reports a non-executable file as executable), so an authoritative POSIX permission-bit check (`Files.getPosixFilePermissions`) is AND-ed in as a veto. All three documented throws are handled — `UnsupportedOperationException` (non-POSIX/Windows) → defer to `canExecute()`, `IOException` → not installed (recoverable), `SecurityException` → defer — each covered by a unit test.

Self-contained; targets `master`. Supersedes the JaCoCo opt-in approach previously split into #853 (now closed/folded in here).

## Test plan
- [x] Full `./gradlew test` suite passes in the dev container (pre-push hook: verifyPlugin + test, green)
- [x] `./gradlew spotlessApply ktlintCheck verifyPlugin` clean
- [x] `koverXmlReport` produces coverage with the JaCoCo backend; overall 52.03% (> 40% gate)
- [x] Unit tests cover the `isCliInstalled()` POSIX exec-bit veto and all three exception branches
- [ ] CI green on this commit


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Enable MockK tests in dev container.

- Use JaCoCo coverage backend unconditionally.

- Fix CLI executable check logic.

- Update documentation and scripts.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[Old: MockK tests fail in dev container] --> B{Resolve Conflicts};
  B --> C[Use JaCoCo coverage backend];
  B --> D[Preload ByteBuddy agent];
  B --> E[Fix CLI executable check];
  C --> F[Kover agent replaced/removed];
  D --> G[ByteBuddy agent loaded at startup];
  E --> H[Reliable CLI installation check];
  F & G & H --> I[MockK tests pass in dev container];
  I --> J[Consistent coverage reports];
  K[Docs & Scripts Updated] --> I;
  K --> J;
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>build.gradle.kts</strong><dd><code>Configure JaCoCo backend and preload ByteBuddy agent</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-intellij-plugin/pull/852/changes#diff-c0dfa6bc7a8685217f70a860145fbdf416d449eaff052fa28352c5cec1a98c06">+43/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>Utils.kt</strong><dd><code>Enhance CLI installation check with POSIX permissions</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-intellij-plugin/pull/852/changes#diff-406e7dc9e2fe86f8d21201d462b284dabe35acec37a912ade78734d5ee88ca15">+25/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>UtilsKtTest.kt</strong><dd><code>Add tests for CLI executable check exceptions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-intellij-plugin/pull/852/changes#diff-7a3ce2318338dd2438bf913220ff09f6e1546d44b742533f3b8b6c5bdd19039a">+72/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Build scripts</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>pre-push-test.sh</strong><dd><code>New script to robustly run Gradle tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-intellij-plugin/pull/852/changes#diff-4d0b8294dd911d9d5f272b81677ea376059f10f3325e36def738aaf972e2eab7">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>.pre-commit-config.yaml</strong><dd><code>Update pre-commit config to use new test script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-intellij-plugin/pull/852/changes#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>AGENT.md</strong><dd><code>Update agent docs for test execution and coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-intellij-plugin/pull/852/changes#diff-c1e87407ce72f38b645f627c7fbda6e6999170c840cded6ce82c1bd2c10923e8">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CONTRIBUTING.md</strong><dd><code>Add guide for dev-container test execution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-intellij-plugin/pull/852/changes#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>PLAN.md</strong><dd><code>Update roadmap for dev-container test fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-intellij-plugin/pull/852/changes#diff-e132139cdfbe5ebee2fbc9fcd835dcaa403d75dc7675fdab450adc6aa991bfe1">+47/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>container-mockk-bytebuddy-agent.md</strong><dd><code>Create sub-plan for MockK/ByteBuddy test fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-intellij-plugin/pull/852/changes#diff-1d9f29ade7d7e40099cfc4b7847544646da7d3c8275712424b453cbd17cf1d26">+102/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>architecture.md</strong><dd><code>Add ADRs for Kover/MockK conflict and JaCoCo backend</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-intellij-plugin/pull/852/changes#diff-c42fd51236bd86284fe75cf97e3aa165aa019138c5da1ede2d74902a873f2bc0">+62/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

