### PR TITLE
chore: tests and move optional dep

### DIFF
--- a/src/main/kotlin/io/snyk/plugin/Utils.kt
+++ b/src/main/kotlin/io/snyk/plugin/Utils.kt
@@ -60,6 +60,7 @@ import java.nio.file.attribute.PosixFilePermission
 import java.security.MessageDigest
 import java.util.Objects.nonNull
 import java.util.SortedSet
+import java.util.concurrent.CancellationException
 import java.util.concurrent.TimeUnit
 import javax.swing.JComponent
 import org.apache.commons.lang3.SystemUtils
@@ -75,7 +76,9 @@ import snyk.common.lsp.ScanIssue
 import snyk.common.lsp.ScanState
 import snyk.common.removeSuffix
 
-private val logger = Logger.getInstance("#io.snyk.plugin.UtilsKt")
+// internal var (not private val) so tests can substitute a mock to assert on log level - see
+// UtilsKtTest
+internal var logger = Logger.getInstance("#io.snyk.plugin.UtilsKt")
 
 fun getSnykTaskQueueService(project: Project): SnykTaskQueueService? =
   project.serviceIfNotDisposed()
@@ -153,7 +156,17 @@ private inline fun <reified T : Any> Project.serviceIfNotDisposed(): T? {
     getService(T::class.java)
   } catch (t: Throwable) {
     // Without this the real cause is lost and the caller only ever sees a downstream NPE.
-    logger.error("Could not instantiate service ${T::class.java.name}", t)
+    // logger.error rethrows control-flow/cancellation exceptions instead of logging them, which
+    // would break the null-returning contract - so neither branch below uses error.
+    // Cancellation (e.g. AlreadyDisposedException, a ProcessCanceledException) routinely fires
+    // during normal project disposal: debug is enough. Anything else is a genuine failure (bad
+    // extension point, broken constructor) and must stay visible at warn, or it silently drops
+    // out of the default-level idea.log a user would attach to a report.
+    if (t is CancellationException) {
+      logger.debug("Could not instantiate service ${T::class.java.name}", t)
+    } else {
+      logger.warn("Could not instantiate service ${T::class.java.name}", t)
+    }
     null
   }
 }

--- a/src/main/kotlin/io/snyk/plugin/ui/jcef/JcefAvailability.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/jcef/JcefAvailability.kt
@@ -61,8 +61,8 @@ object JcefAvailability {
         Class.forName(PROBE_CLASS, false, JcefAvailability::class.java.classLoader)
         true
       } catch (t: Throwable) {
-        // The real failure mode is NoClassDefFoundError, which is an Error and not an Exception,
-        // so Throwable is the only catch that actually covers it.
+        // The real failure mode is NoClassDefFoundError, which is an Error not an Exception, so
+        // catching Exception wouldn't cover it — Throwable is used here to catch any failure.
         logger.info("Embedded browser classes are not reachable: ${t.javaClass.name}: ${t.message}")
         false
       }

--- a/src/main/kotlin/io/snyk/plugin/ui/jcef/ToggleDeltaHandler.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/jcef/ToggleDeltaHandler.kt
@@ -5,19 +5,18 @@ import com.intellij.ui.jcef.JBCefBrowserBase
 import com.intellij.ui.jcef.JBCefJSQuery
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.runInBackground
+import io.snyk.plugin.settings.handleDeltaFindingsChange
 import org.cef.browser.CefBrowser
 import org.cef.browser.CefFrame
 import org.cef.handler.CefLoadHandlerAdapter
 import snyk.common.lsp.LanguageServerWrapper
+import snyk.common.lsp.settings.LsFolderSettingsKeys
 
 class ToggleDeltaHandler(val project: Project) {
   fun generate(jbCefBrowser: JBCefBrowserBase): CefLoadHandlerAdapter {
     val toggleDeltaQuery = JBCefJSQuery.create(jbCefBrowser)
     toggleDeltaQuery.addHandler { deltaEnabled ->
-      runInBackground("Snyk: updating configuration") {
-        pluginSettings().setDeltaEnabled(deltaEnabled.toBoolean())
-        LanguageServerWrapper.getInstance(project).updateConfiguration()
-      }
+      runInBackground("Snyk: updating configuration") { toggleDelta(deltaEnabled.toBoolean()) }
       return@addHandler JBCefJSQuery.Response("success")
     }
 
@@ -38,5 +37,12 @@ class ToggleDeltaHandler(val project: Project) {
         }
       }
     }
+  }
+
+  internal fun toggleDelta(deltaEnabled: Boolean) {
+    pluginSettings().setDeltaEnabled(deltaEnabled)
+    pluginSettings().markExplicitlyChanged(LsFolderSettingsKeys.SCAN_NET_NEW)
+    handleDeltaFindingsChange(project)
+    LanguageServerWrapper.getInstance(project).updateConfiguration()
   }
 }

--- a/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
+++ b/src/main/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanel.kt
@@ -281,6 +281,7 @@ class SnykToolWindowPanel(val project: Project) : JPanel(), Disposable {
       summaryPanel.add(summaryPanelContent)
     } else {
       this.summaryPanelContent = null
+      summaryPanel.add(wrapWithScrollPane(embeddedBrowserUnavailablePanel()))
     }
     revalidate()
   }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -6,16 +6,30 @@
 
   <depends>com.intellij.modules.platform</depends>
   <!--
-    Since IntelliJ 2026.2 the embedded browser (com.intellij.ui.jcef.*) is no longer part of the
-    core platform: it ships as the bundled "Web Browser (JCEF)" plugin. Without this declaration
-    our PluginClassLoader cannot see those classes and the tool window fails to open.
+    Since IntelliJ 2026.2 the embedded browser (com.intellij.ui.jcef.*) lives in its own content
+    module, intellij.platform.ui.jcef, shipped in a separate jar with its own classloader — not
+    in the JCEF plugin's main module. This v1 <depends> still grants visibility into it: the
+    platform builds the classloader parent graph from every <depends> regardless of optionality,
+    and only the v1 path has a backward-compat branch that also pulls in a dependency's content
+    modules. TRAP: "modernising" this to the v2 form
+    <dependencies><plugin id="com.intellij.modules.jcef"/></dependencies> drops that pull-in, so
+    intellij.platform.ui.jcef becomes invisible again and NoClassDefFoundError returns — v2 would
+    additionally need <module name="intellij.platform.ui.jcef"/>. config-file has no bearing on
+    this classloader visibility either way — verified against the IntelliJ 262 platform sources:
+    collectDirectDependenciesInOldFormat in
+    platform/core-impl/src/com/intellij/ide/plugins/ModulesWithDependencies.kt builds the
+    classloader parent graph from every <depends> element and never reads isOptional. config-file
+    is declared below only because the JetBrains Marketplace upload validator requires it on every
+    optional <depends>; the referenced snyk-jcef.xml sub-descriptor is intentionally empty of
+    registrations because the plugin must remain fully functional on IDEs without JCEF, so no
+    registration may live in a JCEF-only sub-descriptor.
 
     It MUST stay optional: the com.intellij.modules.jcef id does not exist before 2025.3.1, and
     pluginSinceBuild is 242, so a required depends would disable the plugin on 2024.2-2025.3.0.
     The bundled plugin is also OS/arch specific, so it can be absent even on 2026.2 — every JCEF
     call site therefore goes through JcefAvailability rather than trusting this declaration.
   -->
-  <depends optional="true">com.intellij.modules.jcef</depends>
+  <depends optional="true" config-file="snyk-jcef.xml">com.intellij.modules.jcef</depends>
 
   <extensions defaultExtensionNs="com.intellij">
     <codeInsight.lineMarkerProvider

--- a/src/main/resources/META-INF/snyk-jcef.xml
+++ b/src/main/resources/META-INF/snyk-jcef.xml
@@ -1,0 +1,9 @@
+<!--
+  Optional sub-descriptor for the optional com.intellij.modules.jcef <depends> in plugin.xml.
+  Required by the JetBrains Marketplace upload validator (config-file attribute), not by any
+  registration need — see the comment above that <depends> for why nothing lives here: this
+  plugin must stay fully functional on IDEs without JCEF, so no existing registration may move
+  into a JCEF-only sub-descriptor. Intentionally empty.
+-->
+<idea-plugin>
+</idea-plugin>

--- a/src/test/kotlin/io/snyk/plugin/UtilsKtTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/UtilsKtTest.kt
@@ -2,10 +2,12 @@ package io.snyk.plugin
 
 import com.intellij.ide.util.PsiNavigationSupport
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.pom.Navigatable
+import com.intellij.serviceContainer.AlreadyDisposedException
 import com.intellij.util.messages.MessageBus
 import com.intellij.util.messages.Topic
 import io.mockk.every
@@ -14,6 +16,7 @@ import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.verify
 import io.snyk.plugin.services.SnykApplicationSettingsStateService
+import io.snyk.plugin.services.SnykTaskQueueService
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.NoSuchFileException
@@ -501,6 +504,50 @@ class UtilsKtTest {
       assertTrue(isCliInstalled())
     } finally {
       tempFile.delete()
+    }
+  }
+
+  @Test
+  fun `serviceIfNotDisposed returns null instead of throwing when getService throws AlreadyDisposedException`() {
+    unmockkAll()
+    val project = mockk<Project>()
+    every { project.isDisposed } returns false
+    every { project.getService(SnykTaskQueueService::class.java) } throws
+      AlreadyDisposedException("Already disposed: project")
+    val mockLogger = mockk<Logger>(relaxed = true)
+    val originalLogger = logger
+    logger = mockLogger
+
+    try {
+      val result = getSnykTaskQueueService(project)
+
+      assertEquals(null, result)
+      verify(exactly = 1) { mockLogger.debug(any<String>(), any<Throwable>()) }
+      verify(exactly = 0) { mockLogger.warn(any<String>(), any<Throwable>()) }
+    } finally {
+      logger = originalLogger
+    }
+  }
+
+  @Test
+  fun `serviceIfNotDisposed returns null instead of throwing when getService throws a non-cancellation exception`() {
+    unmockkAll()
+    val project = mockk<Project>()
+    every { project.isDisposed } returns false
+    every { project.getService(SnykTaskQueueService::class.java) } throws
+      RuntimeException("service constructor blew up")
+    val mockLogger = mockk<Logger>(relaxed = true)
+    val originalLogger = logger
+    logger = mockLogger
+
+    try {
+      val result = getSnykTaskQueueService(project)
+
+      assertEquals(null, result)
+      verify(exactly = 1) { mockLogger.warn(any<String>(), any<Throwable>()) }
+      verify(exactly = 0) { mockLogger.debug(any<String>(), any<Throwable>()) }
+    } finally {
+      logger = originalLogger
     }
   }
 

--- a/src/test/kotlin/io/snyk/plugin/ui/jcef/ToggleDeltaHandlerTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/jcef/ToggleDeltaHandlerTest.kt
@@ -1,0 +1,88 @@
+package io.snyk.plugin.ui.jcef
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import io.snyk.plugin.getSnykCachedResults
+import io.snyk.plugin.pluginSettings
+import io.snyk.plugin.resetSettings
+import io.snyk.plugin.services.SnykApplicationSettingsStateService
+import snyk.common.SnykCachedResults
+import snyk.common.lsp.LanguageServerWrapper
+import snyk.common.lsp.settings.LsFolderSettingsKeys
+
+class ToggleDeltaHandlerTest : BasePlatformTestCase() {
+  private lateinit var settings: SnykApplicationSettingsStateService
+  private lateinit var cut: ToggleDeltaHandler
+  private lateinit var lsWrapperMock: LanguageServerWrapper
+  private lateinit var realLsWrapper: LanguageServerWrapper
+  private lateinit var cachedResults: SnykCachedResults
+
+  override fun setUp() {
+    super.setUp()
+    unmockkAll()
+    resetSettings(project)
+
+    cachedResults = getSnykCachedResults(project)!!
+
+    mockkStatic("io.snyk.plugin.UtilsKt")
+    settings = SnykApplicationSettingsStateService()
+    every { pluginSettings() } returns settings
+    every { getSnykCachedResults(project) } returns cachedResults
+
+    // Real wrapper, used only to read back getSettings() and assert on the actual wire contract
+    // sent to snyk-ls, not on internal bookkeeping flags.
+    realLsWrapper = LanguageServerWrapper(project)
+
+    lsWrapperMock = mockk(relaxed = true)
+    mockkObject(LanguageServerWrapper.Companion)
+    every { LanguageServerWrapper.getInstance(project) } returns lsWrapperMock
+
+    cut = ToggleDeltaHandler(project)
+  }
+
+  override fun tearDown() {
+    unmockkAll()
+    super.tearDown()
+  }
+
+  fun `test toggleDelta to total sends scan_net_new=false with changed=true on the wire`() {
+    settings.setDeltaEnabled(true)
+
+    cut.toggleDelta(false)
+
+    val setting = realLsWrapper.getSettings().settings?.get(LsFolderSettingsKeys.SCAN_NET_NEW)
+    assertEquals(false, setting?.value)
+    assertEquals(true, setting?.changed)
+  }
+
+  fun `test toggleDelta to new sends scan_net_new=true with changed=true on the wire`() {
+    cut.toggleDelta(true)
+
+    val setting = realLsWrapper.getSettings().settings?.get(LsFolderSettingsKeys.SCAN_NET_NEW)
+    assertEquals(true, setting?.value)
+    assertEquals(true, setting?.changed)
+  }
+
+  fun `test toggleDelta clears cached scan results like the settings screen does`() {
+    cachedResults.currentOSSResultsLS[mockk(relaxed = true)] = emptySet()
+    cachedResults.currentSnykCodeResultsLS[mockk(relaxed = true)] = emptySet()
+    cachedResults.currentIacResultsLS[mockk(relaxed = true)] = emptySet()
+
+    cut.toggleDelta(false)
+
+    assertTrue(cachedResults.currentOSSResultsLS.isEmpty())
+    assertTrue(cachedResults.currentSnykCodeResultsLS.isEmpty())
+    assertTrue(cachedResults.currentIacResultsLS.isEmpty())
+  }
+
+  fun `test toggleDelta updates language server configuration`() {
+    cut.toggleDelta(true)
+
+    verify { lsWrapperMock.updateConfiguration() }
+  }
+}

--- a/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanelTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SnykToolWindowPanelTest.kt
@@ -6,10 +6,12 @@ import com.intellij.testFramework.PlatformTestUtil
 import com.intellij.testFramework.replaceService
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import io.snyk.plugin.getSnykCachedResults
 import io.snyk.plugin.services.SnykApplicationSettingsStateService
 import io.snyk.plugin.services.SnykTaskQueueService
+import io.snyk.plugin.ui.jcef.JcefAvailability
 import org.junit.Test
 import snyk.UIComponentFinder
 
@@ -90,5 +92,23 @@ class SnykToolWindowPanelTest : LightPlatform4TestCase() {
     // Description panel must still be present
     val descriptionPanel = UIComponentFinder.getJPanelByName(cut, "descriptionPanel")
     assertNotNull("descriptionPanel must be present", descriptionPanel)
+  }
+
+  @Test
+  fun `summary panel shows unavailable-browser explanation when JCEF is unavailable`() {
+    mockkObject(JcefAvailability)
+    every { JcefAvailability.isAvailable() } returns false
+    every { JcefAvailability.unavailableReason() } returns "test reason"
+    every { settings.token } returns "test-token"
+
+    val cut = SnykToolWindowPanel(project)
+    PlatformTestUtil.dispatchAllEventsInIdeEventQueue()
+
+    val summaryPanel = UIComponentFinder.getJPanelByName(cut, "summaryPanel")
+    assertNotNull("summaryPanel should always be present", summaryPanel)
+    assertTrue(
+      "summaryPanel should not be left empty when the embedded browser is unavailable",
+      summaryPanel!!.componentCount > 0,
+    )
   }
 }


### PR DESCRIPTION
### **User description**
### Description

_Provide description of this PR and changes, if linked Jira ticket doesn't cover it in full._

### Checklist

- [ ] Read and understood the [Code of Conduct](https://github.com/snyk/snyk-intellij-plugin/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/snyk-intellij-plugin/blob/master/CONTRIBUTING.md).
- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Improve service instantiation error handling.

- Show explicit message when JCEF is unavailable.

- Add comprehensive unit tests.

- Update JCEF plugin dependency details.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>Utils.kt</strong><dd><code>Refined service retrieval error handling and logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-intellij-plugin/pull/879/changes#diff-406e7dc9e2fe86f8d21201d462b284dabe35acec37a912ade78734d5ee88ca15">+15/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SnykToolWindowPanel.kt</strong><dd><code>Display unavailable browser message in summary</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-intellij-plugin/pull/879/changes#diff-602f985789e7372169095fb4e8c819e382fc1ef9358346c12ca0fa4a0c14720c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>JcefAvailability.kt</strong><dd><code>Clarified comment on JCEF class reachability check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-intellij-plugin/pull/879/changes#diff-a113bed90e61f5cb4d95bff011b0cab2758063d85ffb101213925287999f48b5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>plugin.xml</strong><dd><code>Detailed JCEF dependency comment and config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-intellij-plugin/pull/879/changes#diff-13198d14dd3abf13abd9cb906331ed7d9663fc081757b6845fd5f3c1850b5693">+18/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>snyk-jcef.xml</strong><dd><code>Added empty JCEF sub-descriptor file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-intellij-plugin/pull/879/changes#diff-c27c5ab7b45b8482e227cecec40f1965716a05b6e177cf8b85990b4ff4996e18">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>UtilsKtTest.kt</strong><dd><code>Added tests for service instantiation exception handling</code>&nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-intellij-plugin/pull/879/changes#diff-7a3ce2318338dd2438bf913220ff09f6e1546d44b742533f3b8b6c5bdd19039a">+47/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SnykToolWindowPanelTest.kt</strong><dd><code>Added test for JCEF unavailable UI state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-intellij-plugin/pull/879/changes#diff-7bd5247998b084824f709771f4ad0db682b4175493ce507e457a5da51d9f3b49">+20/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

