### PR TITLE
ci: bound the Test job on hang and capture thread dumps [IDE-2237]

### DIFF
--- a/.github/scripts/hang-watchdog.sh
+++ b/.github/scripts/hang-watchdog.sh
@@ -26,21 +26,26 @@ capture() { # $1 = pid, $2 = outfile
   "${JAVA_BIN}jstack" -l "$1" >"$2" 2>&1 || "${JAVA_BIN}jcmd" "$1" Thread.print >"$2" 2>&1
 }
 
-mkdir -p "$DUMP_DIR"
 sleep "$THRESHOLD"
 
 iter=0
 while true; do
   iter=$((iter + 1))
   ts="$(date +%Y%m%d-%H%M%S)"
+  # (Re)create the dump dir every iteration: `./gradlew clean` deletes build/ at the start of the
+  # step, so a dir created once up-front is gone by the time we dump.
+  mkdir -p "$DUMP_DIR"
   pids="$("${JAVA_BIN}jps" -l 2>/dev/null | grep 'GradleWorkerMain' | awk '{print $1}')"
   if [ -z "$pids" ]; then
     echo "[hang-watchdog] iter ${iter} @ ${ts}: no GradleWorkerMain process found"
   else
     for pid in $pids; do
       out="${DUMP_DIR}/threaddump-${ts}-pid${pid}-${iter}.txt"
-      capture "$pid" "$out"
-      echo "[hang-watchdog] iter ${iter} @ ${ts}: wrote ${out} for pid ${pid}"
+      if capture "$pid" "$out"; then
+        echo "[hang-watchdog] iter ${iter} @ ${ts}: wrote ${out} for pid ${pid}"
+      else
+        echo "[hang-watchdog] iter ${iter} @ ${ts}: FAILED to capture pid ${pid}"
+      fi
       kill -3 "$pid" 2>/dev/null || true
     done
   fi

--- a/.github/scripts/hang-watchdog.sh
+++ b/.github/scripts/hang-watchdog.sh
@@ -41,7 +41,13 @@ run_bounded() { # $1 = outfile; rest = command...
   local p=$! waited=0
   while kill -0 "$p" 2>/dev/null; do
     if [ "$waited" -ge "$CAPTURE_TIMEOUT" ]; then
+      # A capture wedged in JVM dynamic-attach may ignore SIGTERM; escalate to SIGKILL after a
+      # brief grace, then reap so stuck attach processes don't accumulate (zombies / a half-open
+      # attach socket) and degrade later captures in the series.
       kill "$p" 2>/dev/null || true
+      sleep 2
+      kill -0 "$p" 2>/dev/null && kill -9 "$p" 2>/dev/null || true
+      wait "$p" 2>/dev/null || true
       return 124
     fi
     sleep 2
@@ -51,11 +57,15 @@ run_bounded() { # $1 = outfile; rest = command...
 }
 
 capture() { # $1 = pid, $2 = outfile
-  run_bounded "$2" "${JAVA_BIN}jstack" -l "$1" && return 0
-  # jstack failed or timed out. If it left a partial dump, keep it — do NOT let the jcmd fallback
-  # truncate it (both use `>` on the same file). Only fall back when jstack produced nothing.
-  [ -s "$2" ] && return 1
+  run_bounded "$2" "${JAVA_BIN}jstack" -l "$1"
+  # Keep the jstack output only if it is a real thread dump (even a partial one, from a timeout)
+  # rather than an error string — `run_bounded` merges stderr into the file, so a fast attach
+  # failure ("Unable to open socket file", AttachNotSupportedException, wrong pid) also makes the
+  # file non-empty. A dump always contains a thread-state line; an error string does not. If it is
+  # a real dump, keep it and don't let the jcmd fallback truncate it; otherwise fall back to jcmd.
+  grep -q 'java.lang.Thread.State' "$2" 2>/dev/null && return 0
   run_bounded "$2" "${JAVA_BIN}jcmd" "$1" Thread.print
+  grep -q 'java.lang.Thread.State' "$2" 2>/dev/null
 }
 
 sleep "$THRESHOLD"

--- a/.github/scripts/hang-watchdog.sh
+++ b/.github/scripts/hang-watchdog.sh
@@ -7,23 +7,52 @@
 # a healthy run: that finishes before the threshold and the caller kills this
 # watchdog while it is still sleeping.
 #
-# Both capture mechanisms are used:
+# Scope: this targets the Gradle *test worker* (`GradleWorkerMain`), which is where
+# the known hang lives (IDE-2237: an EDT-dispatch deadlock in the test JVM). A hang
+# that instead wedges the Gradle daemon or a compile/lint phase has no test worker,
+# so this logs "no test-worker JVM found" and captures nothing — that means "not a
+# test-worker hang", NOT "nothing wrong"; such a run is still bounded by the job
+# `timeout-minutes` backstop, just without a thread dump.
+#
+# Capture uses two mechanisms:
 #   1. `jstack -l` -> a file per dump (primary; `-l` includes lock ownership).
 #   2. `kill -3` (SIGQUIT) -> the JVM's own stdout (Unix best-effort; on Windows a
 #      JVM dumps on Ctrl-Break rather than SIGQUIT, so this is a no-op there and
 #      jstack remains the source of truth).
+# Each capture is time-bounded: jstack/jcmd attach via the JVM dynamic-attach
+# socket, which can itself hang if the target is wedged in native code or a GC
+# stall. Bounding it keeps the watchdog loop alive so later iterations still fire.
 #
 # See .local/test-hang-capture-plan.md and the IDE-2237 investigation.
 set -uo pipefail
 
-THRESHOLD="${HANG_THRESHOLD_SECONDS:-1200}"      # 20m: above the ~16m real-run max, below the 25m Gradle test timeout
-INTERVAL="${HANG_DUMP_INTERVAL_SECONDS:-120}"    # dump every 2m thereafter
+THRESHOLD="${HANG_THRESHOLD_SECONDS:-1200}"          # 20m: above the ~16m real-run max, below the 25m Gradle test timeout
+INTERVAL="${HANG_DUMP_INTERVAL_SECONDS:-120}"        # dump every 2m thereafter
+CAPTURE_TIMEOUT="${HANG_CAPTURE_TIMEOUT_SECONDS:-60}" # bound a single jstack/jcmd attach
 DUMP_DIR="${HANG_DUMP_DIR:-build/hang-dumps}"
 
 JAVA_BIN="${JAVA_HOME:+${JAVA_HOME}/bin/}"
 
+# Run a command with its stdout+stderr to $out, killed if it exceeds CAPTURE_TIMEOUT.
+# Portable (no coreutils `timeout`, which is absent on macOS runners). Returns 124 on timeout.
+run_bounded() { # $1 = outfile; rest = command...
+  local out="$1"; shift
+  "$@" >"$out" 2>&1 &
+  local p=$! waited=0
+  while kill -0 "$p" 2>/dev/null; do
+    if [ "$waited" -ge "$CAPTURE_TIMEOUT" ]; then
+      kill "$p" 2>/dev/null || true
+      return 124
+    fi
+    sleep 2
+    waited=$((waited + 2))
+  done
+  wait "$p"
+}
+
 capture() { # $1 = pid, $2 = outfile
-  "${JAVA_BIN}jstack" -l "$1" >"$2" 2>&1 || "${JAVA_BIN}jcmd" "$1" Thread.print >"$2" 2>&1
+  run_bounded "$2" "${JAVA_BIN}jstack" -l "$1" && return 0
+  run_bounded "$2" "${JAVA_BIN}jcmd" "$1" Thread.print
 }
 
 sleep "$THRESHOLD"
@@ -37,14 +66,14 @@ while true; do
   mkdir -p "$DUMP_DIR"
   pids="$("${JAVA_BIN}jps" -l 2>/dev/null | grep 'GradleWorkerMain' | awk '{print $1}')"
   if [ -z "$pids" ]; then
-    echo "[hang-watchdog] iter ${iter} @ ${ts}: no GradleWorkerMain process found"
+    echo "[hang-watchdog] iter ${iter} @ ${ts}: no test-worker JVM found (a daemon/compile-phase hang is not captured here)"
   else
     for pid in $pids; do
       out="${DUMP_DIR}/threaddump-${ts}-pid${pid}-${iter}.txt"
       if capture "$pid" "$out"; then
         echo "[hang-watchdog] iter ${iter} @ ${ts}: wrote ${out} for pid ${pid}"
       else
-        echo "[hang-watchdog] iter ${iter} @ ${ts}: FAILED to capture pid ${pid}"
+        echo "[hang-watchdog] iter ${iter} @ ${ts}: capture FAILED/timed out for pid ${pid} (kept partial ${out})"
       fi
       kill -3 "$pid" 2>/dev/null || true
     done

--- a/.github/scripts/hang-watchdog.sh
+++ b/.github/scripts/hang-watchdog.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Hang watchdog for the Gradle `test` task.
+#
+# Sleeps past the normal run time, then repeatedly captures thread dumps of the
+# Gradle test-worker JVM(s) so an intermittent CI hang can be diagnosed from the
+# run's uploaded artifacts alone, with no local reproduction. It never triggers on
+# a healthy run: that finishes before the threshold and the caller kills this
+# watchdog while it is still sleeping.
+#
+# Both capture mechanisms are used:
+#   1. `jstack -l` -> a file per dump (primary; `-l` includes lock ownership).
+#   2. `kill -3` (SIGQUIT) -> the JVM's own stdout (Unix best-effort; on Windows a
+#      JVM dumps on Ctrl-Break rather than SIGQUIT, so this is a no-op there and
+#      jstack remains the source of truth).
+#
+# See .local/test-hang-capture-plan.md and the IDE-2237 investigation.
+set -uo pipefail
+
+THRESHOLD="${HANG_THRESHOLD_SECONDS:-1200}"      # 20m: above the ~16m real-run max, below the 25m Gradle test timeout
+INTERVAL="${HANG_DUMP_INTERVAL_SECONDS:-120}"    # dump every 2m thereafter
+DUMP_DIR="${HANG_DUMP_DIR:-build/hang-dumps}"
+
+JAVA_BIN="${JAVA_HOME:+${JAVA_HOME}/bin/}"
+
+capture() { # $1 = pid, $2 = outfile
+  "${JAVA_BIN}jstack" -l "$1" >"$2" 2>&1 || "${JAVA_BIN}jcmd" "$1" Thread.print >"$2" 2>&1
+}
+
+mkdir -p "$DUMP_DIR"
+sleep "$THRESHOLD"
+
+iter=0
+while true; do
+  iter=$((iter + 1))
+  ts="$(date +%Y%m%d-%H%M%S)"
+  pids="$("${JAVA_BIN}jps" -l 2>/dev/null | grep 'GradleWorkerMain' | awk '{print $1}')"
+  if [ -z "$pids" ]; then
+    echo "[hang-watchdog] iter ${iter} @ ${ts}: no GradleWorkerMain process found"
+  else
+    for pid in $pids; do
+      out="${DUMP_DIR}/threaddump-${ts}-pid${pid}-${iter}.txt"
+      capture "$pid" "$out"
+      echo "[hang-watchdog] iter ${iter} @ ${ts}: wrote ${out} for pid ${pid}"
+      kill -3 "$pid" 2>/dev/null || true
+    done
+  fi
+  sleep "$INTERVAL"
+done

--- a/.github/scripts/hang-watchdog.sh
+++ b/.github/scripts/hang-watchdog.sh
@@ -52,6 +52,9 @@ run_bounded() { # $1 = outfile; rest = command...
 
 capture() { # $1 = pid, $2 = outfile
   run_bounded "$2" "${JAVA_BIN}jstack" -l "$1" && return 0
+  # jstack failed or timed out. If it left a partial dump, keep it — do NOT let the jcmd fallback
+  # truncate it (both use `>` on the same file). Only fall back when jstack produced nothing.
+  [ -s "$2" ] && return 1
   run_bounded "$2" "${JAVA_BIN}jcmd" "$1" Thread.print
 }
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,13 +19,9 @@ jobs:
     name: Test
     needs: gradleValidation
     runs-on: ${{ matrix.os }}
-    # Outer backstop and the real safety net: catches anything the Gradle test timeout can't
-    # (wedged daemon, hung compile/spotless/kover, hung setup, or a test wedged in uninterruptible
-    # native I/O that ignores Gradle's interrupt). An interruptible hung test is caught earlier and
-    # more precisely by the Gradle `test` task timeout (25m) in build.gradle.kts. No per-step
-    # timeout on the "Run Tests" step on purpose: a step timeout low enough to be useful would fire
-    # before Gradle's 25m test timeout (compile+lint run first), turning a precise "test timed out"
-    # failure into a generic "step timed out". Keep this comfortably above the 25m Gradle timeout.
+    # Real backstop for hangs the Gradle `test` task timeout (in build.gradle.kts) can't catch
+    # — wedged daemon, hung compile/lint, or uninterruptible native I/O. No per-step timeout: a
+    # step limit could fire before that task timeout and mask the precise failure.
     timeout-minutes: 40
     strategy:
       matrix:
@@ -52,9 +48,7 @@ jobs:
 
       - name: Run Tests
         # Linters listed before `check` so a formatting slip fails fast, before the long test task.
-        # An interruptible hung test is bounded by the Gradle `test` task timeout (25m) in
-        # build.gradle.kts; the job timeout (40m) is the real backstop. No step-level timeout — see
-        # the job comment.
+        # No per-step timeout — see the job `timeout-minutes` comment above for why.
         run: ./gradlew clean ktlintCheck spotlessCheck check
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,14 @@ jobs:
     name: Test
     needs: gradleValidation
     runs-on: ${{ matrix.os }}
+    # Outer backstop and the real safety net: catches anything the Gradle test timeout can't
+    # (wedged daemon, hung compile/spotless/kover, hung setup, or a test wedged in uninterruptible
+    # native I/O that ignores Gradle's interrupt). An interruptible hung test is caught earlier and
+    # more precisely by the Gradle `test` task timeout (25m) in build.gradle.kts. No per-step
+    # timeout on the "Run Tests" step on purpose: a step timeout low enough to be useful would fire
+    # before Gradle's 25m test timeout (compile+lint run first), turning a precise "test timed out"
+    # failure into a generic "step timed out". Keep this comfortably above the 25m Gradle timeout.
+    timeout-minutes: 40
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -43,6 +51,10 @@ jobs:
           restore-keys: ${{ runner.os }}-gradle
 
       - name: Run Tests
+        # Linters listed before `check` so a formatting slip fails fast, before the long test task.
+        # An interruptible hung test is bounded by the Gradle `test` task timeout (25m) in
+        # build.gradle.kts; the job timeout (40m) is the real backstop. No step-level timeout — see
+        # the job comment.
         run: ./gradlew clean ktlintCheck spotlessCheck check
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,17 @@ jobs:
       - name: Run Tests
         # Linters listed before `check` so a formatting slip fails fast, before the long test task.
         # No per-step timeout — see the job `timeout-minutes` comment above for why.
-        run: ./gradlew clean ktlintCheck spotlessCheck check
+        # A background watchdog captures thread dumps of the test worker if it runs abnormally long,
+        # so an intermittent hang (see the Gradle `test` timeout in build.gradle.kts) is diagnosable
+        # from the uploaded dumps alone. `shell: bash` so the one script runs on all three OSes
+        # (git-bash on Windows). The trap tears the watchdog down whether gradle passes, fails, or is
+        # killed by its task timeout.
+        shell: bash
+        run: |
+          bash .github/scripts/hang-watchdog.sh &
+          WATCHDOG_PID=$!
+          trap 'kill "$WATCHDOG_PID" 2>/dev/null || true' EXIT
+          ./gradlew clean ktlintCheck spotlessCheck check
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
           SNYK_ORG_NAME: ${{ secrets.SNYK_ORG_NAME }}
@@ -63,6 +73,16 @@ jobs:
         with:
           name: test-results-${{ matrix.os }}
           path: build/test-results/**/*.xml
+          if-no-files-found: ignore
+
+      # Thread dumps captured by hang-watchdog.sh when the test worker ran abnormally long. Present
+      # only on a hung run; they identify the wedged thread (see IDE-2237).
+      - name: Upload hang thread dumps
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-hang-dumps-${{ matrix.os }}
+          path: build/hang-dumps/**
           if-no-files-found: ignore
 
       - name: Publish Kover Report

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,11 +52,13 @@ jobs:
         # A background watchdog captures thread dumps of the test worker if it runs abnormally long,
         # so an intermittent hang (see the Gradle `test` timeout in build.gradle.kts) is diagnosable
         # from the uploaded dumps alone. `shell: bash` so the one script runs on all three OSes
-        # (git-bash on Windows). The trap tears the watchdog down whether gradle passes, fails, or is
-        # killed by its task timeout.
+        # (git-bash on Windows). Its stdio is redirected to a file (uploaded as an artifact) rather
+        # than inherited: otherwise the backgrounded process holds the runner's log pipe open, and a
+        # healthy run would stall at step end waiting for that fd to close. The trap tears the
+        # watchdog down whether gradle passes, fails, or is killed by its task timeout.
         shell: bash
         run: |
-          bash .github/scripts/hang-watchdog.sh &
+          bash .github/scripts/hang-watchdog.sh >hang-watchdog.log 2>&1 &
           WATCHDOG_PID=$!
           trap 'kill "$WATCHDOG_PID" 2>/dev/null || true' EXIT
           ./gradlew clean ktlintCheck spotlessCheck check
@@ -82,7 +84,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test-hang-dumps-${{ matrix.os }}
-          path: build/hang-dumps/**
+          path: |
+            build/hang-dumps/**
+            hang-watchdog.log
           if-no-files-found: ignore
 
       - name: Publish Kover Report

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,17 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
           SNYK_ORG_NAME: ${{ secrets.SNYK_ORG_NAME }}
 
+      # Upload test results even when the job fails or times out, so a hung run (see the Gradle
+      # `test` timeout in build.gradle.kts) can be diagnosed: the last-written result file points at
+      # the test that was in flight when the suite wedged.
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ matrix.os }}
+          path: build/test-results/**/*.xml
+          if-no-files-found: ignore
+
       - name: Publish Kover Report
         uses: mi-kas/kover-report@v1
         with:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import java.time.Duration
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.changelog.markdownToHTML
 import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
@@ -174,6 +175,15 @@ tasks {
     compilerOptions.jvmTarget.set(JvmTarget.fromTarget(jdk))
     compilerOptions.languageVersion.set(KotlinVersion.KOTLIN_2_1)
   }
+
+  // Wall-clock cap on the unit-test task only (deliberately NOT withType<Test>, so heavier Test
+  // tasks such as a future testIdeUi don't inherit this 25m limit sized for the unit suite). It
+  // bounds an *interruptible* hung test with a precise "test timed out" failure, locally and in
+  // CI, and sits above the ~16m worst-case real run so it won't false-trip. It is not a guarantee:
+  // a test wedged in uninterruptible native I/O can ignore the interrupt, so the GitHub Actions
+  // `test` job `timeout-minutes` (40m) in .github/workflows/build.yml is the real backstop. Keep
+  // this below that job timeout.
+  named<Test>("test") { timeout.set(Duration.ofMinutes(25)) }
 
   withType<Test> {
     maxHeapSize = "4096m"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -183,15 +183,6 @@ tasks {
     compilerOptions.languageVersion.set(KotlinVersion.KOTLIN_2_1)
   }
 
-  // Wall-clock cap on the unit-test task only (deliberately NOT withType<Test>, so heavier Test
-  // tasks such as a future testIdeUi don't inherit this 25m limit sized for the unit suite). It
-  // bounds an *interruptible* hung test with a precise "test timed out" failure, locally and in
-  // CI, and sits above the ~16m worst-case real run so it won't false-trip. It is not a guarantee:
-  // a test wedged in uninterruptible native I/O can ignore the interrupt, so the GitHub Actions
-  // `test` job `timeout-minutes` (40m) in .github/workflows/build.yml is the real backstop. Keep
-  // this below that job timeout.
-  named<Test>("test") { timeout.set(Duration.ofMinutes(25)) }
-
   withType<Test> {
     maxHeapSize = "4096m"
     testLogging { exceptionFormat = TestExceptionFormat.FULL }
@@ -231,6 +222,12 @@ tasks {
       }
     )
   }
+
+  // Wall-clock cap on the unit-test task only (deliberately NOT withType<Test> above, so heavier
+  // Test tasks such as a future testIdeUi don't inherit this limit). Bounds an *interruptible*
+  // hung test with a precise "test timed out" failure; the GitHub Actions job `timeout-minutes`
+  // (in .github/workflows/build.yml) is the real backstop for non-interruptible hangs.
+  named<Test>("test") { timeout.set(Duration.ofMinutes(25)) }
 
   // Configure the PatchPluginXml task
   patchPluginXml {


### PR DESCRIPTION
## What

Stop a hung `Test` job from stalling CI for hours, and make a rare hang diagnosable from the run's artifacts alone.

Three parts:

### 1. Bound the hang — layered timeouts

| Tier | Where | Value | Role |
|------|-------|-------|------|
| Gradle `test` task timeout | `build.gradle.kts` | **25m** | Fails an *interruptible* hung test with a precise "test timed out" message. Scoped to the `test` task (not `withType<Test>`) so heavier Test tasks like a future `testIdeUi` don't inherit a limit sized for the unit suite. |
| Test job `timeout-minutes` | `.github/workflows/build.yml` | **40m** | The real backstop — catches hangs the task timeout can't (wedged daemon, hung compile/spotless/kover, uninterruptible native I/O). |

No per-step timeout on purpose: a step timeout low enough to be useful would fire before the 25m Gradle timeout (compile+lint run first), degrading a precise "test timed out" failure into a generic "step timed out".

### 2. Diagnose the hang — thread-dump capture

`.github/scripts/hang-watchdog.sh` runs alongside `./gradlew` (backgrounded, torn down by a trap). It sleeps past the normal run time (`HANG_THRESHOLD_SECONDS`, default 20m — above the ~16m real-run max, below the 25m kill), then every 2m captures the Gradle test-worker JVM(s):
- `jstack -l` → a file per dump (primary; `-l` gives lock ownership)
- `kill -3` (SIGQUIT) → the JVM's own stdout (Unix best-effort)

Dumps upload as the `test-hang-dumps-<os>` artifact (`if: always()`). The `test-results` artifact also uploads on failure. On a healthy run the watchdog is killed while still sleeping and adds nothing.

### 3. Why this matters

The hang (IDE-2237) is intermittent and leaves no ordinary evidence — the worker goes silent and is killed. A thread dump taken while it is wedged is the one artifact that identifies the blocked thread. Capturing it in CI means a 1-in-N hang is diagnosable without a local repro.

## Validation (with links)

- **Timeout bounds the hang.** A real hang was killed by the 25m Gradle timeout instead of running to the 6h default — [Test (windows-latest), run 29255954069](https://github.com/snyk/snyk-intellij-plugin/actions/runs/29255954069/job/86844286732): `Execution failed for task ':test' > Timeout has been exceeded`, `BUILD FAILED in 29m 37s`. Earlier instances: [macOS run 29102204741](https://github.com/snyk/snyk-intellij-plugin/actions/runs/29102204741/job/86393680974), [ubuntu run 29110833595](https://github.com/snyk/snyk-intellij-plugin/actions/runs/29110833595/job/86422520894).
- **Watchdog detects a real hang.** On that same windows hang the watchdog fired and located the wedged test-worker JVM (log: `[hang-watchdog] iter N ... pid 7484`). That run also surfaced a bug — `./gradlew clean` had wiped the dump dir, so writes failed — fixed in this PR (recreate the dir each iteration + report write failures).
- **Capture works end-to-end.** [Run 29326207693](https://github.com/snyk/snyk-intellij-plugin/actions/runs/29326207693) (threshold temporarily lowered to force the watchdog on a healthy run) produced populated `test-hang-dumps-<os>` artifacts on all three OSes — each a real `Full thread dump` containing the `Test worker` and `AWT-EventQueue-0` stacks plus `jstack -l` lock ownership, the exact signal needed to diagnose the deadlock.

Normal `Test` durations (last 8 successful `master` runs): Linux ~6–7m, macOS ~8m, Windows ~13m (max 16m) — all well under the 25m timeout, so it won't false-trip.

## Out of scope

- The underlying flaky hang itself (IDE-2237): `UtilsKtTest` leaks `runAsync`/`invokeLater` work past teardown, deadlocking a later test's EDT dispatch. Fixed separately; this PR bounds and diagnoses it.
- `pluginVerifier` job also lacks a timeout (still the 6h default) — follow-up.

## Test plan

- [x] `./gradlew help` — config parses (`named<Test>("test")` resolves)
- [x] `ktlintCheck` / `spotlessCheck` — BUILD SUCCESSFUL
- [x] `hang-watchdog.sh` — `bash -n` + local smoke (no-worker + dir-recreate-after-clean paths)
- [x] Workflow YAML validated
- [x] Timeout fired on a real hang
- [x] Capture produced usable thread dumps in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
