### PR TITLE
fix: switch out incompatible internal API [IDE-2331]

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -112,9 +112,6 @@ intellijPlatform {
   pluginVerification {
     ides {
       // this is gonna need `create` instead of `ide` in future platform versions
-      ide(IntelliJPlatformType.IntellijIdeaCommunity, "2024.1")
-      ide(IntelliJPlatformType.IntellijIdeaCommunity, "2024.2")
-      ide(IntelliJPlatformType.IntellijIdeaCommunity, "2025.1")
       ide(IntelliJPlatformType.IntellijIdeaCommunity, "2025.2")
       // as of 2025.3, there's no community edition anymore
       ide(IntelliJPlatformType.IntellijIdeaUltimate, "2025.3")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -110,7 +110,17 @@ intellijPlatform {
   }
 
   pluginVerification {
-    ides { ide(IntelliJPlatformType.IntellijIdeaCommunity, "2025.1") }
+    ides {
+      // this is gonna need `create` instead of `ide` in future platform versions
+      ide(IntelliJPlatformType.IntellijIdeaCommunity, "2024.1")
+      ide(IntelliJPlatformType.IntellijIdeaCommunity, "2024.2")
+      ide(IntelliJPlatformType.IntellijIdeaCommunity, "2025.1")
+      ide(IntelliJPlatformType.IntellijIdeaCommunity, "2025.2")
+      // as of 2025.3, there's no community edition anymore
+      ide(IntelliJPlatformType.IntellijIdeaUltimate, "2025.3")
+      ide(IntelliJPlatformType.IntellijIdeaUltimate, "2026.1")
+      ide(IntelliJPlatformType.IntellijIdeaUltimate, "2026.2")
+    }
     freeArgs.set(listOf("-mute", "TemplateWordInPluginId"))
     failureLevel.set(
       listOf(

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,8 +14,6 @@ platformDownloadSources=true
 # see https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 #platformPlugins=org.jetbrains.plugins.yaml
 platformPlugins=
-# list of versions for which to check the plugin for api compatibility
-pluginVerifierIdeVersions=2024.3,2025.1,2025.2,2025.3,2026.1,2026.2
 localIdeDirectory=
 # opt-out flag for bundling Kotlin standard library
 # see https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library

--- a/src/main/kotlin/snyk/PluginInformation.kt
+++ b/src/main/kotlin/snyk/PluginInformation.kt
@@ -2,18 +2,16 @@
 
 package snyk
 
-import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.ide.plugins.cl.PluginAwareClassLoader
 import com.intellij.openapi.application.ApplicationInfo
-import com.intellij.openapi.extensions.PluginId
-
-const val PLUGIN_ID = "io.snyk.snyk-intellij-plugin"
 
 /** Snyk IntelliJ plugin information. */
 val pluginInfo: PluginInformation by lazy { getPluginInformation() }
 
 private fun getPluginInformation(): PluginInformation {
+  val classLoader = PluginInformation::class.java.classLoader
   val snykPluginVersion =
-    PluginManagerCore.getPlugin(PluginId.getId(PLUGIN_ID))?.version ?: "UNKNOWN"
+    (classLoader as? PluginAwareClassLoader)?.pluginDescriptor?.version ?: "UNKNOWN"
 
   val applicationInfo = ApplicationInfo.getInstance()
   val integrationEnvironment =

--- a/src/test/kotlin/io/snyk/plugin/cli/ConsoleCommandRunnerTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/cli/ConsoleCommandRunnerTest.kt
@@ -13,9 +13,9 @@ import io.snyk.plugin.removeDummyCliFile
 import io.snyk.plugin.resetSettings
 import io.snyk.plugin.services.AuthenticationType
 import io.snyk.plugin.setupDummyCliFile
-import snyk.pluginInfo
 import java.net.URLEncoder
 import java.util.UUID
+import snyk.pluginInfo
 
 @Suppress("HttpUrlsUsage")
 class ConsoleCommandRunnerTest : LightPlatformTestCase() {
@@ -169,7 +169,10 @@ class ConsoleCommandRunnerTest : LightPlatformTestCase() {
 
     assertEquals("test-api-token", generalCommandLine.environment["SNYK_TOKEN"])
     assertEquals("JETBRAINS_IDE", generalCommandLine.environment["SNYK_INTEGRATION_NAME"])
-    assertEquals(pluginInfo.integrationVersion, generalCommandLine.environment["SNYK_INTEGRATION_VERSION"])
+    assertEquals(
+      pluginInfo.integrationVersion,
+      generalCommandLine.environment["SNYK_INTEGRATION_VERSION"],
+    )
     assertEquals("INTELLIJ IDEA IC", generalCommandLine.environment["SNYK_INTEGRATION_ENVIRONMENT"])
     assertEquals(
       "2023.1".length,

--- a/src/test/kotlin/io/snyk/plugin/cli/ConsoleCommandRunnerTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/cli/ConsoleCommandRunnerTest.kt
@@ -2,8 +2,6 @@ package io.snyk.plugin.cli
 
 import com.intellij.credentialStore.Credentials
 import com.intellij.execution.configurations.GeneralCommandLine
-import com.intellij.ide.plugins.PluginManagerCore
-import com.intellij.openapi.extensions.PluginId
 import com.intellij.testFramework.LightPlatformTestCase
 import com.intellij.util.net.ProxyConfiguration
 import com.intellij.util.net.ProxyConfiguration.StaticProxyConfiguration
@@ -15,9 +13,9 @@ import io.snyk.plugin.removeDummyCliFile
 import io.snyk.plugin.resetSettings
 import io.snyk.plugin.services.AuthenticationType
 import io.snyk.plugin.setupDummyCliFile
+import snyk.pluginInfo
 import java.net.URLEncoder
 import java.util.UUID
-import snyk.PLUGIN_ID
 
 @Suppress("HttpUrlsUsage")
 class ConsoleCommandRunnerTest : LightPlatformTestCase() {
@@ -166,14 +164,12 @@ class ConsoleCommandRunnerTest : LightPlatformTestCase() {
 
   fun testSetupCliEnvironmentVariables() {
     val generalCommandLine = GeneralCommandLine("")
-    val snykPluginVersion =
-      PluginManagerCore.getPlugin(PluginId.getId(PLUGIN_ID))?.version ?: "UNKNOWN"
     pluginSettings().authenticationType = AuthenticationType.API_TOKEN
     ConsoleCommandRunner().setupCliEnvironmentVariables(generalCommandLine, "test-api-token")
 
     assertEquals("test-api-token", generalCommandLine.environment["SNYK_TOKEN"])
     assertEquals("JETBRAINS_IDE", generalCommandLine.environment["SNYK_INTEGRATION_NAME"])
-    assertEquals(snykPluginVersion, generalCommandLine.environment["SNYK_INTEGRATION_VERSION"])
+    assertEquals(pluginInfo.integrationVersion, generalCommandLine.environment["SNYK_INTEGRATION_VERSION"])
     assertEquals("INTELLIJ IDEA IC", generalCommandLine.environment["SNYK_INTEGRATION_ENVIRONMENT"])
     assertEquals(
       "2023.1".length,


### PR DESCRIPTION

### Description

JetBrains moved previously public API to internal status, which is hindering plugin publication.

Unfortunately, we also had a plugin verification bug so that the verification only ran against 2025.1.

The API change is not documented in https://plugins.jetbrains.com/docs/intellij/api-changes-list-2026.html.

### Checklist

- [x] Read and understood the [Code of Conduct](https://github.com/snyk/snyk-intellij-plugin/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/snyk-intellij-plugin/blob/master/CONTRIBUTING.md).
- [x] Tests added and all succeed

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
