### PR TITLE
chore: sync settings-fallback.html from snyk-ls

### DIFF
--- a/src/main/resources/html/settings-fallback.html
+++ b/src/main/resources/html/settings-fallback.html
@@ -62,6 +62,10 @@
       /* Buttons */
       --button-background: var(--vscode-button-background, #0e639c);
       --button-foreground: var(--vscode-button-foreground, #ffffff);
+      --button-hover-background: var(--vscode-button-hoverBackground, #1177bb);
+      --button-secondary-background: var(--vscode-button-secondaryBackground, #3a3d41);
+      --button-secondary-foreground: var(--vscode-button-secondaryForeground, #ffffff);
+      --button-secondary-hover-background: var(--vscode-button-secondaryHoverBackground, #45494e);
 
       /* Other */
       --border-radius: 4px;
@@ -226,13 +230,18 @@
     .logout-button {
       align-self: flex-start;
       padding: var(--input-padding) 16px;
-      background-color: var(--button-background);
-      color: var(--button-foreground);
-      border: 1px solid var(--button-background);
+      background-color: var(--button-secondary-background);
+      color: var(--button-secondary-foreground);
+      border: none;
       border-radius: var(--border-radius-small);
       font-family: inherit;
       font-size: inherit;
+      font-weight: 600;
       cursor: pointer;
+    }
+
+    .logout-button:hover {
+      background-color: var(--button-secondary-hover-background);
     }
 
     .logout-button:focus {
@@ -337,9 +346,9 @@
   <div class="section">
     <h2>Authentication</h2>
 
-    <div class="form-group">
-      <p id="logout-status" class="logout-status">If Snyk is stuck, clear your stored credentials to recover, then reopen Settings to sign in again.</p>
-      <button type="button" id="logout-button" class="logout-button">Log out</button>
+    <div class="form-group" aria-live="polite">
+      <p id="logout-status" class="logout-status hidden"></p>
+      <button type="button" id="logout-button" class="logout-button">Clear credentials</button>
     </div>
 
     <div class="form-group half-width">
@@ -541,7 +550,8 @@
       var statusEl = get('logout-status');
       function done() {
         if (statusEl) {
-          statusEl.textContent = 'Signed out. Your stored credentials were cleared — reopen Settings to sign in again.';
+          statusEl.className = statusEl.className.replace(/\bhidden\b/, '').trim();
+          statusEl.textContent = 'Signed out.';
         }
       }
       try {


### PR DESCRIPTION
Automatic sync of `settings-fallback.html` triggered by [snyk/snyk-ls@920eb24](https://github.com/snyk/snyk-ls/commit/920eb24fdb6677d8767aa86ca6153242ca80f535).

This PR was opened by the [distribute-fallback-html](https://github.com/snyk/snyk-ls/blob/main/.github/workflows/distribute-fallback-html.yaml) workflow in snyk-ls.

## What changed

`settings-fallback.html` is the settings page displayed before the Language Server binary is available. It is maintained in [snyk/snyk-ls](https://github.com/snyk/snyk-ls) and must be kept in sync with the copy in each IDE plugin. This repo's `resource-check` CI workflow verifies that the local copy matches the snyk-ls main branch; this PR restores that sync.

## Merge instructions

Review and merge when ready. No manual testing is required beyond confirming that `resource-check` passes on this PR.