### PR TITLE
test: await Utils async helpers to reduce cross-test leakage [IDE-2237]

### DIFF
--- a/src/main/kotlin/io/snyk/plugin/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/Utils.kt
@@ -361,7 +361,12 @@ fun refreshAnnotationsForOpenFiles(project: Project): Promise<Unit> {
         }
       }
     } else {
-      openFiles.forEach { refreshAnnotationsForFile(project, it) }
+      // Wait for the per-file refresh promises, so the Promise this function returns reflects
+      // them rather than resolving as soon as they are started. (Each still schedules its EDT work
+      // via invokeLater — see refreshAnnotationsForFile — so this drains the pooled portion; the
+      // EDT portion only completes synchronously when invokeLater is executed inline, e.g. in
+      // tests.)
+      openFiles.map { refreshAnnotationsForFile(project, it) }.forEach { it.blockingGet(10_000) }
     }
   }
 }

--- a/src/main/kotlin/io/snyk/plugin/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/Utils.kt
@@ -63,6 +63,8 @@ import java.util.SortedSet
 import java.util.concurrent.TimeUnit
 import javax.swing.JComponent
 import org.apache.commons.lang3.SystemUtils
+import org.jetbrains.concurrency.Promise
+import org.jetbrains.concurrency.resolvedPromise
 import org.jetbrains.concurrency.runAsync
 import snyk.common.ProductType
 import snyk.common.SnykCachedResults
@@ -306,11 +308,13 @@ fun findPsiFileIgnoringExceptions(virtualFile: VirtualFile, project: Project): P
   }
 }
 
-fun refreshAnnotationsForFile(project: Project, virtualFile: VirtualFile) {
-  if (project.isDisposed || ApplicationManager.getApplication().isDisposed) return
-  if (!virtualFile.isValid) return
+fun refreshAnnotationsForFile(project: Project, virtualFile: VirtualFile): Promise<Unit> {
+  if (project.isDisposed || ApplicationManager.getApplication().isDisposed) {
+    return resolvedPromise()
+  }
+  if (!virtualFile.isValid) return resolvedPromise()
 
-  runAsync {
+  return runAsync {
     if (project.isDisposed || ApplicationManager.getApplication().isDisposed) return@runAsync
     if (!virtualFile.isValid) return@runAsync
 
@@ -333,8 +337,8 @@ fun refreshAnnotationsForFile(psiFile: PsiFile) {
 
 private const val SINGLE_FILE_DECORATION_UPDATE_THRESHOLD = 5
 
-fun refreshAnnotationsForOpenFiles(project: Project) {
-  runAsync {
+fun refreshAnnotationsForOpenFiles(project: Project): Promise<Unit> {
+  return runAsync {
     if (project.isDisposed || ApplicationManager.getApplication().isDisposed) return@runAsync
     // Note: Avoid VirtualFileManager.asyncRefresh() as it refreshes ALL files including
     // remote/HTTP files, which can cause NPE in RemoteFileInfoImpl when localFile is null.
@@ -367,8 +371,8 @@ fun navigateToSource(
   virtualFile: VirtualFile,
   selectionStartOffset: Int,
   selectionEndOffset: Int? = null,
-) {
-  runAsync {
+): Promise<Unit> {
+  return runAsync {
     if (project.isDisposed || !virtualFile.isValid) return@runAsync
     // Check that the offset is valid. If not, log it and let PsiNavigationSupport handle it instead
     // of returning early

--- a/src/test/kotlin/io/snyk/plugin/UtilsKtTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/UtilsKtTest.kt
@@ -337,7 +337,6 @@ class UtilsKtTest {
     mockkStatic("io.snyk.plugin.UtilsKt")
     mockkStatic(ApplicationManager::class)
     mockkStatic(PsiNavigationSupport::class)
-    mockkStatic(FileEditorManager::class)
 
     val appMock = mockk<com.intellij.openapi.application.Application>(relaxed = true)
     every { ApplicationManager.getApplication() } returns appMock
@@ -367,12 +366,8 @@ class UtilsKtTest {
     every { PsiNavigationSupport.getInstance() } returns psiNavSupport
     every { psiNavSupport.createNavigatable(project, virtualFile, 5) } returns navigatable
 
-    // Selection-highlight path early-returns on a null selected editor, so this mock only
-    // needs to keep the (unmocked-by-default) static call from throwing.
-    val fileEditorManager = mockk<FileEditorManager>(relaxed = true)
-    every { FileEditorManager.getInstance(project) } returns fileEditorManager
-    every { fileEditorManager.selectedTextEditor } returns null
-
+    // document == null, so the selection-highlight block (guarded by `document != null`) is
+    // skipped and FileEditorManager is never touched here — no mock needed for it in this test.
     val promise = navigateToSource(project, virtualFile, 5, 10)
 
     assertTrue("Navigation should complete within timeout", latch.await(2, TimeUnit.SECONDS))

--- a/src/test/kotlin/io/snyk/plugin/UtilsKtTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/UtilsKtTest.kt
@@ -2,6 +2,7 @@ package io.snyk.plugin
 
 import com.intellij.ide.util.PsiNavigationSupport
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.pom.Navigatable
@@ -336,6 +337,7 @@ class UtilsKtTest {
     mockkStatic("io.snyk.plugin.UtilsKt")
     mockkStatic(ApplicationManager::class)
     mockkStatic(PsiNavigationSupport::class)
+    mockkStatic(FileEditorManager::class)
 
     val appMock = mockk<com.intellij.openapi.application.Application>(relaxed = true)
     every { ApplicationManager.getApplication() } returns appMock
@@ -365,10 +367,19 @@ class UtilsKtTest {
     every { PsiNavigationSupport.getInstance() } returns psiNavSupport
     every { psiNavSupport.createNavigatable(project, virtualFile, 5) } returns navigatable
 
-    navigateToSource(project, virtualFile, 5, 10)
+    // Selection-highlight path early-returns on a null selected editor, so this mock only
+    // needs to keep the (unmocked-by-default) static call from throwing.
+    val fileEditorManager = mockk<FileEditorManager>(relaxed = true)
+    every { FileEditorManager.getInstance(project) } returns fileEditorManager
+    every { fileEditorManager.selectedTextEditor } returns null
+
+    val promise = navigateToSource(project, virtualFile, 5, 10)
 
     assertTrue("Navigation should complete within timeout", latch.await(2, TimeUnit.SECONDS))
     verify { navigatable.navigate(false) }
+    // Drain the async work (including the selection-highlight invokeLater) before the test
+    // returns, so it cannot leak into a later test's mocks/EDT queue.
+    promise.blockingGet(2000)
   }
 
   @Test
@@ -377,6 +388,7 @@ class UtilsKtTest {
     mockkStatic("io.snyk.plugin.UtilsKt")
     mockkStatic(ApplicationManager::class)
     mockkStatic(PsiNavigationSupport::class)
+    mockkStatic(FileEditorManager::class)
 
     val appMock = mockk<com.intellij.openapi.application.Application>(relaxed = true)
     every { ApplicationManager.getApplication() } returns appMock
@@ -407,10 +419,24 @@ class UtilsKtTest {
     every { PsiNavigationSupport.getInstance() } returns psiNavSupport
     every { psiNavSupport.createNavigatable(project, virtualFile, 100) } returns navigatable
 
-    navigateToSource(project, virtualFile, 100, 110)
+    // document != null here, so the selection-highlight invokeLater path runs too. It needs a
+    // real (mocked) FileEditorManager or it throws a ClassCastException on the pooled thread
+    // after this test has already returned/torn down its mocks (the original hang cause).
+    val editor = mockk<com.intellij.openapi.editor.Editor>(relaxed = true)
+    val editorDocument = mockk<com.intellij.openapi.editor.Document>(relaxed = true)
+    every { editorDocument.textLength } returns 50
+    every { editor.document } returns editorDocument
+    val fileEditorManager = mockk<FileEditorManager>(relaxed = true)
+    every { FileEditorManager.getInstance(project) } returns fileEditorManager
+    every { fileEditorManager.selectedTextEditor } returns editor
+
+    val promise = navigateToSource(project, virtualFile, 100, 110)
 
     assertTrue("Navigation should complete within timeout", latch.await(2, TimeUnit.SECONDS))
     verify { navigatable.navigate(false) }
+    // Drain the async work (including the selection-highlight invokeLater) before the test
+    // returns, so it cannot leak into a later test's mocks/EDT queue.
+    promise.blockingGet(2000)
   }
 
   @Test

--- a/src/test/kotlin/snyk/common/AnnotatorCommonIntegTest.kt
+++ b/src/test/kotlin/snyk/common/AnnotatorCommonIntegTest.kt
@@ -19,6 +19,7 @@ import io.snyk.plugin.refreshAnnotationsForOpenFiles
 import io.snyk.plugin.resetSettings
 import java.nio.file.Paths
 import org.eclipse.lsp4j.WorkspaceFolder
+import org.jetbrains.concurrency.resolvedPromise
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -129,7 +130,7 @@ class AnnotatorCommonIntegTest : BasePlatformTestCase() {
   fun `initRefreshing subscribes so folder config changes refresh annotations`() {
     mockkStatic("io.snyk.plugin.UtilsKt")
     try {
-      justRun { refreshAnnotationsForOpenFiles(project) }
+      every { refreshAnnotationsForOpenFiles(project) } returns resolvedPromise()
       AnnotatorCommon(project).initRefreshing()
       project.messageBus
         .syncPublisher(SnykProductsOrSeverityListener.SNYK_ENABLEMENT_TOPIC)

--- a/src/test/kotlin/snyk/common/lsp/SnykLanguageClientTest.kt
+++ b/src/test/kotlin/snyk/common/lsp/SnykLanguageClientTest.kt
@@ -48,6 +48,7 @@ import org.eclipse.lsp4j.Range
 import org.eclipse.lsp4j.ShowDocumentParams
 import org.eclipse.lsp4j.TextEdit
 import org.eclipse.lsp4j.WorkspaceEdit
+import org.jetbrains.concurrency.resolvedPromise
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -137,7 +138,7 @@ class SnykLanguageClientTest {
     every { encodedUri.toVirtualFile() } returns virtualFile
 
     every { snyk.common.editor.DocumentChanger.applyChange(any()) } returns Unit
-    every { refreshAnnotationsForFile(projectMock, any()) } returns Unit
+    every { refreshAnnotationsForFile(projectMock, any()) } returns resolvedPromise()
 
     val edits = listOf(TextEdit(Range(Position(0, 0), Position(0, 0)), "test"))
     val params = ApplyWorkspaceEditParams(WorkspaceEdit(mapOf(encodedUri to edits)))
@@ -544,7 +545,7 @@ class SnykLanguageClientTest {
   fun `refreshCodeLenses and refreshInlineValues invoke refreshAnnotationsForOpenFiles`() {
     mockkStatic("io.snyk.plugin.UtilsKt")
     every { projectMock.isDisposed } returns false
-    justRun { refreshAnnotationsForOpenFiles(projectMock) }
+    every { refreshAnnotationsForOpenFiles(projectMock) } returns resolvedPromise()
 
     cut.refreshCodeLenses().get()
     cut.refreshInlineValues().get()
@@ -556,7 +557,7 @@ class SnykLanguageClientTest {
   fun `refreshCodeLenses does not call refreshAnnotationsForOpenFiles when project is disposed`() {
     mockkStatic("io.snyk.plugin.UtilsKt")
     every { projectMock.isDisposed } returns true
-    justRun { refreshAnnotationsForOpenFiles(any()) }
+    every { refreshAnnotationsForOpenFiles(any()) } returns resolvedPromise()
 
     cut.refreshCodeLenses().get()
 
@@ -981,7 +982,7 @@ class SnykLanguageClientTest {
     every { virtualFile.getDocument() } returns document
     every { document.lineCount } returns 100
     every { document.getLineStartOffset(any()) } returns 0
-    every { io.snyk.plugin.navigateToSource(any(), any(), any(), any()) } returns Unit
+    every { io.snyk.plugin.navigateToSource(any(), any(), any(), any()) } returns resolvedPromise()
 
     val params =
       ShowDocumentParams(fileUri).apply { selection = Range(Position(5, 0), Position(5, 10)) }


### PR DESCRIPTION
## What

Make the fire-and-forget `runAsync { … invokeLater { … } }` helpers in `Utils.kt` awaitable, and await them in the tests that drive them, to remove a source of cross-test async leakage behind the intermittent `:test` hang (IDE-2237).

- `Utils.kt`: `navigateToSource`, `refreshAnnotationsForOpenFiles`, `refreshAnnotationsForFile(project, virtualFile)` now **return** the `runAsync` `Promise<Unit>` (guards return `resolvedPromise()`). Production callers ignore the return — no behaviour change. `refreshAnnotationsForOpenFiles` also collects and awaits its per-file promises so the returned promise reflects them.
- `UtilsKtTest`: the two `navigateToSource` tests `blockingGet` the returned promise so the pooled async work is drained before the test returns; the out-of-bounds test mocks `FileEditorManager` so the selection-highlight `invokeLater` no longer throws a `ClassCastException` on the pooled thread after teardown.
- `SnykLanguageClientTest` / `AnnotatorCommonIntegTest`: mocks updated for the new `Promise` return type.

## Scope — what this does and does not do

**Does:** removes the specific pooled-async leak these helpers caused in the tests that call them for real (notably the `navigateToSource` CCE), and makes the helpers awaitable so a test can drain their pooled portion.

**Does not:** by itself eliminate the IDE-2237 hang. These promises resolve once the background thread *schedules* the UI work via `invokeLater` — not when the EDT task runs. So awaiting them fully drains the work only where `invokeLater` executes inline (as the tests mock it). A leaked `invokeLater` from any test that does not can still corrupt the shared EDT/`LaterInvocator` queue and deadlock a later test's dispatch. Eliminating that class fully needs a systemic between-test drain (flush the EDT + wait for the app pooled executor to idle), tracked on IDE-2237 — this PR is a scoped hardening step, not the whole fix.

## Test plan

- [x] `ktlintCheck` / `spotlessCheck` — BUILD SUCCESSFUL
- [x] Compiles; production caller behaviour unchanged (return value ignored)
- [x] Reviewed (no blocking findings)
- [ ] Does not, on its own, eliminate the IDE-2237 hang — see Scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)
