### PR TITLE
ci: include .gradle.kts and gradle.properties in Gradle cache key

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle', '**/*.gradle.kts', '**/gradle.properties') }}
           restore-keys: ${{ runner.os }}-gradle
 
       - name: Run Tests
@@ -79,7 +79,7 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle', '**/*.gradle.kts', '**/gradle.properties') }}
           restore-keys: ${{ runner.os }}-gradle
 
       - name: Run Plugin Verifier

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle', '**/*.gradle.kts', '**/gradle.properties') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle', '**/*.gradle.kts', '**/gradle.properties', '**/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-gradle
 
       - name: Run Tests
@@ -79,7 +79,7 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle', '**/*.gradle.kts', '**/gradle.properties') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle', '**/*.gradle.kts', '**/gradle.properties', '**/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-gradle
 
       - name: Run Plugin Verifier

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -19,12 +19,12 @@ jobs:
           java-version: '21'
 
       - name: Setup Gradle Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle', '**/*.gradle.kts', '**/gradle.properties', '**/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-gradle
 
       - name: Run Spotless (format check)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,12 +32,12 @@ jobs:
           java-version: '21'
 
       - name: Setup Gradle Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle', '**/*.gradle.kts', '**/gradle.properties', '**/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-gradle
 
       - name: Run Plugin Verifier


### PR DESCRIPTION
## What

Hash the Kotlin DSL build scripts and `gradle.properties` in the Gradle cache key on both cache steps (test + pluginVerifier):

```
key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle', '**/*.gradle.kts', '**/gradle.properties') }}
```

## Why

The key hashed only `**/*.gradle`. This project's build config is Kotlin DSL — `build.gradle.kts`, `settings.gradle.kts`, `gradle.properties` — and the only files matching `*.gradle` are test fixtures (`src/test/resources/test-fixtures/oss/annotator/build.gradle`). So changes to the real build config never invalidated the dependency cache: CI restored a stale cache and re-downloaded changed dependencies every run without re-saving them. A dependency bump (e.g. jackson) got no cache benefit.

Now the key changes when the actual build scripts or properties change.

## Notes

- Pre-existing issue; split out of #863 per review feedback (that PR touches this workflow + `build.gradle.kts` but is scoped to test-hang timeout/capture).
- Expect a one-time cache miss per branch on first run after this lands (the key changes), then normal caching resumes.

## Test plan

- [x] Workflow YAML validated
- [x] Both cache steps updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only changes; no application code, auth, or runtime behavior.
> 
> **Overview**
> **Gradle CI caches** now invalidate when Kotlin DSL scripts, `gradle.properties`, or the wrapper properties change—not only legacy `*.gradle` files. That fixes stale dependency caches on a Kotlin-DSL project where real build config lived outside the old hash pattern.
> 
> The expanded `hashFiles(...)` key is applied to every **Setup Gradle Cache** step in `build.yml` (test + plugin verifier), `detekt.yml`, and `release.yml`. **Lint and release** workflows also move `actions/cache` from v4 to v5 (build was already on v5).
> 
> Expect a one-time cache miss per branch after merge, then normal restore/save behavior when dependencies or Gradle config change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96b384efd9138deb937028a336e1a63998affddb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->