### PR TITLE
fix(download): fall back to default host when CLI base URL blank [IDE-2188]

### DIFF
--- a/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
@@ -39,7 +39,7 @@ class SnykApplicationSettingsStateService :
 
   // download settings
   var currentLSProtocolVersion: Int? = 0
-  var cliBaseDownloadURL: String = "https://downloads.snyk.io"
+  var cliBaseDownloadURL: String = PLUGIN_DEFAULT_BINARY_BASE_URL
   var cliPath: String = getDefaultCliPath()
   var cliReleaseChannel = "stable"
   var manageBinariesAutomatically: Boolean = true
@@ -398,7 +398,7 @@ class SnykApplicationSettingsStateService :
     private val PLUGIN_DEFAULT_ORGANIZATION: String? = null
 
     private const val PLUGIN_DEFAULT_API_ENDPOINT = "https://api.snyk.io"
-    private const val PLUGIN_DEFAULT_BINARY_BASE_URL = "https://downloads.snyk.io"
+    const val PLUGIN_DEFAULT_BINARY_BASE_URL = "https://downloads.snyk.io"
     private const val PLUGIN_DEFAULT_CLI_RELEASE_CHANNEL = "stable"
   }
 }

--- a/src/main/kotlin/io/snyk/plugin/services/download/CliDownloader.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/download/CliDownloader.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.progress.ProgressIndicator
 import io.snyk.plugin.cli.Platform
 import io.snyk.plugin.pluginSettings
+import io.snyk.plugin.services.SnykApplicationSettingsStateService
 import io.snyk.plugin.services.download.HttpRequestHelper.createRequest
 import io.snyk.plugin.ui.SnykBalloonNotificationHelper
 import java.io.File
@@ -22,7 +23,10 @@ class CliDownloader {
 
   companion object {
     val BASE_URL: String
-      get() = pluginSettings().cliBaseDownloadURL
+      get() =
+        pluginSettings().cliBaseDownloadURL.ifBlank {
+          SnykApplicationSettingsStateService.PLUGIN_DEFAULT_BINARY_BASE_URL
+        }
 
     val LATEST_RELEASES_URL: String
       get() =

--- a/src/test/kotlin/io/snyk/plugin/services/download/CliDownloaderTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/services/download/CliDownloaderTest.kt
@@ -72,6 +72,26 @@ class CliDownloaderTest {
   }
 
   @Test
+  fun `should fall back to default base url when cliBaseDownloadURL setting is blank`() {
+    pluginSettings().cliBaseDownloadURL = ""
+
+    assertEquals("https://downloads.snyk.io", CliDownloader.BASE_URL)
+    assertEquals(
+      "https://downloads.snyk.io/cli/${pluginSettings().cliReleaseChannel}/ls-protocol-version-" +
+        pluginSettings().requiredLsProtocolVersion,
+      CliDownloader.LATEST_RELEASES_URL,
+    )
+  }
+
+  @Test
+  fun `should pass through custom cliBaseDownloadURL setting unchanged when non-blank`() {
+    val customUrl = "https://custom.example.com"
+    pluginSettings().cliBaseDownloadURL = customUrl
+
+    assertEquals(customUrl, CliDownloader.BASE_URL)
+  }
+
+  @Test
   fun `should not delete file if checksum verification fails`() {
     val testFile = Files.createTempFile("test", "test").toFile()
     testFile.deleteOnExit()


### PR DESCRIPTION
### Description

Fixes [IDE-2188](https://snyksec.atlassian.net/browse/IDE-2188).

CLI download failed with `java.net.MalformedURLException: no protocol` when `cliBaseDownloadURL` was persisted blank — `BASE_URL` returned the empty string, producing a schemeless URL like `/cli/rc/ls-protocol-version-25` (correct `rc` channel path, missing the host).

**Root cause of the blank:** a circular config exchange. The outbound LS-config write blank-guards `binary_base_url` (omits it when blank — `LanguageServerWrapper.kt:705`), so snyk-ls never receives it and echoes back `""` via `$/snyk.configuration`, which the plugin then persists over its built-in default.

**Fix (read-side backstop, this PR):** `CliDownloader.BASE_URL` now falls back to `PLUGIN_DEFAULT_BINARY_BASE_URL` (`https://downloads.snyk.io`) via `ifBlank`. That constant is made non-private and is now also the source of the `cliBaseDownloadURL` field default (removing a duplicated literal). Release-channel handling is unchanged and correct.

The LS-side default coupling is intentional and confirmed correct: snyk-ls applies an IDE global setting only when `ConfigSetting.changed == true`, so the plugin never overrides the LS/user-asserted value with a silent default.

**Deferred (follow-up if needed):** guarding the inbound blank write at `SnykLanguageClient.kt` and/or giving snyk-ls a default host so it never emits blank. Not required to fix the download.

### Checklist

- [ ] Read and understood the [Code of Conduct](https://github.com/snyk/snyk-intellij-plugin/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/snyk-intellij-plugin/blob/master/CONTRIBUTING.md).
- [x] Tests added and all succeed
- [x] Linted
- [ ] ~CHANGELOG.md updated~ (n/a — changelog is generated from GitHub releases)
- [ ] ~README.md updated~ (n/a — no user-facing UI change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[IDE-2188]: https://snyksec.atlassian.net/browse/IDE-2188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ