### PR TITLE
feat(auth): add "Snyk: Log out" action [IDE-2181]

### DIFF
--- a/src/main/kotlin/io/snyk/plugin/services/SnykCliAuthenticationService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykCliAuthenticationService.kt
@@ -13,9 +13,12 @@ import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.ui.scale.JBUIScale
 import com.intellij.util.PlatformIcons
+import io.snyk.plugin.events.SnykSettingsListener
 import io.snyk.plugin.getCliFile
 import io.snyk.plugin.getSnykTaskQueueService
+import io.snyk.plugin.getSnykToolWindowPanel
 import io.snyk.plugin.pluginSettings
+import io.snyk.plugin.publishAsync
 import io.snyk.plugin.ui.SnykBalloonNotificationHelper
 import io.snyk.plugin.ui.getReadOnlyClickableHtmlJEditorPane
 import java.awt.BorderLayout
@@ -34,6 +37,30 @@ import snyk.common.lsp.LanguageServerWrapper
 @Service(Service.Level.PROJECT)
 class SnykCliAuthenticationService(val project: Project) {
   private val logger = logger<SnykCliAuthenticationService>()
+
+  /**
+   * Log out of Snyk: clears the stored token both in the Language Server and locally, then returns
+   * the tool window to the authentication panel. Runs on a pooled thread so callers (actions, UI)
+   * do not block. Clearing the local token is what stops it being re-sent to the LS on the next
+   * workspace/didChangeConfiguration push.
+   */
+  fun logout() {
+    ApplicationManager.getApplication().executeOnPooledThread {
+      if (project.isDisposed) return@executeOnPooledThread
+      // Clear the local token before logging the LS out. If the LS pulls workspace/configuration
+      // while handling logout, getSettings() would otherwise hand the stale token straight back
+      // and re-authenticate the server we just logged out.
+      pluginSettings().token = ""
+      LanguageServerWrapper.getInstance(project).logout()
+
+      ApplicationManager.getApplication().invokeLater {
+        if (project.isDisposed) return@invokeLater
+        getSnykToolWindowPanel(project)?.cleanUiAndCaches()
+      }
+      // Re-render the tool window; with an empty token it falls back to the authentication panel.
+      publishAsync(project, SnykSettingsListener.SNYK_SETTINGS_TOPIC) { settingsChanged() }
+    }
+  }
 
   fun authenticate() {
     fun showAuthDialog() {

--- a/src/main/kotlin/io/snyk/plugin/services/SnykCliAuthenticationService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykCliAuthenticationService.kt
@@ -50,15 +50,20 @@ class SnykCliAuthenticationService(val project: Project) {
       // Clear the local token before logging the LS out. If the LS pulls workspace/configuration
       // while handling logout, getSettings() would otherwise hand the stale token straight back
       // and re-authenticate the server we just logged out.
-      pluginSettings().token = ""
-      LanguageServerWrapper.getInstance(project).logout()
-
-      ApplicationManager.getApplication().invokeLater {
-        if (project.isDisposed) return@invokeLater
-        getSnykToolWindowPanel(project)?.cleanUiAndCaches()
+      pluginSettings().token = null
+      try {
+        LanguageServerWrapper.getInstance(project).logout()
+      } finally {
+        // Always clean up locally, even if the LS logout call throws something other than the
+        // TimeoutException it already handles internally. Otherwise the previous user's cached
+        // scan findings would remain on screen after the token has been cleared.
+        ApplicationManager.getApplication().invokeLater {
+          if (project.isDisposed) return@invokeLater
+          getSnykToolWindowPanel(project)?.cleanUiAndCaches()
+        }
+        // Re-render the tool window; with an empty token it falls back to the authentication panel.
+        publishAsync(project, SnykSettingsListener.SNYK_SETTINGS_TOPIC) { settingsChanged() }
       }
-      // Re-render the tool window; with an empty token it falls back to the authentication panel.
-      publishAsync(project, SnykSettingsListener.SNYK_SETTINGS_TOPIC) { settingsChanged() }
     }
   }
 

--- a/src/main/kotlin/io/snyk/plugin/ui/actions/SnykLogoutAction.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/actions/SnykLogoutAction.kt
@@ -1,0 +1,31 @@
+package io.snyk.plugin.ui.actions
+
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.DumbAware
+import io.snyk.plugin.getSnykCliAuthenticationService
+import io.snyk.plugin.pluginSettings
+
+/**
+ * Log out of Snyk. Delegates to [io.snyk.plugin.services.SnykCliAuthenticationService.logout].
+ * Available via Find Action ("Snyk: Log out"), so users can recover from a stale/expired token
+ * without needing the settings page to load first.
+ */
+class SnykLogoutAction : AnAction(AllIcons.Actions.Exit), DumbAware {
+
+  override fun actionPerformed(actionEvent: AnActionEvent) {
+    val project = actionEvent.project ?: return
+    if (project.isDisposed) return
+    getSnykCliAuthenticationService(project)?.logout()
+  }
+
+  override fun update(actionEvent: AnActionEvent) {
+    val project = actionEvent.project
+    actionEvent.presentation.isEnabled =
+      project != null && !project.isDisposed && !pluginSettings().token.isNullOrEmpty()
+  }
+
+  override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -74,8 +74,13 @@
     <group id="io.snyk.plugin.MiscActions">
       <action id="io.snyk.plugin.ui.actions.SnykSettingsAction"
               class="io.snyk.plugin.ui.actions.SnykSettingsAction"
-              text="Snyk Settings"/>
+              text="Snyk: Settings"/>
     </group>
+
+    <action id="io.snyk.plugin.ui.actions.SnykLogoutAction"
+            class="io.snyk.plugin.ui.actions.SnykLogoutAction"
+            text="Snyk: Log out"
+            description="Clear the stored Snyk authentication token and return to the login screen."/>
 
   </actions>
 

--- a/src/test/kotlin/io/snyk/plugin/services/SnykCliAuthenticationServiceTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/services/SnykCliAuthenticationServiceTest.kt
@@ -116,12 +116,10 @@ class SnykCliAuthenticationServiceTest : LightPlatform4TestCase() {
 
     SnykCliAuthenticationService(project).logout()
 
-    // logout() runs on a pooled thread; verify with a timeout, then poll for the token clear.
+    // logout() runs on a pooled thread; verify with a timeout. The local token clear happens on
+    // the same thread strictly before the LS logout() call, so once MockK observes that call the
+    // token is guaranteed to already be cleared - no need to sleep-poll for it separately.
     verify(timeout = 2000) { languageServerWrapperMock.logout() }
-    val deadline = System.currentTimeMillis() + 2000
-    while (System.currentTimeMillis() < deadline && !pluginSettings().token.isNullOrEmpty()) {
-      Thread.sleep(20)
-    }
     assertTrue(pluginSettings().token.isNullOrEmpty())
   }
 

--- a/src/test/kotlin/io/snyk/plugin/services/SnykCliAuthenticationServiceTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/services/SnykCliAuthenticationServiceTest.kt
@@ -6,8 +6,10 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
+import io.mockk.verify
 import io.snyk.plugin.getCliFile
 import io.snyk.plugin.getSnykTaskQueueService
+import io.snyk.plugin.pluginSettings
 import java.io.File
 import java.util.concurrent.CompletableFuture
 import org.junit.Test
@@ -105,6 +107,22 @@ class SnykCliAuthenticationServiceTest : LightPlatform4TestCase() {
     val wrapper = LanguageServerWrapper.getInstance(project)
     assertNotNull(wrapper)
     assertEquals(languageServerWrapperMock, wrapper)
+  }
+
+  @Test
+  fun `logout clears the language server and the local token`() {
+    every { languageServerWrapperMock.logout() } returns Unit
+    pluginSettings().token = "a-stale-token"
+
+    SnykCliAuthenticationService(project).logout()
+
+    // logout() runs on a pooled thread; verify with a timeout, then poll for the token clear.
+    verify(timeout = 2000) { languageServerWrapperMock.logout() }
+    val deadline = System.currentTimeMillis() + 2000
+    while (System.currentTimeMillis() < deadline && !pluginSettings().token.isNullOrEmpty()) {
+      Thread.sleep(20)
+    }
+    assertTrue(pluginSettings().token.isNullOrEmpty())
   }
 
   @Test

--- a/src/test/kotlin/io/snyk/plugin/ui/actions/SnykLogoutActionTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/actions/SnykLogoutActionTest.kt
@@ -3,6 +3,7 @@ package io.snyk.plugin.ui.actions
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.Presentation
 import com.intellij.testFramework.LightPlatform4TestCase
+import com.intellij.testFramework.PlatformTestUtil
 import com.intellij.testFramework.replaceService
 import io.mockk.every
 import io.mockk.mockk
@@ -90,5 +91,25 @@ class SnykLogoutActionTest : LightPlatform4TestCase() {
     // that call the token is guaranteed to already be cleared - no need to sleep-poll for it.
     verify(timeout = 2000) { languageServerWrapperMock.logout() }
     assertTrue(pluginSettings().token.isNullOrEmpty())
+  }
+
+  @Test
+  fun `actionPerformed cleans up the tool window UI and caches`() {
+    pluginSettings().token = "a-stale-token"
+    val cleanupLatch = java.util.concurrent.CountDownLatch(1)
+    every { toolWindowPanelMock.cleanUiAndCaches() } answers { cleanupLatch.countDown() }
+
+    action.actionPerformed(actionEvent())
+
+    // The cleanup runs inside invokeLater, scheduled from the pooled thread after the LS logout()
+    // call returns. Pump the EDT queue while waiting for the pooled thread to post and the
+    // invokeLater runnable to execute - race-free regardless of timing.
+    PlatformTestUtil.waitWithEventsDispatching(
+      "cleanUiAndCaches() was not called on logout",
+      { cleanupLatch.count == 0L },
+      5,
+    )
+
+    verify { toolWindowPanelMock.cleanUiAndCaches() }
   }
 }

--- a/src/test/kotlin/io/snyk/plugin/ui/actions/SnykLogoutActionTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/actions/SnykLogoutActionTest.kt
@@ -85,13 +85,10 @@ class SnykLogoutActionTest : LightPlatform4TestCase() {
 
     action.actionPerformed(actionEvent())
 
-    // actionPerformed runs on a pooled thread; verify with a timeout.
+    // actionPerformed runs on a pooled thread; verify with a timeout. The local token clear
+    // happens on the same thread strictly before the LS logout() call, so once MockK observes
+    // that call the token is guaranteed to already be cleared - no need to sleep-poll for it.
     verify(timeout = 2000) { languageServerWrapperMock.logout() }
-
-    val deadline = System.currentTimeMillis() + 2000
-    while (System.currentTimeMillis() < deadline && !pluginSettings().token.isNullOrEmpty()) {
-      Thread.sleep(20)
-    }
     assertTrue(pluginSettings().token.isNullOrEmpty())
   }
 }

--- a/src/test/kotlin/io/snyk/plugin/ui/actions/SnykLogoutActionTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/actions/SnykLogoutActionTest.kt
@@ -1,0 +1,97 @@
+package io.snyk.plugin.ui.actions
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.Presentation
+import com.intellij.testFramework.LightPlatform4TestCase
+import com.intellij.testFramework.replaceService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import io.snyk.plugin.getSnykToolWindowPanel
+import io.snyk.plugin.pluginSettings
+import io.snyk.plugin.ui.toolwindow.SnykToolWindowPanel
+import org.junit.Test
+import snyk.common.lsp.LanguageServerWrapper
+
+class SnykLogoutActionTest : LightPlatform4TestCase() {
+
+  private val languageServerWrapperMock = mockk<LanguageServerWrapper>(relaxed = true)
+  private val toolWindowPanelMock = mockk<SnykToolWindowPanel>(relaxed = true)
+  private lateinit var action: SnykLogoutAction
+
+  override fun setUp() {
+    super.setUp()
+    unmockkAll()
+    mockkStatic("io.snyk.plugin.UtilsKt")
+    every { getSnykToolWindowPanel(any()) } returns toolWindowPanelMock
+    project.replaceService(LanguageServerWrapper::class.java, languageServerWrapperMock, project)
+    action = SnykLogoutAction()
+  }
+
+  override fun tearDown() {
+    pluginSettings().token = null
+    project.replaceService(
+      LanguageServerWrapper::class.java,
+      LanguageServerWrapper(project),
+      project,
+    )
+    unmockkAll()
+    super.tearDown()
+  }
+
+  private fun actionEvent(withProject: Boolean = true): AnActionEvent {
+    val presentation = Presentation()
+    return mockk<AnActionEvent>(relaxed = true).also {
+      every { it.project } returns if (withProject) project else null
+      every { it.presentation } returns presentation
+    }
+  }
+
+  @Test
+  fun `update enables the action when a token is present`() {
+    pluginSettings().token = "a-token"
+    val event = actionEvent()
+
+    action.update(event)
+
+    assertTrue(event.presentation.isEnabled)
+  }
+
+  @Test
+  fun `update disables the action when the token is blank`() {
+    pluginSettings().token = ""
+    val event = actionEvent()
+
+    action.update(event)
+
+    assertFalse(event.presentation.isEnabled)
+  }
+
+  @Test
+  fun `update disables the action when there is no project`() {
+    pluginSettings().token = "a-token"
+    val event = actionEvent(withProject = false)
+
+    action.update(event)
+
+    assertFalse(event.presentation.isEnabled)
+  }
+
+  @Test
+  fun `actionPerformed logs out of the language server and clears the local token`() {
+    pluginSettings().token = "a-stale-token"
+
+    action.actionPerformed(actionEvent())
+
+    // actionPerformed runs on a pooled thread; verify with a timeout.
+    verify(timeout = 2000) { languageServerWrapperMock.logout() }
+
+    val deadline = System.currentTimeMillis() + 2000
+    while (System.currentTimeMillis() < deadline && !pluginSettings().token.isNullOrEmpty()) {
+      Thread.sleep(20)
+    }
+    assertTrue(pluginSettings().token.isNullOrEmpty())
+  }
+}

--- a/src/test/kotlin/snyk/common/lsp/LanguageServerWrapperTest.kt
+++ b/src/test/kotlin/snyk/common/lsp/LanguageServerWrapperTest.kt
@@ -197,6 +197,15 @@ class LanguageServerWrapperTest {
   }
 
   @Test
+  fun `logout does not send COMMAND_LOGOUT when the language server is not initialized`() {
+    every { applicationMock.isDisposed } returns true
+
+    cut.logout()
+
+    verify(exactly = 0) { lsMock.workspaceService.executeCommand(any()) }
+  }
+
+  @Test
   fun `sendScanCommand waits for smart mode`() {
     simulateRunningLS()
     justRun { dumbServiceMock.runWhenSmart(any()) }


### PR DESCRIPTION
### Description

Adds a first-class **Snyk: Log out** action so users can clear a stale/expired OAuth token without needing the HTML settings page to load first.

Context ([IDE-2181](https://snyksec.atlassian.net/browse/IDE-2181), caused by [IDE-2178](https://snyksec.atlassian.net/browse/IDE-2178)): when the stored token is expired (`invalid_grant`), the language server thrashes on a doomed refresh and starves the `workspace/configuration` command, so the settings page — the only existing re-auth entry point — times out to the fallback. This action breaks that chicken-and-egg.

Changes:
- New `SnykCliAuthenticationService.logout()`, symmetric with `authenticate()`: clears the local token **first** (so a `workspace/configuration` pull during logout can't hand the stale token back and re-auth the LS), then clears it in the LS via `COMMAND_LOGOUT`, then resets the tool window to the auth panel.
- New `SnykLogoutAction` delegates to it. Registered standalone → surfaces in **Find Action** ("Snyk: Log out"), not the tool window toolbar.
- Renamed the existing settings action to **"Snyk: Settings"**.

### Checklist

- [x] Read and understood the [Code of Conduct](https://github.com/snyk/snyk-intellij-plugin/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/snyk-intellij-plugin/blob/master/CONTRIBUTING.md).
- [x] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated
 - N/A
- [ ] README.md updated, if user-facing
 - N/A

### Screenshots / GIFs

_Toolbar unchanged (settings gear retained); logout is available via Find Action (Cmd+Shift+A -> "Snyk: Log out")._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[IDE-2181]: https://snyksec.atlassian.net/browse/IDE-2181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDE-2178]: https://snyksec.atlassian.net/browse/IDE-2178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ