### PR TITLE
fix: executeCommandWithArgs throws instead of silently returning null when LS not initialized [IDE-2181]

### DIFF
--- a/src/main/kotlin/io/snyk/plugin/ui/jcef/SaveConfigHandler.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/jcef/SaveConfigHandler.kt
@@ -5,6 +5,7 @@ import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import com.google.gson.JsonSyntaxException
 import com.intellij.ide.impl.ProjectUtil
+import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.application.invokeLater
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
@@ -58,8 +59,11 @@ class SaveConfigHandler(
       var response: JBCefJSQuery.Response
       try {
         saveConfig(jsonString)
-        // Hide any previous error on success - defer to avoid EDT blocking
-        invokeLater {
+        // Hide any previous error on success - defer to avoid EDT blocking.
+        // ModalityState.any(): this handler runs off-EDT (JBCefJSQuery callback), so the default
+        // modality state resolves to non-modal — if a modal dialog (e.g. Settings) is open, a
+        // non-modal invokeLater is queued and silently never runs until that dialog closes.
+        invokeLater(ModalityState.any()) {
           jbCefBrowser.cefBrowser.executeJavaScript(
             "if (typeof window.hideError === 'function') { window.hideError(); }",
             jbCefBrowser.cefBrowser.url,
@@ -71,7 +75,7 @@ class SaveConfigHandler(
         logger.warn("Error saving config", e)
         // Show error in browser - defer to avoid EDT blocking
         val errorMsg = (e.message ?: "Unknown error").replace("'", "\\'")
-        invokeLater {
+        invokeLater(ModalityState.any()) {
           jbCefBrowser.cefBrowser.executeJavaScript(
             "if (typeof window.showError === 'function') { window.showError('$errorMsg'); }",
             jbCefBrowser.cefBrowser.url,
@@ -115,7 +119,13 @@ class SaveConfigHandler(
 
     executeCommandQuery.addHandler { value ->
       dispatchSettingsCommand(value) { callbackId, escaped ->
-        invokeLater {
+        // dispatch() resolves the command asynchronously on a background thread (runAsync), so this
+        // callback fires off-EDT. ModalityState.any() is required, not just "defer to avoid EDT
+        // blocking": the default modality state resolves to non-modal from a background thread, so
+        // a plain invokeLater is silently queued forever while a modal dialog (e.g. Settings) is
+        // open — the command bridge result (including error feedback, see IDE-2181) would never
+        // reach the page until the user closed and reopened the dialog.
+        invokeLater(ModalityState.any()) {
           jbCefBrowser.cefBrowser.executeJavaScript(
             "if(window.__ideCallbacks__&&window.__ideCallbacks__['$callbackId'])" +
               "{window.__ideCallbacks__['$callbackId']($escaped);}",

--- a/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
@@ -619,7 +619,15 @@ class LanguageServerWrapper(private val project: Project) : Disposable {
     languageServer.workspaceService.executeCommand(param).get(timeoutMillis, TimeUnit.MILLISECONDS)
 
   fun executeCommandWithArgs(command: String, args: List<Any>, timeoutMillis: Long = 5_000): Any? {
-    if (!isInitialized) return null
+    // Fail loud, not silent: both callers (ExecuteCommandBridge, HtmlTreePanel) already wrap this
+    // in a try/catch. A silent null here is indistinguishable from a real null LS result, so a
+    // JCEF bridge command issued while the LS is stuck pre-initialize (e.g. the settings-fallback
+    // page's "Clear credentials") looks like it succeeded when it was never sent. See IDE-2181.
+    if (!isInitialized) {
+      throw IllegalStateException(
+        "Cannot execute command '$command': language server is not initialized"
+      )
+    }
     val param = ExecuteCommandParams()
     param.command = command
     param.arguments = args

--- a/src/test/kotlin/io/snyk/plugin/ui/jcef/SaveConfigHandlerExecuteCommandTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/jcef/SaveConfigHandlerExecuteCommandTest.kt
@@ -205,4 +205,26 @@ class SaveConfigHandlerExecuteCommandTest {
     handler.dispatchSettingsCommand("not-valid-json")
     // should not throw
   }
+
+  @Test
+  fun `dispatchSettingsCommand surfaces an error to the callback when the language server is not initialized`() {
+    every { lsWrapperMock.executeCommandWithArgs("snyk.logout", any(), any()) } throws
+      IllegalStateException(
+        "Cannot execute command 'snyk.logout': language server is not initialized"
+      )
+
+    val latch = CountDownLatch(1)
+    var receivedResult: String? = null
+
+    val request =
+      ExecuteCommandRequest(command = "snyk.logout", args = emptyList(), callbackId = "__cb_1")
+    handler.dispatchSettingsCommand(gson.toJson(request)) { _, escaped ->
+      receivedResult = escaped
+      latch.countDown()
+    }
+
+    assertTrue("Callback should be invoked within timeout", latch.await(2, TimeUnit.SECONDS))
+    assertTrue(receivedResult!!.contains("error"))
+    assertTrue(receivedResult!!.contains("not initialized"))
+  }
 }

--- a/src/test/kotlin/snyk/common/lsp/LanguageServerWrapperTest.kt
+++ b/src/test/kotlin/snyk/common/lsp/LanguageServerWrapperTest.kt
@@ -602,12 +602,15 @@ class LanguageServerWrapperTest {
   }
 
   @Test
-  fun `executeCommandWithArgs should return null when not initialized`() {
+  fun `executeCommandWithArgs should throw when not initialized`() {
     cut.isInitialized = false
 
-    val result = cut.executeCommandWithArgs("snyk.testCommand", listOf("arg1"))
-
-    assertEquals(null, result)
+    try {
+      cut.executeCommandWithArgs("snyk.testCommand", listOf("arg1"))
+      fail("Expected IllegalStateException")
+    } catch (e: IllegalStateException) {
+      assertTrue(e.message!!.contains("snyk.testCommand"))
+    }
   }
 
   @Test


### PR DESCRIPTION
### Description

Found while investigating [IDE-2181](https://snyksec.atlassian.net/browse/IDE-2181): `LanguageServerWrapper.executeCommandWithArgs()` silently returned `null` whenever the LS hadn't finished initializing, instead of throwing. That's indistinguishable from a real `null` LS result, so any JCEF bridge command dispatched via `ExecuteCommandBridge` (e.g. the settings-fallback page's "Clear credentials" button, or `snyk.login`) would silently no-op while the LS is stuck pre-initialize — which is close to the default state while that fallback page is even showing. The user just sees nothing happen, no error, no feedback.

Contrast with `notAuthenticated()`, which every other LS-facing call goes through — it actively calls `ensureLanguageServerInitialized()`. `executeCommandWithArgs` didn't.

Fix: throw `IllegalStateException` instead of returning `null`. Both existing callers (`ExecuteCommandBridge`, `HtmlTreePanel`) already wrap this in try/catch, so behavior there is unaffected except that `ExecuteCommandBridge`'s catch clause now actually surfaces `{error: ...}` to the JS callback instead of a false-positive success.

Companion fix landed in `snyk-ls` (source of truth for `settings-fallback.html`, auto-distributed to all IDE plugins): https://github.com/snyk/snyk-ls/pull/1388 — makes the fallback page's logout button show "Failed to sign out: ..." instead of always claiming "Signed out."

### Checklist

- [x] Read and understood the Code of Conduct and Contributing Guidelines.
- [x] Tests added and all succeed (targeted + full `./gradlew test`, BUILD SUCCESSFUL)
- [x] Linted (`spotlessApply`)
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing (N/A — internal error-handling fix, no user-facing behavior change beyond the bug being fixed)

[IDE-2181]: https://snyksec.atlassian.net/browse/IDE-2181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ