### PR TITLE
fix: apply the selected issues-to-display value in legacy settings dialog [IDE-2477]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,4 @@ docs/plan.md
 # Implementation plan working copies and generated diagrams (session scratchpads — source of truth is Confluence + brain)
 *_implementation_plan.md
 docs/diagrams/
+.verify-report

--- a/src/main/kotlin/io/snyk/plugin/settings/SnykProjectSettingsConfigurable.kt
+++ b/src/main/kotlin/io/snyk/plugin/settings/SnykProjectSettingsConfigurable.kt
@@ -17,6 +17,7 @@ import io.snyk.plugin.isNewConfigDialogEnabled
 import io.snyk.plugin.isProjectSettingsAvailable
 import io.snyk.plugin.isUrlValid
 import io.snyk.plugin.pluginSettings
+import io.snyk.plugin.services.SnykApplicationSettingsStateService
 import io.snyk.plugin.ui.SnykBalloonNotificationHelper
 import io.snyk.plugin.ui.SnykSettingsDialog
 import io.snyk.plugin.ui.settings.HTMLSettingsPanel
@@ -176,8 +177,7 @@ class SnykProjectSettingsConfigurable(val project: Project) : SearchableConfigur
     }
 
     val newDisplayIssuesSelection = snykSettingsDialog.getDisplayIssuesSelection()
-    if (settingsStateService.issuesToDisplay != newDisplayIssuesSelection) {
-      settingsStateService.issuesToDisplay = newCliReleaseChannel
+    if (applyDisplayIssuesSelection(settingsStateService, newDisplayIssuesSelection)) {
       runBackgroundableTask("Processing display issue selection changes", project, true) {
         handleDeltaFindingsChange(project)
       }
@@ -251,6 +251,23 @@ fun applyFolderConfigChanges(
       )
       .withSetting(LsFolderSettingsKeys.ORG_SET_BY_USER, !autoSelectOrgEnabled, changed = true)
   fcs.addFolderConfig(updatedConfig)
+}
+
+/**
+ * Applies a new "issues to display" selection from the settings dialog, returning whether it
+ * actually changed so callers know whether to trigger [handleDeltaFindingsChange]. Extracted as a
+ * standalone function so the comparison and assignment are unit-testable without instantiating the
+ * platform-heavy [SnykProjectSettingsConfigurable].
+ */
+fun applyDisplayIssuesSelection(
+  settingsStateService: SnykApplicationSettingsStateService,
+  newDisplayIssuesSelection: String,
+): Boolean {
+  val changed = settingsStateService.issuesToDisplay != newDisplayIssuesSelection
+  if (changed) {
+    settingsStateService.issuesToDisplay = newDisplayIssuesSelection
+  }
+  return changed
 }
 
 /**

--- a/src/test/kotlin/io/snyk/plugin/settings/SnykProjectSettingsConfigurableTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/settings/SnykProjectSettingsConfigurableTest.kt
@@ -7,6 +7,7 @@ import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import io.snyk.plugin.fromPathToUriString
 import io.snyk.plugin.fromUriToPath
+import io.snyk.plugin.services.SnykApplicationSettingsStateService
 import io.snyk.plugin.ui.SnykSettingsDialog
 import org.eclipse.lsp4j.WorkspaceFolder
 import org.junit.After
@@ -718,6 +719,43 @@ class SnykProjectSettingsConfigurableTest {
       "additionalParameters should be empty list",
       emptyList<String>(),
       result.settings?.get(LsFolderSettingsKeys.ADDITIONAL_PARAMETERS)?.value,
+    )
+  }
+
+  @Test
+  fun `applyDisplayIssuesSelection stores the new selection and reports changed`() {
+    val settingsStateService = SnykApplicationSettingsStateService()
+    settingsStateService.issuesToDisplay = SnykApplicationSettingsStateService.DISPLAY_ALL_ISSUES
+
+    val changed =
+      applyDisplayIssuesSelection(
+        settingsStateService,
+        SnykApplicationSettingsStateService.DISPLAY_NEW_ISSUES,
+      )
+
+    assertTrue("should report a change", changed)
+    assertEquals(
+      "issuesToDisplay should be set to the selection that was passed in",
+      SnykApplicationSettingsStateService.DISPLAY_NEW_ISSUES,
+      settingsStateService.issuesToDisplay,
+    )
+  }
+
+  @Test
+  fun `applyDisplayIssuesSelection is a no-op and reports unchanged when selection is the same`() {
+    val settingsStateService = SnykApplicationSettingsStateService()
+    settingsStateService.issuesToDisplay = SnykApplicationSettingsStateService.DISPLAY_NEW_ISSUES
+
+    val changed =
+      applyDisplayIssuesSelection(
+        settingsStateService,
+        SnykApplicationSettingsStateService.DISPLAY_NEW_ISSUES,
+      )
+
+    assertFalse("should report no change", changed)
+    assertEquals(
+      SnykApplicationSettingsStateService.DISPLAY_NEW_ISSUES,
+      settingsStateService.issuesToDisplay,
     )
   }
 }


### PR DESCRIPTION
### Description

`apply()` in `SnykProjectSettingsConfigurable.kt` compared `settingsStateService.issuesToDisplay` against `newDisplayIssuesSelection` but then assigned `newCliReleaseChannel` into it — a copy-paste slip from the sibling CLI-release-channel block just above. This meant the legacy Settings dialog's New/Total radio buttons never actually took effect.

Extracted the compare-and-assign into a standalone `applyDisplayIssuesSelection(settingsStateService, newDisplayIssuesSelection): Boolean` so the logic is unit-testable without instantiating the platform-heavy `Configurable`, and added coverage for both the changed and unchanged cases (there was previously zero test coverage on this code path, which is how the bug shipped unnoticed).

### Checklist

- [x] Read and understood the Code of Conduct and Contributing Guidelines.
- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing (not user-facing)

### Screenshots / GIFs

N/A — internal logic fix, no UI change.