### PR TITLE
fix(download): fall back to default CLI path when cliPath is blank [IDE-2188]

### DIFF
--- a/src/main/kotlin/io/snyk/plugin/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/Utils.kt
@@ -102,7 +102,7 @@ fun getSnykCliAuthenticationService(project: Project?): SnykCliAuthenticationSer
 fun getSnykCliDownloaderService(): SnykCliDownloaderService =
   ApplicationManager.getApplication().service()
 
-fun getCliFile() = File(pluginSettings().cliPath)
+fun getCliFile() = File(pluginSettings().cliPath.ifBlank { getDefaultCliPath() })
 
 fun isCliInstalled(): Boolean {
   if (ApplicationManager.getApplication().isUnitTestMode) return true

--- a/src/test/kotlin/io/snyk/plugin/UtilsKtTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/UtilsKtTest.kt
@@ -12,6 +12,7 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.verify
+import io.snyk.plugin.services.SnykApplicationSettingsStateService
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.NoSuchFileException
@@ -144,6 +145,17 @@ class UtilsKtTest {
       assertEquals("Testing $actualPath to uri conversion", uri, actualPath.fromPathToUriString())
       i++
     }
+  }
+
+  @Test
+  fun `getCliFile falls back to default path when cliPath setting is blank`() {
+    unmockkAll()
+    val settingsStateService = SnykApplicationSettingsStateService()
+    settingsStateService.cliPath = ""
+    mockkStatic(::pluginSettings)
+    every { pluginSettings() } returns settingsStateService
+
+    assertEquals(getDefaultCliPath(), getCliFile().path)
   }
 
   @Test

--- a/src/test/kotlin/io/snyk/plugin/UtilsKtTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/UtilsKtTest.kt
@@ -155,7 +155,10 @@ class UtilsKtTest {
     mockkStatic(::pluginSettings)
     every { pluginSettings() } returns settingsStateService
 
-    assertEquals(getDefaultCliPath(), getCliFile().path)
+    // Compare via File so the assertion is separator-agnostic: getDefaultCliPath() builds a raw
+    // string with a hardcoded '/', while getCliFile().path is normalized to the OS separator
+    // (e.g. '\' on Windows). Wrapping both in File normalizes them consistently.
+    assertEquals(File(getDefaultCliPath()).path, getCliFile().path)
   }
 
   @Test


### PR DESCRIPTION
### Description

Third field in the same blank-value class as [IDE-2188](https://snyksec.atlassian.net/browse/IDE-2188) (after #864 `binary_base_url` and #865 `cli_release_channel`).

When `cliPath` is persisted blank (via the unguarded inbound LS-config write, `SnykLanguageClient.kt:270-293`), `getCliFile()` returned `File("")`, whose `parentFile` is `null`, crashing CLI download:

```
java.lang.NullPointerException: Cannot invoke "java.io.File.exists()" because the return value of "java.io.File.getParentFile()" is null
	at io.snyk.plugin.services.download.CliDownloader.downloadFile(CliDownloader.kt:51)
	at io.snyk.plugin.services.download.SnykCliDownloaderService.downloadLatestRelease(SnykCliDownloaderService.kt:82)
```

Blank `cliPath` also made `isCliInstalled()` return false (re-download loop), threw `CliNotExistsException`, and let the process CWD be spawned as the CLI.

**Fix (read-side, mirrors #864/#865):** `getCliFile()` (`Utils.kt:105`) falls back to `getDefaultCliPath()` via `ifBlank` when `cliPath` is blank.

**Manually verified** with a controlled IC-2024.2 sandbox repro (`cliPath=""`, other download settings valid so nothing masked it):
- **Without** the fix → `SEVERE` NPE above on startup CLI download.
- **With** the fix → no NPE; `CLI Path` resolves to the default plugin path (`…/plugins/snyk-intellij-plugin/snyk-macos-arm64`), `CLI Installed? true`, while `cliPath` stays blank.

**Audit note — `organization` deliberately unchanged:** there is no default org; a blank org is a valid user choice that must reach LS so it performs its own default-org resolution. `api_endpoint` (self-heals) and `additional_parameters`/`additional_environment` (blank is the valid no-op) also need no change.

**Systemic follow-up recommended (separate ticket):** the read-side fallback has now been applied per-field three times. The deeper fix is to guard the inbound write at `SnykLanguageClient.kt:270-293` for fields where blank has no valid meaning, while still allowing blank for `organization`/`additional_*`.

### Checklist

- [ ] Read and understood the [Code of Conduct](https://github.com/snyk/snyk-intellij-plugin/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/snyk-intellij-plugin/blob/master/CONTRIBUTING.md).
- [x] Tests added and all succeed
- [x] Linted
- [ ] ~CHANGELOG.md updated~ (n/a — changelog is generated from GitHub releases)
- [ ] ~README.md updated~ (n/a — no user-facing UI change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[IDE-2188]: https://snyksec.atlassian.net/browse/IDE-2188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ