### PR TITLE
fix(download): fall back to default release channel when blank [IDE-2188]

### DIFF
--- a/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
@@ -41,7 +41,7 @@ class SnykApplicationSettingsStateService :
   var currentLSProtocolVersion: Int? = 0
   var cliBaseDownloadURL: String = PLUGIN_DEFAULT_BINARY_BASE_URL
   var cliPath: String = getDefaultCliPath()
-  var cliReleaseChannel = "stable"
+  var cliReleaseChannel = PLUGIN_DEFAULT_CLI_RELEASE_CHANNEL
   var manageBinariesAutomatically: Boolean = true
 
   // testing flag
@@ -399,7 +399,7 @@ class SnykApplicationSettingsStateService :
 
     private const val PLUGIN_DEFAULT_API_ENDPOINT = "https://api.snyk.io"
     const val PLUGIN_DEFAULT_BINARY_BASE_URL = "https://downloads.snyk.io"
-    private const val PLUGIN_DEFAULT_CLI_RELEASE_CHANNEL = "stable"
+    const val PLUGIN_DEFAULT_CLI_RELEASE_CHANNEL = "stable"
   }
 }
 

--- a/src/main/kotlin/io/snyk/plugin/services/download/CliDownloader.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/download/CliDownloader.kt
@@ -30,7 +30,11 @@ class CliDownloader {
 
     val LATEST_RELEASES_URL: String
       get() =
-        "$BASE_URL/cli/${pluginSettings().cliReleaseChannel}/ls-protocol-version-" +
+        "$BASE_URL/cli/${
+          pluginSettings().cliReleaseChannel.ifBlank {
+            SnykApplicationSettingsStateService.PLUGIN_DEFAULT_CLI_RELEASE_CHANNEL
+          }
+        }/ls-protocol-version-" +
           pluginSettings().requiredLsProtocolVersion
   }
 

--- a/src/test/kotlin/io/snyk/plugin/services/download/CliDownloaderTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/services/download/CliDownloaderTest.kt
@@ -92,6 +92,29 @@ class CliDownloaderTest {
   }
 
   @Test
+  fun `should fall back to default release channel when cliReleaseChannel setting is blank`() {
+    pluginSettings().cliReleaseChannel = ""
+
+    assertEquals(
+      "${CliDownloader.BASE_URL}/cli/stable/ls-protocol-version-" +
+        pluginSettings().requiredLsProtocolVersion,
+      CliDownloader.LATEST_RELEASES_URL,
+    )
+  }
+
+  @Test
+  fun `should pass through custom cliReleaseChannel setting unchanged when non-blank`() {
+    val customChannel = "customChannel"
+    pluginSettings().cliReleaseChannel = customChannel
+
+    assertEquals(
+      "${CliDownloader.BASE_URL}/cli/$customChannel/ls-protocol-version-" +
+        pluginSettings().requiredLsProtocolVersion,
+      CliDownloader.LATEST_RELEASES_URL,
+    )
+  }
+
+  @Test
   fun `should not delete file if checksum verification fails`() {
     val testFile = Files.createTempFile("test", "test").toFile()
     testFile.deleteOnExit()


### PR DESCRIPTION
### Description

Follow-up to #864, fixes another instance of [IDE-2188](https://snyksec.atlassian.net/browse/IDE-2188).

#864 made CLI download fall back to the default host when `binary_base_url` was persisted blank. Manual testing on IC-2024.2 showed the download still fails — the host is now correct, but the release channel is *also* persisted blank, producing:

`https://downloads.snyk.io/cli//ls-protocol-version-25` → **HTTP 403**

Note the double slash — the channel segment is empty. Same blank-value bug class as #864, different field. (The original reporter had channel `rc`, so it looked fine there.)

**Fix (read-side, mirrors #864):** `CliDownloader.LATEST_RELEASES_URL` now falls back to `PLUGIN_DEFAULT_CLI_RELEASE_CHANNEL` (`stable`) via `ifBlank` when the channel is blank. This repairs an already-persisted blank, which a write-guard alone cannot. The constant is made non-private and reused as the `cliReleaseChannel` field default (dropping a duplicated literal).

Verified against the failing sandbox log; manual re-test now downloads successfully.

**Deferred (systemic follow-up):** the inbound write persists `cliPath`, `binary_base_url` and `cli_release_channel` blank unguarded (`SnykLanguageClient.kt:270-293`). `cliPath` is the remaining unpatched field. The deeper fix is to guard the inbound write (mirror the outbound `isNullOrBlank()` guard) and/or give snyk-ls a real default so it never emits blank — recommend a dedicated ticket. Noted on IDE-2188.

### Checklist

- [ ] Read and understood the [Code of Conduct](https://github.com/snyk/snyk-intellij-plugin/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/snyk-intellij-plugin/blob/master/CONTRIBUTING.md).
- [x] Tests added and all succeed
- [x] Linted
- [ ] ~CHANGELOG.md updated~ (n/a — changelog is generated from GitHub releases)
- [ ] ~README.md updated~ (n/a — no user-facing UI change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[IDE-2188]: https://snyksec.atlassian.net/browse/IDE-2188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ