### PR TITLE
fix: code enablement lost on upgrade [IDE-2223]

### DIFF
--- a/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
@@ -59,6 +59,11 @@ class SnykApplicationSettingsStateService :
   // ([snyk.common.lsp.settings.withSetting]), which getSettings emits verbatim.
   var explicitChanges: MutableSet<String> = ConcurrentHashMap.newKeySet()
 
+  // One-shot upgrade marker for the per-key `changed` LS schema (introduced after 2.21.0).
+  // Persisted; defaults to false so it fires once on the first launch after upgrading from a
+  // pre-[explicitChanges] version. See [migrateProductEnablementToExplicitChanges].
+  var explicitProductEnablementMigrated: Boolean = false
+
   // Global keys pending a reset signal ({ value: null, changed: true }) to the LS.
   // Transient (not persisted): enqueued by the JCEF query thread, consumed once by every
   // getSettings() across the multi-project fan-out. Concurrent-set backed so all access is
@@ -313,7 +318,37 @@ class SnykApplicationSettingsStateService :
       useTokenAuthentication = false
     }
 
-    reconcileProductExplicitKeysIfDeviatingFromDefaults()
+    migrateProductEnablementToExplicitChanges()
+  }
+
+  /**
+   * One-time upgrade migration for the per-key `changed` LS schema (introduced after 2.21.0).
+   *
+   * Plugin versions <= 2.21.0 pushed every product-enablement value to the LS as an
+   * always-authoritative value (e.g. `activateSnykCodeSecurity="true"`). The new schema only honors
+   * a user:global value when its [ConfigSetting.changed] flag is true; otherwise the LS defers to
+   * org/LDX-Sync/default. So on the first launch after upgrading we must carry the persisted product
+   * toggles forward as explicit user intent — otherwise a pre-existing "enabled" preference that
+   * happens to equal the new plugin default is silently dropped and the org "Disabled at Snyk" state
+   * wins.
+   *
+   * Fresh installs ([pluginFirstRun]) must NOT be seeded: with no prior user preference they must
+   * defer to org governance. After the one-time migration, steady-state startups fall back to
+   * [reconcileProductExplicitKeysIfDeviatingFromDefaults] so a product reset isn't re-asserted.
+   */
+  private fun migrateProductEnablementToExplicitChanges() {
+    val isLegacyUpgrade = !explicitProductEnablementMigrated && !pluginFirstRun
+    if (isLegacyUpgrade) {
+      // Covers Code/OSS/IaC/Secrets — every toggle that shares the default-equality path.
+      markAllProductEnablementKeysExplicit()
+    } else {
+      reconcileProductExplicitKeysIfDeviatingFromDefaults()
+    }
+    // Flip the one-shot only AFTER the keys are marked, so "migrated" always implies "work done".
+    // The flag and [explicitChanges] persist together in the same settings component, so a crash
+    // before persistence loses both and re-runs the migration next launch — never a flag set with
+    // keys unmarked.
+    explicitProductEnablementMigrated = true
   }
 
   fun isDeltaFindingsEnabled(): Boolean = (issuesToDisplay == DISPLAY_NEW_ISSUES)

--- a/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
@@ -254,7 +254,8 @@ class SnykApplicationSettingsStateService :
   // Defaults to false to match the Language Server's own flagset default for Snyk Code
   // (register_configurations.go: SettingSnykCodeEnabled = false). Keeping this in sync with the LS
   // default means an at-default value sent with changed=false resolves back to the same state, so a
-  // user's enabled preference (which now deviates from the default -> changed=true) survives upgrade
+  // user's enabled preference (which now deviates from the default -> changed=true) survives
+  // upgrade
   // without a bespoke migration. OSS/IaC (true) and Secrets (false) already match the LS defaults.
   var snykCodeSecurityIssuesScanEnable: Boolean = false
   var iacScanEnabled: Boolean = true

--- a/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
@@ -59,11 +59,6 @@ class SnykApplicationSettingsStateService :
   // ([snyk.common.lsp.settings.withSetting]), which getSettings emits verbatim.
   var explicitChanges: MutableSet<String> = ConcurrentHashMap.newKeySet()
 
-  // One-shot upgrade marker for the per-key `changed` LS schema (introduced after 2.21.0).
-  // Persisted; defaults to false so it fires once on the first launch after upgrading from a
-  // pre-[explicitChanges] version. See [migrateProductEnablementToExplicitChanges].
-  var explicitProductEnablementMigrated: Boolean = false
-
   // Global keys pending a reset signal ({ value: null, changed: true }) to the LS.
   // Transient (not persisted): enqueued by the JCEF query thread, consumed once by every
   // getSettings() across the multi-project fan-out. Concurrent-set backed so all access is
@@ -256,7 +251,12 @@ class SnykApplicationSettingsStateService :
 
   // products enablement store
   var ossScanEnable: Boolean = true
-  var snykCodeSecurityIssuesScanEnable: Boolean = true
+  // Defaults to false to match the Language Server's own flagset default for Snyk Code
+  // (register_configurations.go: SettingSnykCodeEnabled = false). Keeping this in sync with the LS
+  // default means an at-default value sent with changed=false resolves back to the same state, so a
+  // user's enabled preference (which now deviates from the default -> changed=true) survives upgrade
+  // without a bespoke migration. OSS/IaC (true) and Secrets (false) already match the LS defaults.
+  var snykCodeSecurityIssuesScanEnable: Boolean = false
   var iacScanEnabled: Boolean = true
   var secretsEnabled: Boolean = false
 
@@ -318,37 +318,7 @@ class SnykApplicationSettingsStateService :
       useTokenAuthentication = false
     }
 
-    migrateProductEnablementToExplicitChanges()
-  }
-
-  /**
-   * One-time upgrade migration for the per-key `changed` LS schema (introduced after 2.21.0).
-   *
-   * Plugin versions <= 2.21.0 pushed every product-enablement value to the LS as an
-   * always-authoritative value (e.g. `activateSnykCodeSecurity="true"`). The new schema only honors
-   * a user:global value when its [ConfigSetting.changed] flag is true; otherwise the LS defers to
-   * org/LDX-Sync/default. So on the first launch after upgrading we must carry the persisted
-   * product toggles forward as explicit user intent — otherwise a pre-existing "enabled" preference
-   * that happens to equal the new plugin default is silently dropped and the org "Disabled at Snyk"
-   * state wins.
-   *
-   * Fresh installs ([pluginFirstRun]) must NOT be seeded: with no prior user preference they must
-   * defer to org governance. After the one-time migration, steady-state startups fall back to
-   * [reconcileProductExplicitKeysIfDeviatingFromDefaults] so a product reset isn't re-asserted.
-   */
-  private fun migrateProductEnablementToExplicitChanges() {
-    val isLegacyUpgrade = !explicitProductEnablementMigrated && !pluginFirstRun
-    if (isLegacyUpgrade) {
-      // Covers Code/OSS/IaC/Secrets — every toggle that shares the default-equality path.
-      markAllProductEnablementKeysExplicit()
-    } else {
-      reconcileProductExplicitKeysIfDeviatingFromDefaults()
-    }
-    // Flip the one-shot only AFTER the keys are marked, so "migrated" always implies "work done".
-    // The flag and [explicitChanges] persist together in the same settings component, so a crash
-    // before persistence loses both and re-runs the migration next launch — never a flag set with
-    // keys unmarked.
-    explicitProductEnablementMigrated = true
+    reconcileProductExplicitKeysIfDeviatingFromDefaults()
   }
 
   fun isDeltaFindingsEnabled(): Boolean = (issuesToDisplay == DISPLAY_NEW_ISSUES)
@@ -421,7 +391,9 @@ class SnykApplicationSettingsStateService :
     const val DISPLAY_NEW_ISSUES = "Net new issues"
 
     private const val PLUGIN_DEFAULT_OSS_SCAN_ENABLE = true
-    private const val PLUGIN_DEFAULT_CODE_SCAN_ENABLE = true
+    // false to match the Language Server flagset default for Snyk Code — see the field declaration
+    // [snykCodeSecurityIssuesScanEnable] for why the plugin default is kept in sync with the LS.
+    private const val PLUGIN_DEFAULT_CODE_SCAN_ENABLE = false
     private const val PLUGIN_DEFAULT_IAC_SCAN_ENABLE = true
     private const val PLUGIN_DEFAULT_SECRETS_SCAN_ENABLE = false
     private const val PLUGIN_DEFAULT_OPEN_ISSUES_ENABLED = true

--- a/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
@@ -327,10 +327,10 @@ class SnykApplicationSettingsStateService :
    * Plugin versions <= 2.21.0 pushed every product-enablement value to the LS as an
    * always-authoritative value (e.g. `activateSnykCodeSecurity="true"`). The new schema only honors
    * a user:global value when its [ConfigSetting.changed] flag is true; otherwise the LS defers to
-   * org/LDX-Sync/default. So on the first launch after upgrading we must carry the persisted product
-   * toggles forward as explicit user intent — otherwise a pre-existing "enabled" preference that
-   * happens to equal the new plugin default is silently dropped and the org "Disabled at Snyk" state
-   * wins.
+   * org/LDX-Sync/default. So on the first launch after upgrading we must carry the persisted
+   * product toggles forward as explicit user intent — otherwise a pre-existing "enabled" preference
+   * that happens to equal the new plugin default is silently dropped and the org "Disabled at Snyk"
+   * state wins.
    *
    * Fresh installs ([pluginFirstRun]) must NOT be seeded: with no prior user preference they must
    * defer to org governance. After the one-time migration, steady-state startups fall back to

--- a/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
@@ -251,12 +251,7 @@ class SnykApplicationSettingsStateService :
 
   // products enablement store
   var ossScanEnable: Boolean = true
-  // Defaults to false to match the Language Server's own flagset default for Snyk Code
-  // (register_configurations.go: SettingSnykCodeEnabled = false). Keeping this in sync with the LS
-  // default means an at-default value sent with changed=false resolves back to the same state, so a
-  // user's enabled preference (which now deviates from the default -> changed=true) survives
-  // upgrade
-  // without a bespoke migration. OSS/IaC (true) and Secrets (false) already match the LS defaults.
+  // Product enablement flags match the language server's defaults.
   var snykCodeSecurityIssuesScanEnable: Boolean = false
   var iacScanEnabled: Boolean = true
   var secretsEnabled: Boolean = false
@@ -392,8 +387,7 @@ class SnykApplicationSettingsStateService :
     const val DISPLAY_NEW_ISSUES = "Net new issues"
 
     private const val PLUGIN_DEFAULT_OSS_SCAN_ENABLE = true
-    // false to match the Language Server flagset default for Snyk Code — see the field declaration
-    // [snykCodeSecurityIssuesScanEnable] for why the plugin default is kept in sync with the LS.
+    // Product enablement flags match the Language Server defaults.
     private const val PLUGIN_DEFAULT_CODE_SCAN_ENABLE = false
     private const val PLUGIN_DEFAULT_IAC_SCAN_ENABLE = true
     private const val PLUGIN_DEFAULT_SECRETS_SCAN_ENABLE = false

--- a/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
+++ b/src/main/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateService.kt
@@ -9,6 +9,8 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.util.xmlb.XmlSerializerUtil
+import com.intellij.util.xmlb.annotations.OptionTag
+import com.intellij.util.xmlb.annotations.Transient
 import io.snyk.plugin.Severity
 import io.snyk.plugin.getDefaultCliPath
 import java.time.Instant
@@ -236,6 +238,26 @@ class SnykApplicationSettingsStateService :
     }
   }
 
+  /**
+   * One-time upgrade migration (2.22.1) that recovers Snyk Code enablement lost when the plugin
+   * default flipped from `true` (<= 2.21.0) to `false` (2.22.0, to match the Language Server, which
+   * is needed for LDX-Sync).
+   */
+  private fun migrateCodeEnablementForV2221() {
+    if (!codeEnablementUpgradeMigratedV2221) {
+      codeEnablementUpgradeMigratedV2221 = true
+      val existingInstallAtLegacyDefault =
+        !pluginFirstRun &&
+          snykCodeSecurityIssuesScanEnableRaw == null &&
+          !isExplicitlyChanged(LsFolderSettingsKeys.SNYK_CODE_ENABLED)
+      if (existingInstallAtLegacyDefault) {
+        snykCodeSecurityIssuesScanEnableRaw = true
+        markExplicitlyChanged(LsFolderSettingsKeys.SNYK_CODE_ENABLED)
+      }
+    }
+    reconcileProductExplicitKeysIfDeviatingFromDefaults()
+  }
+
   // TODO migrate to
   // https://plugins.jetbrains.com/docs/intellij/persisting-sensitive-data.html?from=jetbrains.org
   var token: String? = null
@@ -251,10 +273,33 @@ class SnykApplicationSettingsStateService :
 
   // products enablement store
   var ossScanEnable: Boolean = true
-  // Product enablement flags match the language server's defaults.
-  var snykCodeSecurityIssuesScanEnable: Boolean = false
+
+  // Persisted raw Snyk Code enablement. `null` means no value was ever written to
+  // snyk.settings.xml, which is an important distinction for [migrateCodeEnablementForV2221]
+  // @OptionTag keeps the element name identical to the pre-2.22.1 field so existing configs
+  // are still deserialize.
+  @OptionTag("snykCodeSecurityIssuesScanEnable")
+  var snykCodeSecurityIssuesScanEnableRaw: Boolean? = null
+
+  // Non-null view used by the rest of the plugin.
+  // Falls back to the plugin default when unset. NOT serialized — the raw field above is;
+  // @Transient also keeps XmlSerializerUtil.copyBean (loadState) from overwriting the null via
+  // the getter.
+  @get:Transient
+  @set:Transient
+  var snykCodeSecurityIssuesScanEnable: Boolean
+    get() = snykCodeSecurityIssuesScanEnableRaw ?: PLUGIN_DEFAULT_CODE_SCAN_ENABLE
+    set(value) {
+      snykCodeSecurityIssuesScanEnableRaw = value
+    }
+
   var iacScanEnabled: Boolean = true
   var secretsEnabled: Boolean = false
+
+  // One-shot upgrade marker for the 2.22.1 Snyk Code enablement migration. Persisted; `false` on
+  // any config last written by <= 2.22.0, so [migrateCodeEnablementForV2221] runs exactly once
+  // after upgrading.
+  var codeEnablementUpgradeMigratedV2221: Boolean = false
 
   // feature flag / server-side enablement
   var sastOnServerEnabled: Boolean? = null
@@ -314,7 +359,7 @@ class SnykApplicationSettingsStateService :
       useTokenAuthentication = false
     }
 
-    reconcileProductExplicitKeysIfDeviatingFromDefaults()
+    migrateCodeEnablementForV2221()
   }
 
   fun isDeltaFindingsEnabled(): Boolean = (issuesToDisplay == DISPLAY_NEW_ISSUES)

--- a/src/test/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateServiceTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateServiceTest.kt
@@ -308,6 +308,59 @@ class SnykApplicationSettingsStateServiceTest {
   }
 
   @Test
+  fun initializeComponent_legacyUpgrade_marksAllProductKeysExplicitEvenWhenAtDefault() {
+    // Bug repro: upgrading from a pre-explicit-change version (<= 2.21.0) must carry the persisted
+    // product toggles forward as user intent, even when a toggle equals the new plugin default
+    // (e.g. Snyk Code enabled == default true). pluginFirstRun == false marks this as an upgrade,
+    // not a fresh install; explicitProductEnablementMigrated == false means the one-shot hasn't run.
+    val target = SnykApplicationSettingsStateService()
+    target.pluginFirstRun = false
+    target.explicitProductEnablementMigrated = false
+    // All products left at their plugin defaults — this is exactly the case that used to be lost.
+    target.snykCodeSecurityIssuesScanEnable = true // == PLUGIN_DEFAULT_CODE_SCAN_ENABLE
+
+    target.initializeComponent()
+
+    assertTrue(target.isExplicitlyChanged(LsFolderSettingsKeys.SNYK_CODE_ENABLED))
+    assertTrue(target.isExplicitlyChanged(LsFolderSettingsKeys.SNYK_OSS_ENABLED))
+    assertTrue(target.isExplicitlyChanged(LsFolderSettingsKeys.SNYK_IAC_ENABLED))
+    assertTrue(target.isExplicitlyChanged(LsFolderSettingsKeys.SNYK_SECRETS_ENABLED))
+    assertTrue(target.explicitProductEnablementMigrated)
+  }
+
+  @Test
+  fun initializeComponent_freshInstall_doesNotSeedProductKeysAtDefault() {
+    // Fresh install (pluginFirstRun == true): no prior preference to preserve, so products at their
+    // defaults must NOT be marked explicit — org governance ("Disabled at Snyk") must still apply.
+    val target = SnykApplicationSettingsStateService()
+    assertTrue(target.pluginFirstRun) // default for a genuinely new install
+    assertFalse(target.explicitProductEnablementMigrated)
+
+    target.initializeComponent()
+
+    assertFalse(target.isExplicitlyChanged(LsFolderSettingsKeys.SNYK_CODE_ENABLED))
+    assertFalse(target.isExplicitlyChanged(LsFolderSettingsKeys.SNYK_OSS_ENABLED))
+    assertFalse(target.isExplicitlyChanged(LsFolderSettingsKeys.SNYK_IAC_ENABLED))
+    assertFalse(target.isExplicitlyChanged(LsFolderSettingsKeys.SNYK_SECRETS_ENABLED))
+    // The one-shot must be marked done so it never fires later for this install.
+    assertTrue(target.explicitProductEnablementMigrated)
+  }
+
+  @Test
+  fun initializeComponent_afterMigration_doesNotReAssertResetKeys() {
+    // Steady state: once migrated, a product reset back to default (cleared from explicitChanges)
+    // must not be re-asserted on the next startup — only still-deviating keys get re-marked.
+    val target = SnykApplicationSettingsStateService()
+    target.pluginFirstRun = false
+    target.explicitProductEnablementMigrated = true
+    target.snykCodeSecurityIssuesScanEnable = true // reset to default, no longer explicit
+
+    target.initializeComponent()
+
+    assertFalse(target.isExplicitlyChanged(LsFolderSettingsKeys.SNYK_CODE_ENABLED))
+  }
+
+  @Test
   fun clearAllExplicitlyChanged_clearsGlobalChanges() {
     val target = SnykApplicationSettingsStateService()
     target.markExplicitlyChanged("global_key_a")

--- a/src/test/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateServiceTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateServiceTest.kt
@@ -308,57 +308,45 @@ class SnykApplicationSettingsStateServiceTest {
   }
 
   @Test
-  fun initializeComponent_legacyUpgrade_marksAllProductKeysExplicitEvenWhenAtDefault() {
-    // Bug repro: upgrading from a pre-explicit-change version (<= 2.21.0) must carry the persisted
-    // product toggles forward as user intent, even when a toggle equals the new plugin default
-    // (e.g. Snyk Code enabled == default true). pluginFirstRun == false marks this as an upgrade,
-    // not a fresh install; explicitProductEnablementMigrated == false means the one-shot hasn't
-    // run.
+  fun snykCodeDefault_matchesLanguageServerDefault_false() {
+    // The plugin's Snyk Code default is kept in sync with the Language Server flagset default
+    // (false). This alignment is what lets an at-default value sent with changed=false resolve back
+    // to the same state, so no bespoke upgrade migration is needed. See the field declaration.
     val target = SnykApplicationSettingsStateService()
-    target.pluginFirstRun = false
-    target.explicitProductEnablementMigrated = false
-    // All products left at their plugin defaults — this is exactly the case that used to be lost.
-    target.snykCodeSecurityIssuesScanEnable = true // == PLUGIN_DEFAULT_CODE_SCAN_ENABLE
+    assertFalse(target.snykCodeSecurityIssuesScanEnable)
+  }
+
+  @Test
+  fun initializeComponent_enabledCodeSurvivesUpgrade_becauseItDeviatesFromDefault() {
+    // Upgrade repro: a user who had Snyk Code enabled in the old plugin has snykCode... == true
+    // persisted. Because the plugin default is now false, that value deviates from the default, so
+    // it is emitted with changed=true and the LS honors it — the preference survives the upgrade
+    // without any migration.
+    val target = SnykApplicationSettingsStateService()
+    target.snykCodeSecurityIssuesScanEnable = true // persisted "enabled" from the old plugin
 
     target.initializeComponent()
 
     assertTrue(target.isExplicitlyChanged(LsFolderSettingsKeys.SNYK_CODE_ENABLED))
-    assertTrue(target.isExplicitlyChanged(LsFolderSettingsKeys.SNYK_OSS_ENABLED))
-    assertTrue(target.isExplicitlyChanged(LsFolderSettingsKeys.SNYK_IAC_ENABLED))
-    assertTrue(target.isExplicitlyChanged(LsFolderSettingsKeys.SNYK_SECRETS_ENABLED))
-    assertTrue(target.explicitProductEnablementMigrated)
+    assertTrue(
+      target.lsUserAssertedChangeForLsConfigurationKey(LsFolderSettingsKeys.SNYK_CODE_ENABLED)
+    )
   }
 
   @Test
-  fun initializeComponent_freshInstall_doesNotSeedProductKeysAtDefault() {
-    // Fresh install (pluginFirstRun == true): no prior preference to preserve, so products at their
-    // defaults must NOT be marked explicit — org governance ("Disabled at Snyk") must still apply.
+  fun initializeComponent_codeAtDefault_defersToLanguageServer() {
+    // A fresh install (or a user who had Code disabled, which now equals the default) leaves Code at
+    // the default false. It must NOT be marked explicit, so it is sent changed=false and the LS
+    // resolves it (org governance / its own default). Both cases resolve back to false — no
+    // preference is lost.
     val target = SnykApplicationSettingsStateService()
-    assertTrue(target.pluginFirstRun) // default for a genuinely new install
-    assertFalse(target.explicitProductEnablementMigrated)
 
     target.initializeComponent()
 
     assertFalse(target.isExplicitlyChanged(LsFolderSettingsKeys.SNYK_CODE_ENABLED))
-    assertFalse(target.isExplicitlyChanged(LsFolderSettingsKeys.SNYK_OSS_ENABLED))
-    assertFalse(target.isExplicitlyChanged(LsFolderSettingsKeys.SNYK_IAC_ENABLED))
-    assertFalse(target.isExplicitlyChanged(LsFolderSettingsKeys.SNYK_SECRETS_ENABLED))
-    // The one-shot must be marked done so it never fires later for this install.
-    assertTrue(target.explicitProductEnablementMigrated)
-  }
-
-  @Test
-  fun initializeComponent_afterMigration_doesNotReAssertResetKeys() {
-    // Steady state: once migrated, a product reset back to default (cleared from explicitChanges)
-    // must not be re-asserted on the next startup — only still-deviating keys get re-marked.
-    val target = SnykApplicationSettingsStateService()
-    target.pluginFirstRun = false
-    target.explicitProductEnablementMigrated = true
-    target.snykCodeSecurityIssuesScanEnable = true // reset to default, no longer explicit
-
-    target.initializeComponent()
-
-    assertFalse(target.isExplicitlyChanged(LsFolderSettingsKeys.SNYK_CODE_ENABLED))
+    assertFalse(
+      target.lsUserAssertedChangeForLsConfigurationKey(LsFolderSettingsKeys.SNYK_CODE_ENABLED)
+    )
   }
 
   @Test

--- a/src/test/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateServiceTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateServiceTest.kt
@@ -312,7 +312,8 @@ class SnykApplicationSettingsStateServiceTest {
     // Bug repro: upgrading from a pre-explicit-change version (<= 2.21.0) must carry the persisted
     // product toggles forward as user intent, even when a toggle equals the new plugin default
     // (e.g. Snyk Code enabled == default true). pluginFirstRun == false marks this as an upgrade,
-    // not a fresh install; explicitProductEnablementMigrated == false means the one-shot hasn't run.
+    // not a fresh install; explicitProductEnablementMigrated == false means the one-shot hasn't
+    // run.
     val target = SnykApplicationSettingsStateService()
     target.pluginFirstRun = false
     target.explicitProductEnablementMigrated = false

--- a/src/test/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateServiceTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateServiceTest.kt
@@ -1,5 +1,7 @@
 package io.snyk.plugin.services
 
+import com.intellij.util.xmlb.SkipDefaultsSerializationFilter
+import com.intellij.util.xmlb.XmlSerializer
 import io.snyk.plugin.Severity
 import java.time.LocalDateTime
 import junit.framework.TestCase.assertEquals
@@ -309,45 +311,147 @@ class SnykApplicationSettingsStateServiceTest {
 
   @Test
   fun snykCodeDefault_matchesLanguageServerDefault_false() {
-    // The plugin's Snyk Code default is kept in sync with the Language Server flagset default
-    // (false). This alignment is what lets an at-default value sent with changed=false resolve back
-    // to the same state, so no bespoke upgrade migration is needed. See the field declaration.
+    // An unset Code value resolves to the plugin default, kept in sync with the LS flagset default
+    // (false). The raw persisted value is null until something writes it.
     val target = SnykApplicationSettingsStateService()
+    assertNull(target.snykCodeSecurityIssuesScanEnableRaw)
     assertFalse(target.snykCodeSecurityIssuesScanEnable)
   }
 
   @Test
-  fun initializeComponent_enabledCodeSurvivesUpgrade_becauseItDeviatesFromDefault() {
-    // Upgrade repro: a user who had Snyk Code enabled in the old plugin has snykCode... == true
-    // persisted. Because the plugin default is now false, that value deviates from the default, so
-    // it is emitted with changed=true and the LS honors it — the preference survives the upgrade
-    // without any migration.
-    val target = SnykApplicationSettingsStateService()
-    target.snykCodeSecurityIssuesScanEnable = true // persisted "enabled" from the old plugin
+  fun codeEnablement_unsetValueOmittedFromPersistedXml_setValueWrittenUnderLegacyName() {
+    // The 2.21.0-enabled recovery depends on the enabled value being ABSENT from persisted state.
+    // Lock the serialization contract using the same skip-defaults filter PersistentStateComponent
+    // applies: an unset (null) raw value is not written; a set value is, under the legacy element
+    // name so old configs still deserialize.
+    val filter = SkipDefaultsSerializationFilter()
+    val unsetXml = XmlSerializer.serialize(SnykApplicationSettingsStateService(), filter)
+    assertFalse(
+      unsetXml.getChildren("option").any {
+        it.getAttributeValue("name") == "snykCodeSecurityIssuesScanEnable"
+      }
+    )
 
-    target.initializeComponent()
-
-    assertTrue(target.isExplicitlyChanged(LsFolderSettingsKeys.SNYK_CODE_ENABLED))
+    val enabled = SnykApplicationSettingsStateService()
+    enabled.snykCodeSecurityIssuesScanEnable = true
+    val enabledXml = XmlSerializer.serialize(enabled, filter)
     assertTrue(
-      target.lsUserAssertedChangeForLsConfigurationKey(LsFolderSettingsKeys.SNYK_CODE_ENABLED)
+      enabledXml.getChildren("option").any {
+        it.getAttributeValue("name") == "snykCodeSecurityIssuesScanEnable" &&
+          it.getAttributeValue("value") == "true"
+      }
     )
   }
 
   @Test
-  fun initializeComponent_codeAtDefault_defersToLanguageServer() {
-    // A fresh install (or a user who had Code disabled, which now equals the default) leaves Code
-    // at
-    // the default false. It must NOT be marked explicit, so it is sent changed=false and the LS
-    // resolves it (org governance / its own default). Both cases resolve back to false — no
-    // preference is lost.
+  fun migration_enabledCodeFrom221_recoveredWhenNoValuePersisted() {
+    // 2.21.0 user who had Code enabled (the old default): the value equalled the default and so was
+    // omitted from persisted state -> loads as null. On an existing install it must be recovered as
+    // enabled AND asserted, so the LS (default false) honors it.
+    val persisted =
+      SnykApplicationSettingsStateService().apply {
+        pluginFirstRun = false // existing install upgrading
+        // snykCodeSecurityIssuesScanEnableRaw stays null == absent from persisted XML
+      }
     val target = SnykApplicationSettingsStateService()
+    target.loadState(persisted)
 
     target.initializeComponent()
 
+    assertTrue(target.snykCodeSecurityIssuesScanEnable)
+    assertTrue(target.isExplicitlyChanged(LsFolderSettingsKeys.SNYK_CODE_ENABLED))
+    assertTrue(target.codeEnablementUpgradeMigratedV2221)
+  }
+
+  @Test
+  fun migration_enabledCodeVia222Straggler_recoveredWhenConfigUnchanged() {
+    // 2.21.0 -> 2.22.0 -> 2.22.1 with no config changes: 2.22.0 silently disabled Code, but that
+    // disabled value equalled 2.22.0's own default (false), so it was omitted from persisted state
+    // and never entered explicitChanges. The migration marker did not exist in 2.22.0 either. So
+    // the loaded 2.22.1 state is indistinguishable from a direct 2.21.0 -> 2.22.1 upgrade, and
+    // Code is recovered the same way.
+    val persisted =
+      SnykApplicationSettingsStateService().apply {
+        pluginFirstRun = false // already existed since 2.21.0
+        // raw == null (no code element ever persisted), SNYK_CODE_ENABLED not explicit,
+        // codeEnablementUpgradeMigratedV2221 == false (absent in <= 2.22.0)
+      }
+    val target = SnykApplicationSettingsStateService()
+    target.loadState(persisted)
+
+    target.initializeComponent()
+
+    assertTrue(target.snykCodeSecurityIssuesScanEnable)
+    assertTrue(target.isExplicitlyChanged(LsFolderSettingsKeys.SNYK_CODE_ENABLED))
+  }
+
+  @Test
+  fun migration_explicitlyDisabledCodeFrom221_preserved() {
+    // 2.21.0 user who explicitly disabled Code: persisted as false (deviated from the old true
+    // default), so raw loads as false. Must stay disabled and NOT be re-enabled.
+    val persisted =
+      SnykApplicationSettingsStateService().apply {
+        pluginFirstRun = false
+        snykCodeSecurityIssuesScanEnableRaw = false
+      }
+    val target = SnykApplicationSettingsStateService()
+    target.loadState(persisted)
+
+    target.initializeComponent()
+
+    assertFalse(target.snykCodeSecurityIssuesScanEnable)
     assertFalse(target.isExplicitlyChanged(LsFolderSettingsKeys.SNYK_CODE_ENABLED))
-    assertFalse(
-      target.lsUserAssertedChangeForLsConfigurationKey(LsFolderSettingsKeys.SNYK_CODE_ENABLED)
-    )
+  }
+
+  @Test
+  fun migration_freshInstall_defersToLanguageServer() {
+    // Fresh 2.22.1 install (pluginFirstRun == true) with no persisted Code value must not be
+    // seeded: LS default applies.
+    val target = SnykApplicationSettingsStateService()
+    assertTrue(target.pluginFirstRun)
+
+    target.initializeComponent()
+
+    assertFalse(target.snykCodeSecurityIssuesScanEnable)
+    assertFalse(target.isExplicitlyChanged(LsFolderSettingsKeys.SNYK_CODE_ENABLED))
+    assertTrue(target.codeEnablementUpgradeMigratedV2221)
+  }
+
+  @Test
+  fun migration_2220UserExplicitlyDisabledCode_preserved() {
+    // Users who already upgraded to 2.22.0 and explicitly disabled Code: the value equals the
+    // 2.22.0 default (false) so it was omitted (raw null), but the toggle is tracked in
+    // explicitChanges, which persists. The explicit-change guard must keep them disabled.
+    val persisted =
+      SnykApplicationSettingsStateService().apply {
+        pluginFirstRun = false
+        markExplicitlyChanged(LsFolderSettingsKeys.SNYK_CODE_ENABLED)
+      }
+    val target = SnykApplicationSettingsStateService()
+    target.loadState(persisted)
+
+    target.initializeComponent()
+
+    assertFalse(target.snykCodeSecurityIssuesScanEnable)
+    assertTrue(target.isExplicitlyChanged(LsFolderSettingsKeys.SNYK_CODE_ENABLED))
+  }
+
+  @Test
+  fun migration_isOneShot_doesNotReAssertAfterUserResetsCode() {
+    // Once migrated, a later reset of Code back to default must not be re-enabled on next startup.
+    val persisted =
+      SnykApplicationSettingsStateService().apply {
+        pluginFirstRun = false
+        codeEnablementUpgradeMigratedV2221 = true // migration already ran previously
+        // Code since reset to default: raw null, not explicitly changed
+      }
+    val target = SnykApplicationSettingsStateService()
+    target.loadState(persisted)
+
+    target.initializeComponent()
+
+    assertFalse(target.snykCodeSecurityIssuesScanEnable)
+    assertFalse(target.isExplicitlyChanged(LsFolderSettingsKeys.SNYK_CODE_ENABLED))
   }
 
   @Test

--- a/src/test/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateServiceTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/services/SnykApplicationSettingsStateServiceTest.kt
@@ -335,7 +335,8 @@ class SnykApplicationSettingsStateServiceTest {
 
   @Test
   fun initializeComponent_codeAtDefault_defersToLanguageServer() {
-    // A fresh install (or a user who had Code disabled, which now equals the default) leaves Code at
+    // A fresh install (or a user who had Code disabled, which now equals the default) leaves Code
+    // at
     // the default false. It must NOT be marked explicit, so it is sent changed=false and the LS
     // resolves it (org governance / its own default). Both cases resolve back to false — no
     // preference is lost.

--- a/src/test/kotlin/io/snyk/plugin/ui/jcef/SaveConfigHandlerTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/jcef/SaveConfigHandlerTest.kt
@@ -604,7 +604,7 @@ class SaveConfigHandlerTest : BasePlatformTestCase() {
 
   fun `test re-enabling a field to its default value after reset re-asserts the override (ADR-1)`() {
     // Regression for IDE-2149 / ADR-1: after a Project Defaults reset restores snyk_code_enabled to
-    // its plugin default (true), a later save re-enabling it to that SAME default value must still
+    // its plugin default (false), a later save setting it to that SAME default value must still
     // mark it explicitly changed so getSettings() emits changed:true and the LS relearns the
     // override. Previously the value-equals-default shortcut auto-cleared it (changed:false).
     val realSettings = SnykApplicationSettingsStateService()
@@ -613,20 +613,20 @@ class SaveConfigHandlerTest : BasePlatformTestCase() {
     // 1) User resets snyk_code_enabled to Project Defaults (explicit JSON null).
     invokeParseAndSaveConfig("""{"snyk_code_enabled": null}""")
     assertFalse(realSettings.isExplicitlyChanged(LsFolderSettingsKeys.SNYK_CODE_ENABLED))
-    // reset restores the plugin default (true) and queues a one-shot reset
-    assertTrue(realSettings.snykCodeSecurityIssuesScanEnable)
+    // reset restores the plugin default (false) and queues a one-shot reset
+    assertFalse(realSettings.snykCodeSecurityIssuesScanEnable)
     verify {
       lsWrapperMock.updateConfiguration(
         resets = match { it.contains(LsFolderSettingsKeys.SNYK_CODE_ENABLED) }
       )
     }
 
-    // 2) User re-enables snyk_code_enabled to the SAME value as the store default.
-    invokeParseAndSaveConfig("""{"snyk_code_enabled": true}""")
+    // 2) User re-saves snyk_code_enabled at the SAME value as the store default (false).
+    invokeParseAndSaveConfig("""{"snyk_code_enabled": false}""")
 
     // The re-assertion is tracked as an explicit change, so getSettings() will emit changed:true.
     assertTrue(realSettings.isExplicitlyChanged(LsFolderSettingsKeys.SNYK_CODE_ENABLED))
-    assertTrue(realSettings.snykCodeSecurityIssuesScanEnable)
+    assertFalse(realSettings.snykCodeSecurityIssuesScanEnable)
   }
 
   fun `test applyGlobalSettings marks machine-scoped keys as explicitly changed`() {
@@ -1516,7 +1516,7 @@ class SaveConfigHandlerTest : BasePlatformTestCase() {
         assertTrue("snyk_oss_enabled default is true", it.ossScanEnable)
       },
       ResetKeySpec("snyk_code_enabled", LsFolderSettingsKeys.SNYK_CODE_ENABLED) {
-        assertTrue("snyk_code_enabled default is true", it.snykCodeSecurityIssuesScanEnable)
+        assertFalse("snyk_code_enabled default is false", it.snykCodeSecurityIssuesScanEnable)
       },
       ResetKeySpec("snyk_iac_enabled", LsFolderSettingsKeys.SNYK_IAC_ENABLED) {
         assertTrue("snyk_iac_enabled default is true", it.iacScanEnabled)
@@ -1565,7 +1565,8 @@ class SaveConfigHandlerTest : BasePlatformTestCase() {
       // undo.
       when (spec.jsonField) {
         "snyk_oss_enabled" -> realSettings.ossScanEnable = false
-        "snyk_code_enabled" -> realSettings.snykCodeSecurityIssuesScanEnable = false
+        // default is now false, so drive it to true to make the reset observable
+        "snyk_code_enabled" -> realSettings.snykCodeSecurityIssuesScanEnable = true
         "snyk_iac_enabled" -> realSettings.iacScanEnabled = false
         "snyk_secrets_enabled" -> realSettings.secretsEnabled = true
         "scan_automatic" -> realSettings.scanOnSave = false


### PR DESCRIPTION
### Description

Previous to v2.22.0, Snyk Code defaulted to False in the LS, but True in the IDE. The IDE does not write default values to its config, so we had no way of distinguishing between Snyk Code = false (not set) and Snyk Code = false (explicitly disabled). This fix adds one-shot migration for users upgrading to V2.22.1 to resolve this.

This will also fix the issue for any users who upgraded from 2.21.0. to 2.22.0 (unlikely to be any as he plugin was only live for a few minutes, and outside of US working hours)

The product enablement flags in the IDE plugin now match the language server, so LDX-Sync derived values will just work for future installs.

### Checklist

- [ ] Read and understood the [Code of Conduct](https://github.com/snyk/snyk-intellij-plugin/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/snyk-intellij-plugin/blob/master/CONTRIBUTING.md).
- [x] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
