### PR TITLE
[DO NOT MERGE] measure JaCoCo coverage %

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -130,6 +130,7 @@ ktlint { ignoreFailures.set(false) }
 
 // Configure Kover for code coverage
 kover {
+  useJacoco("0.8.14")
   reports {
     total {
       xml {


### PR DESCRIPTION
Throwaway: switches Kover to JaCoCo backend to read the CI coverage number for comparison vs native Kover (~54%). Will be closed.