### PR TITLE
chore: sync settings-fallback.html from snyk-ls

### DIFF
--- a/src/main/resources/html/settings-fallback.html
+++ b/src/main/resources/html/settings-fallback.html
@@ -548,9 +548,12 @@
     function startLogout() {
       if (typeof window.__ideExecuteCommand__ !== 'function') { return; }
       var statusEl = get('logout-status');
-      function done() {
-        if (statusEl) {
-          statusEl.className = statusEl.className.replace(/\bhidden\b/, '').trim();
+      function done(result) {
+        if (!statusEl) { return; }
+        statusEl.className = statusEl.className.replace(/\bhidden\b/, '').trim();
+        if (result && result.error) {
+          statusEl.textContent = 'Failed to sign out: ' + result.error;
+        } else {
           statusEl.textContent = 'Signed out.';
         }
       }
@@ -558,6 +561,7 @@
         window.__ideExecuteCommand__('snyk.logout', [], done);
       } catch (e) {
         console.error('Error logging out:', e);
+        done({ error: String(e) });
       }
     }
 


### PR DESCRIPTION
Automatic sync of `settings-fallback.html` triggered by [snyk/snyk-ls@84952ef](https://github.com/snyk/snyk-ls/commit/84952efebbacbcc6979392fa841bf05ab64ee7dd).

This PR was opened by the [distribute-fallback-html](https://github.com/snyk/snyk-ls/blob/main/.github/workflows/distribute-fallback-html.yaml) workflow in snyk-ls.

## What changed

`settings-fallback.html` is the settings page displayed before the Language Server binary is available. It is maintained in [snyk/snyk-ls](https://github.com/snyk/snyk-ls) and must be kept in sync with the copy in each IDE plugin. This repo's `resource-check` CI workflow verifies that the local copy matches the snyk-ls main branch; this PR restores that sync.

## Merge instructions

Review and merge when ready. No manual testing is required beyond confirming that `resource-check` passes on this PR.