### PR TITLE
chore: remove dead CHANGELOG checkbox from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,6 @@ _Provide description of this PR and changes, if linked Jira ticket doesn't cover
 - [ ] Read and understood the [Code of Conduct](https://github.com/snyk/snyk-intellij-plugin/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/snyk-intellij-plugin/blob/master/CONTRIBUTING.md).
 - [ ] Tests added and all succeed
 - [ ] Linted
-- [ ] CHANGELOG.md updated
 - [ ] README.md updated, if user-facing
 
 ### Screenshots / GIFs


### PR DESCRIPTION
## Description

CHANGELOG.md is no longer hand-maintained: release workflows generate notes via `gh release create --generate-notes`. This removes the dead CHANGELOG references from the PR template and release docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)