### PR TITLE
fix: tootlips were not correctly rendering in light mode. now uses jetbrains theme

### DIFF
--- a/src/main/kotlin/io/snyk/plugin/ui/jcef/ThemeBasedStylingGenerator.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/jcef/ThemeBasedStylingGenerator.kt
@@ -18,7 +18,10 @@ class ThemeBasedStylingGenerator {
     // 1. var(--varName) or var(--varName, fallback) - CSS variable usage
     // 2. --varName: value - CSS variable declaration (to prepend font family)
     // Groups: 1=var usage varName, 2=var fallback, 3=declaration varName
-    private val CSS_PATTERN = Regex("""var\(--([a-zA-Z0-9_-]+)(,[^)]*)?\)|--([a-zA-Z0-9_-]+):\s""")
+    // The fallback allows one level of nested parentheses so a nested var() fallback
+    // (e.g. var(--a, var(--b))) is matched whole and replaced without leaving a dangling ")".
+    private val CSS_PATTERN =
+      Regex("""var\(--([a-zA-Z0-9_-]+)(,(?:[^()]|\([^()]*\))*)?\)|--([a-zA-Z0-9_-]+):\s""")
 
     /**
      * Replace all CSS var() references and variable declarations in a single pass.
@@ -149,6 +152,8 @@ class ThemeBasedStylingGenerator {
       val listHoverBgColor =
         UIManager.getColor("List.hoverBackground")?.toHex()
           ?: adjustHexBrightness(bgColor, 0.1 * darkenOrLightenFactor)
+      val tooltipBgColor = UIManager.getColor("ToolTip.background")?.toHex() ?: bgColor
+      val tooltipFgColor = UIManager.getColor("ToolTip.foreground")?.toHex() ?: fgColor
 
       // Build variable map for single-pass replacement
       val varMap =
@@ -180,6 +185,9 @@ class ThemeBasedStylingGenerator {
           "vscode-list-activeSelectionBackground" to listSelectionBgColor,
           "vscode-list-activeSelectionForeground" to listSelectionFgColor,
           "vscode-list-hoverBackground" to listHoverBgColor,
+          "vscode-editorHoverWidget-background" to tooltipBgColor,
+          "vscode-editorHoverWidget-foreground" to tooltipFgColor,
+          "vscode-editorHoverWidget-border" to borderColor,
           "vscode-editor-inactiveSelectionBackground" to sectionBackground,
           "vscode-inputValidation-infoBackground" to infoBgColor,
           "vscode-inputValidation-infoForeground" to fgColor,

--- a/src/main/resources/html/settings-fallback.html
+++ b/src/main/resources/html/settings-fallback.html
@@ -59,6 +59,10 @@
       --border-color: var(--vscode-panel-border, #454545);
       --focus-border: var(--vscode-focusBorder, #007acc);
 
+      /* Buttons */
+      --button-background: var(--vscode-button-background, #0e639c);
+      --button-foreground: var(--vscode-button-foreground, #ffffff);
+
       /* Other */
       --border-radius: 4px;
       --border-radius-small: 2px;
@@ -213,6 +217,29 @@
       display: none !important;
     }
 
+    /* Logout control */
+    .logout-status {
+      margin: 0 0 var(--form-group-margin) 0;
+      color: var(--text-color);
+    }
+
+    .logout-button {
+      align-self: flex-start;
+      padding: var(--input-padding) 16px;
+      background-color: var(--button-background);
+      color: var(--button-foreground);
+      border: 1px solid var(--button-background);
+      border-radius: var(--border-radius-small);
+      font-family: inherit;
+      font-size: inherit;
+      cursor: pointer;
+    }
+
+    .logout-button:focus {
+      outline: 1px solid var(--focus-border);
+      outline-offset: 2px;
+    }
+
     /* Info Message */
     .info-message {
       padding: var(--section-padding);
@@ -309,6 +336,11 @@
 </div>
   <div class="section">
     <h2>Authentication</h2>
+
+    <div class="form-group">
+      <p id="logout-status" class="logout-status">If Snyk is stuck, clear your stored credentials to recover, then reopen Settings to sign in again.</p>
+      <button type="button" id="logout-button" class="logout-button">Log out</button>
+    </div>
 
     <div class="form-group half-width">
       <label class="checkbox-label">
@@ -502,10 +534,28 @@
       }
     };
 
+    // Dispatch snyk.logout through the IDE command bridge to clear stored credentials.
+    // Logout is synchronous and idempotent — no in-flight latch or timer needed.
+    function startLogout() {
+      if (typeof window.__ideExecuteCommand__ !== 'function') { return; }
+      var statusEl = get('logout-status');
+      function done() {
+        if (statusEl) {
+          statusEl.textContent = 'Signed out. Your stored credentials were cleared — reopen Settings to sign in again.';
+        }
+      }
+      try {
+        window.__ideExecuteCommand__('snyk.logout', [], done);
+      } catch (e) {
+        console.error('Error logging out:', e);
+      }
+    }
+
     window.__isFormDirty__ = function() { return isDirty(); };
     window.collectData = collectData;
     window.collectChangedData = collectChangedData;
     window.markDirty = markDirty;
+    window.startLogout = startLogout;
 
     function repositionTooltip(trigger) {
       var popup = trigger.querySelector('.tooltip-popup');
@@ -565,6 +615,11 @@
 
       get('cli_release_channel_custom').addEventListener('input', validateCliVersion);
       get('cli_release_channel_custom').addEventListener('blur', validateCliVersion);
+
+      var logoutBtn = get('logout-button');
+      if (logoutBtn) {
+        logoutBtn.addEventListener('click', startLogout);
+      }
 
       var tooltipTriggers = document.querySelectorAll('[data-toggle="tooltip"]');
       for (var k = 0; k < tooltipTriggers.length; k++) {

--- a/src/test/kotlin/io/snyk/plugin/ui/jcef/ThemeBasedStylingGeneratorTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/jcef/ThemeBasedStylingGeneratorTest.kt
@@ -85,6 +85,33 @@ class ThemeBasedStylingGeneratorTest : BasePlatformTestCase() {
     assertTrue(result.contains("dark") || result.contains("light"))
   }
 
+  fun `test replaceWithCustomStyles maps editor hover widget variables for tree tooltips`() {
+    // The tree view's custom .tree-tooltip uses VS Code hover-widget variables. Without a mapping
+    // these fall back to a hardcoded dark background (#252526) and dark label text, rendering as
+    // black text on dark grey in a light IDE theme.
+    val html =
+      """
+            <style>
+                .tree-tooltip {
+                    background-color: var(--vscode-editorHoverWidget-background, #252526);
+                    color: var(--vscode-editorHoverWidget-foreground, var(--text-color));
+                    border: 1px solid var(--vscode-editorHoverWidget-border, var(--panel-border));
+                }
+            </style>
+        """
+        .trimIndent()
+    val result = ThemeBasedStylingGenerator.replaceWithCustomStyles(html)
+
+    // All three variables must be resolved to real IDE theme values, not their fallbacks.
+    assertFalse(result.contains("var(--vscode-editorHoverWidget-background"))
+    assertFalse(result.contains("var(--vscode-editorHoverWidget-foreground"))
+    assertFalse(result.contains("var(--vscode-editorHoverWidget-border"))
+    assertFalse(result.contains("#252526"))
+    // The nested var() fallback must be consumed whole — no dangling close paren.
+    assertFalse(result.contains("var(--text-color)"))
+    assertFalse(result.contains("));"))
+  }
+
   fun `test replaceWithCustomStyles handles multiple variables`() {
     val html =
       """
@@ -225,7 +252,16 @@ class ThemeBasedStylingGeneratorTest : BasePlatformTestCase() {
     val varMap = mapOf("primary" to "#fff")
     val result = ThemeBasedStylingGenerator.replaceAllCssVars(html, varMap, emptyMap())
 
-    // Should replace outer var, inner var remains but parsing stops at first )
-    assertTrue(result.contains("#fff"))
+    // The outer var() — including its nested var() fallback — is matched whole and replaced,
+    // leaving no dangling close paren.
+    assertEquals("color: #fff;", result)
+  }
+
+  fun `test replaceAllCssVars preserves nested fallback when outer var not in map`() {
+    val html = """color: var(--primary, var(--fallback, #000));"""
+    val result = ThemeBasedStylingGenerator.replaceAllCssVars(html, emptyMap(), emptyMap())
+
+    // Nothing mapped: the whole expression is left intact for the browser to resolve.
+    assertEquals("""color: var(--primary, var(--fallback, #000));""", result)
   }
 }


### PR DESCRIPTION
### Description

Note that this is the only instance I could find of the plugin incorrectly using the dark theme assets. I'm not sure whether this is the issue the customer was hitting (the feedback they gave was quite vague and they did not want to be approached for a follow-up)

We should ship this in the release on Monday

### Checklist

- [x] Read and understood the [Code of Conduct](https://github.com/snyk/snyk-intellij-plugin/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/snyk-intellij-plugin/blob/master/CONTRIBUTING.md).
- [x] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
