### PR TITLE
fix: add re-auth control to settings fallback page (plugin mirror) [IDE-2181]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ DESIGN.md
 .snyk-code-output.err
 .verification-result.*
 docs/plan.md
+.verify-report

--- a/src/main/resources/html/settings-fallback.html
+++ b/src/main/resources/html/settings-fallback.html
@@ -59,6 +59,10 @@
       --border-color: var(--vscode-panel-border, #454545);
       --focus-border: var(--vscode-focusBorder, #007acc);
 
+      /* Buttons */
+      --button-background: var(--vscode-button-background, #0e639c);
+      --button-foreground: var(--vscode-button-foreground, #ffffff);
+
       /* Other */
       --border-radius: 4px;
       --border-radius-small: 2px;
@@ -213,6 +217,34 @@
       display: none !important;
     }
 
+    /* Re-authentication control */
+    .reauth-status {
+      margin: 0 0 var(--form-group-margin) 0;
+      color: var(--text-color);
+    }
+
+    .reauth-button {
+      align-self: flex-start;
+      padding: var(--input-padding) 16px;
+      background-color: var(--button-background);
+      color: var(--button-foreground);
+      border: 1px solid var(--button-background);
+      border-radius: var(--border-radius-small);
+      font-family: inherit;
+      font-size: inherit;
+      cursor: pointer;
+    }
+
+    .reauth-button:focus {
+      outline: 1px solid var(--focus-border);
+      outline-offset: 2px;
+    }
+
+    .reauth-button:disabled {
+      opacity: 0.6;
+      cursor: default;
+    }
+
     /* Info Message */
     .info-message {
       padding: var(--section-padding);
@@ -310,6 +342,11 @@
   <div class="section">
     <h2>Authentication</h2>
 
+    <div class="form-group">
+      <p id="reauth-status" class="reauth-status">Sign in or reconnect with Snyk.</p>
+      <button type="button" id="reauth-button" class="reauth-button">Connect</button>
+    </div>
+
     <div class="form-group half-width">
       <label class="checkbox-label">
         <input type="checkbox" name="proxy_insecure" id="proxy_insecure" {{INSECURE_CHECKED}}>
@@ -366,6 +403,9 @@
     var initialState = null;
     // Guard against re-entrance when blur() triggers getAndSaveIdeConfig
     var _isSaving = false;
+    // Monotonic re-auth cycle counter. Each startReauth() bumps it; a done()
+    // callback from a superseded cycle is inert (see startReauth).
+    var _reauthGen = 0;
 
     function get(id) {
       return document.getElementById(id);
@@ -502,10 +542,63 @@
       }
     };
 
+    // Re-authenticate via the IDE command bridge. D2(a): pass no auth args so the
+    // language server re-auths with the user's existing configured method/endpoint
+    // rather than overwriting it from this limited fallback page.
+    //
+    // The button is disabled while a re-auth is in flight (prevents a double-fire)
+    // and re-enabled when the language server invokes done(). If done() never fires
+    // — the user cancels the OAuth browser tab, auth stalls, or the LS dies mid-flow
+    // — a client-side safety timeout restores the button so the user can retry
+    // instead of being stuck on "Connecting…" forever. done() clears that timer so
+    // there is no double-restore. __REAUTH_TIMEOUT_MS__ overrides the duration in tests.
+    //
+    // done() is single-shot AND cycle-aware. If the safety timeout re-enables the
+    // button (auth exceeds the timeout) the user can start a fresh cycle; the prior
+    // cycle's bridge callback may still fire late. A stale done() from a superseded
+    // cycle (gen !== _reauthGen) — or a second invocation of the same cycle (finished)
+    // — must be inert, or it would re-enable the button mid-new-cycle and reopen the
+    // double-dispatch it guards against.
+    function startReauth() {
+      if (typeof window.__ideExecuteCommand__ !== 'function') { return; }
+      var btn = get('reauth-button');
+      if (btn && btn.disabled) { return; } // a re-auth is already in progress
+      var gen = ++_reauthGen;
+      var timeoutMs = typeof window.__REAUTH_TIMEOUT_MS__ === 'number'
+        ? window.__REAUTH_TIMEOUT_MS__
+        : 60000;
+      var safetyTimer = null;
+      var finished = false;
+      function done() {
+        if (finished || gen !== _reauthGen) { return; }
+        finished = true;
+        if (safetyTimer !== null) {
+          window.clearTimeout(safetyTimer);
+          safetyTimer = null;
+        }
+        if (btn) {
+          btn.disabled = false;
+          btn.textContent = 'Connect';
+        }
+      }
+      if (btn) {
+        btn.disabled = true;
+        btn.textContent = 'Connecting…';
+      }
+      safetyTimer = window.setTimeout(done, timeoutMs);
+      try {
+        window.__ideExecuteCommand__('snyk.login', [], done);
+      } catch (e) {
+        console.error('Error starting authentication:', e);
+        done();
+      }
+    }
+
     window.__isFormDirty__ = function() { return isDirty(); };
     window.collectData = collectData;
     window.collectChangedData = collectChangedData;
     window.markDirty = markDirty;
+    window.startReauth = startReauth;
 
     function repositionTooltip(trigger) {
       var popup = trigger.querySelector('.tooltip-popup');
@@ -565,6 +658,11 @@
 
       get('cli_release_channel_custom').addEventListener('input', validateCliVersion);
       get('cli_release_channel_custom').addEventListener('blur', validateCliVersion);
+
+      var reauthBtn = get('reauth-button');
+      if (reauthBtn) {
+        reauthBtn.addEventListener('click', startReauth);
+      }
 
       var tooltipTriggers = document.querySelectorAll('[data-toggle="tooltip"]');
       for (var k = 0; k < tooltipTriggers.length; k++) {

--- a/src/test/kotlin/io/snyk/plugin/ui/jcef/SettingsFallbackReauthDispatchTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/jcef/SettingsFallbackReauthDispatchTest.kt
@@ -1,0 +1,91 @@
+package io.snyk.plugin.ui.jcef
+
+import com.google.gson.Gson
+import com.intellij.openapi.application.Application
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.project.Project
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import io.snyk.plugin.pluginSettings
+import io.snyk.plugin.services.SnykApplicationSettingsStateService
+import io.snyk.plugin.ui.toolwindow.SnykPluginDisposable
+import java.util.concurrent.TimeUnit
+import org.awaitility.Awaitility.await
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import snyk.common.lsp.LanguageServerWrapper
+
+/**
+ * CP3 (IDE-2181): proves the plugin's fallback settings page Connect control dispatches the
+ * `snyk.login` command through the plugin's command bridge to the language server.
+ *
+ * The proof has two ends, joined by the `window.__ideExecuteCommand__` contract:
+ * 1. The fallback resource that IntelliJ actually loads (`html/settings-fallback.html` on the
+ *    plugin classpath) wires a Connect button to `__ideExecuteCommand__('snyk.login', [])`. RED
+ *    before the CP2->plugin mirror (the pre-mirror copy has no re-auth control).
+ * 2. The bridge, given the exact payload that Connect emits (`snyk.login` with no args, D2(a)),
+ *    forwards `snyk.login` to the language server with the login timeout.
+ */
+class SettingsFallbackReauthDispatchTest {
+  private val projectMock = mockk<Project>(relaxed = true)
+  private val applicationMock = mockk<Application>(relaxed = true)
+  private val lsWrapperMock = mockk<LanguageServerWrapper>(relaxed = true)
+  private val gson = Gson()
+
+  @Before
+  fun setUp() {
+    unmockkAll()
+    mockkStatic(ApplicationManager::class)
+    mockkStatic("io.snyk.plugin.UtilsKt")
+
+    every { ApplicationManager.getApplication() } returns applicationMock
+    every { applicationMock.getService(SnykPluginDisposable::class.java) } returns
+      SnykPluginDisposable()
+    every { pluginSettings() } returns SnykApplicationSettingsStateService()
+
+    mockkObject(LanguageServerWrapper.Companion)
+    every { LanguageServerWrapper.getInstance(projectMock) } returns lsWrapperMock
+  }
+
+  @After
+  fun tearDown() {
+    unmockkAll()
+  }
+
+  @Test
+  fun `fallback resource wires Connect control to dispatch snyk login via the command bridge`() {
+    val html =
+      javaClass.classLoader
+        .getResourceAsStream("html/settings-fallback.html")
+        ?.bufferedReader()
+        ?.use { it.readText() }
+        ?: error("plugin fallback resource html/settings-fallback.html not found on classpath")
+
+    assertTrue(
+      "fallback page must expose a Connect re-auth button",
+      html.contains("id=\"reauth-button\"") && html.contains(">Connect<"),
+    )
+    assertTrue(
+      "Connect control must dispatch snyk.login through window.__ideExecuteCommand__",
+      html.contains("__ideExecuteCommand__('snyk.login'"),
+    )
+  }
+
+  @Test
+  fun `bridge forwards the fallback snyk login payload with no args to the language server`() {
+    // Exact request the fallback emits: __ideExecuteCommand__('snyk.login', [], done)
+    val payload = gson.toJson(ExecuteCommandRequest(command = "snyk.login", args = emptyList()))
+
+    ExecuteCommandBridge(projectMock).dispatch(payload)
+
+    await().atMost(2, TimeUnit.SECONDS).untilAsserted {
+      verify { lsWrapperMock.executeCommandWithArgs("snyk.login", emptyList(), 120_000L) }
+    }
+  }
+}


### PR DESCRIPTION
## Description

The IntelliJ plugin ships its own copy of the settings fallback page. This mirrors the language-server change ([snyk/snyk-ls#1371](https://github.com/snyk/snyk-ls/pull/1371)) into it **byte-identically** so an IntelliJ user dropped to the limited fallback page can re-authenticate.

The Authentication section gains a **"Connect"** control that dispatches `snyk.login` through the plugin command bridge with no args (reusing the configured method/endpoint), with the same safety-timeout recovery and single-shot cycle-aware callback latch as the LS copy.

## Changes

- `src/main/resources/html/settings-fallback.html` — add re-auth "Connect" control mirroring the LS fallback page.
- Kotlin test asserting the shipped fallback resource wires the Connect control to a `snyk.login` dispatch and that the command bridge forwards it with the login timeout.

The two fallback copies (plugin + LS) must remain byte-identical.

## Testing

Covered by `SettingsFallbackReauthDispatchTest`. Full verification runs in CI (no JDK in the local dev container).

Jira: IDE-2181
