### PR TITLE
fix(test): isolate each test class in its own JVM to stop the EDT-deadlock hang [IDE-2237]

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -184,6 +184,9 @@ tasks {
 
   withType<Test> {
     maxHeapSize = "4096m"
+    // Fresh JVM per test class: contains a cross-class EDT-queue leak that deadlocked the suite
+    // intermittently (IDE-2237). Do not remove without a replacement. See the PR / commit / ticket.
+    forkEvery = 1
     testLogging { exceptionFormat = TestExceptionFormat.FULL }
     // Preload the ByteBuddy agent at test-JVM startup so MockK never needs runtime self-attach.
     // This is unconditional and harmless under the JaCoCo backend (JaCoCo uses class-file


### PR DESCRIPTION
## What

Run each test class in its own forked JVM (`forkEvery = 1` on the `Test` task) to stop the intermittent `:test` deadlock (IDE-2237).

```kotlin
withType<Test> {
  forkEvery = 1
  …
}
```

## Root cause

The suite deadlocked ~1 run in 3. A plain unit test that mocks `Application` and fires fire-and-forget async work (`runAsync`→`invokeLater`) leaks a task that runs **after the test tears down** and corrupts the shared IntelliJ `LaterInvocator`/EDT-queue state. The **next test class** — a platform test whose body is dispatched via `EdtTestUtil.runInEdtAndWait` — then never gets flushed onto the EDT and parks forever. jstack signature: `Test worker` parked in `LaterInvocator.invokeAndWait`, `AWT-EventQueue-0` idle in `getNextEvent`, zero further progress.

The contamination is **cross-class** (leaker and victim are different classes, sharing one JVM's Application/EDT). A fresh JVM per class contains it — the leaked task dies with its class's JVM before the next class starts.

## Why this approach (and not the obvious ones)

- **Await the async at the source** (return `Promise`, `blockingGet` in the test — see #871): removed *one* leak but the hang persisted — there are multiple/elusive leak vectors across the plain-mock tests, so per-caller fixes are whack-a-mole.
- **Drain the EDT between tests** (a shared `@Rule` / `tearDown` that pumps the IDE event queue after each test): **tried twice and abandoned — it cannot work by construction.** The corruption *is* in the EDT/`LaterInvocator` queue, and the only supported way to flush that queue (`dispatchAllInvocationEventsInIdeEventQueue`) must run *on* the EDT. So the drain has to dispatch onto the very EDT that's wedged — its own `invokeAndWait`/`runInEdtAndWait` then never gets serviced and parks (verified: a 42-minute hang *inside* the drain). A first variant also silently no-op'd for the platform (JUnit3) tests, which are the actual leak victims. Draining a deadlocked EDT via the EDT is circular; no amount of tweaking fixes that. Full blow-by-blow in the **IDE-2237 comments**.
- **Per-class JVM isolation**: deterministic, one line, no product/test-code churn, no EDT fragility. It's the robust fix.

## Validation

Local bisect (forced `cleanTest test` reruns, per-test logging + jstack-on-stall):
- **Without the change:** reproduced the hang (~1 in 3; jstack = the signature above; pinned the cross-class boundary).
- **With `forkEvery = 1`:** **10/10 clean runs**, no hang (baseline ~1/3 → 10 consecutive green is a ~1.7% fluke). Local run time ~3.5–6 min each.
- The `pre-push` hook (full suite) also passed on this commit.

## Performance impact (the real trade-off)

`forkEvery = 1` spins a fresh JVM per test class (~45 classes), each re-initialising the IntelliJ test Application. That is not free. Measured Test-job durations — no-fork baseline is successful runs across #863/#870/#871 (n≈10 per OS); with-fork is #875 (n=2):

| OS | No-fork (avg, n≈10) | With fork (avg, n=2) | Δ |
|----|----|----|----|
| ubuntu | 6.9m (5.7–7.4) | 9.1m (8.2, 10.0) | +2.2m (~+32%) |
| macOS | 8.7m (6.4–11.3) | 14.6m (13.5, 15.7) | **+5.9m (~+68%)** |
| windows | 12.1m (10.1–14.1) | 15.4m (14.9, 15.6) | +3.3m (~+27%) |

- **CI end-to-end wall-clock** (the three OS jobs run in parallel; the slowest gates the Build): ~12m → ~15–16m, **≈ +3–4 min (~+30%)**. Still ~9 min under the Test job's 25m timeout.
- **CI runner-minutes** (sum across the matrix, i.e. cost): ~28m → ~39m, **≈ +40%**, concentrated on macOS.

### ⚠️ Local dev on macOS takes the biggest hit

macOS is the worst case (~1.7×) because macOS is slowest at spawning JVMs — and **we develop on Macs**, so a local `./gradlew test` is where this is felt most. Rough local measurement on an Apple-silicon machine: full suite ~2.5 min without forking → ~4 min with (~1.6×), matching the CI macOS ratio. Anyone running the whole suite locally will notice.

If that local cost is unacceptable, the fallback is to **scope the forking** — only the plain-`Application`-mocking classes (e.g. `UtilsKtTest`) actually poison the shared JVM, so isolating just those (a dedicated `Test` task / test-tagging with `forkEvery=1`, leaving the rest in one JVM) would keep most of the speed. That's more moving parts than this one-liner; raised here so reviewers can weigh simple-and-slower vs complex-and-fast. Bounded either way by the 25m timeout + hang-dump watchdog (#863).

Related: #871 (await the `Utils.kt` async helpers) is complementary hygiene but not required for this fix.

## Test plan
- [x] `./gradlew help` config parses; `ktlintCheck`/`spotlessCheck` green
- [x] 10/10 local repro runs clean (vs ~1/3 hang without)
- [x] pre-push hook (full suite) passed
- [ ] CI green on all 3 OSes + Test-job duration under the 25m timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)


