### PR TITLE
fix: move sendScanCommand LSP calls off the EDT [IDE-2478]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,10 @@ docs/plan.md
 # Implementation plan working copies and generated diagrams (session scratchpads — source of truth is Confluence + brain)
 *_implementation_plan.md
 docs/diagrams/
+.verify-report
+.security-scan-progress
+.gitleaks-output.json
+.gitleaks-staged.json
+.security-scan-scope
+.snyk-secrets-output.err
+.snyk-secrets-output.json

--- a/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
@@ -40,6 +40,7 @@ import java.util.concurrent.TimeoutException
 import java.util.concurrent.locks.ReentrantLock
 import java.util.logging.Level
 import java.util.logging.Logger.getLogger
+import kotlin.concurrent.withLock
 import org.apache.commons.lang3.SystemUtils
 import org.eclipse.lsp4j.ClientCapabilities
 import org.eclipse.lsp4j.ClientInfo
@@ -159,6 +160,14 @@ class LanguageServerWrapper(private val project: Project) : Disposable {
   lateinit var process: Process
 
   var isInitializing: ReentrantLock = ReentrantLock()
+
+  // Before this class backgrounded sendScanCommand's workspace-folder update, the whole call ran
+  // inside DumbService.runWhenSmart, which always executes on the single-threaded EDT — so
+  // concurrent sendScanCommand() calls (e.g. a token refresh and a user-triggered scan landing
+  // close together) were naturally serialized. Running that update in a background task loses that
+  // for free; this lock restores it so two overlapping calls can't interleave their
+  // configuredWorkspaceFolders mutation and didChangeWorkspaceFolders/executeCommand dispatch.
+  private val workspaceFolderUpdateLock = ReentrantLock()
 
   // Written by initialize() / the LS-termination listener on background threads and read
   // cross-thread (e.g. the settings panel poll and the non-forcing getConfigHtml check) outside the
@@ -418,12 +427,20 @@ class LanguageServerWrapper(private val project: Project) : Disposable {
 
   fun getWorkspaceFoldersFromRoots(project: Project): Set<WorkspaceFolder> {
     if (disposed || project.isDisposed) return emptySet()
-    val normalizedRoots = getContentRoots(project)
-    return normalizedRoots.map { WorkspaceFolder(it.toLanguageServerURI(), it.name) }.toSet()
+    return workspaceFoldersFrom(getContentRoots(project))
   }
 
-  private fun getContentRoots(project: Project): MutableSet<VirtualFile> {
-    val contentRoots = project.getContentRootVirtualFiles()
+  private fun workspaceFoldersFrom(roots: Set<VirtualFile>): Set<WorkspaceFolder> =
+    roots.map { WorkspaceFolder(it.toLanguageServerURI(), it.name) }.toSet()
+
+  private fun getContentRoots(project: Project): MutableSet<VirtualFile> =
+    normalizeContentRoots(project.getContentRootVirtualFiles())
+
+  /**
+   * Drops roots with no resolvable NIO path and folds any root already covered by another
+   * (ancestor) root into it.
+   */
+  private fun normalizeContentRoots(contentRoots: Set<VirtualFile>): MutableSet<VirtualFile> {
     val normalizedRoots = mutableSetOf<VirtualFile>()
 
     for (root in contentRoots) {
@@ -562,8 +579,16 @@ class LanguageServerWrapper(private val project: Project) : Disposable {
     if (notAuthenticated()) return
     DumbService.getInstance(project).runWhenSmart {
       val roots = getContentRoots(project)
-      if (roots.isNotEmpty()) addContentRoots(project)
-      roots.forEach { sendFolderScanCommand(it.path, project) }
+      runInBackground("Snyk: syncing workspace folders and starting scan") {
+        workspaceFolderUpdateLock.withLock {
+          // Backgrounding this loop means it no longer runs atomically with respect to the EDT, so
+          // the project can be disposed mid-loop (e.g. the IDE window closing) in a way that was
+          // impossible when this all ran synchronously inside DumbService.runWhenSmart.
+          if (disposed || project.isDisposed) return@withLock
+          if (roots.isNotEmpty()) addContentRoots(project, roots)
+          roots.forEach { sendFolderScanCommand(it.path, project) }
+        }
+      }
     }
   }
 
@@ -1036,7 +1061,16 @@ class LanguageServerWrapper(private val project: Project) : Disposable {
     }
   }
 
-  fun addContentRoots(project: Project) {
+  /**
+   * [roots], when provided, is normalized and used as-is instead of recomputing content roots via
+   * [getWorkspaceFoldersFromRoots]. That recompute goes through
+   * [io.snyk.plugin.getContentRootVirtualFiles], which resolves via `DumbService.runWhenSmart` — a
+   * call that only executes synchronously when already on the EDT in smart mode; off the EDT (e.g.
+   * from a background task) it defers to a later EDT tick, so a caller reading the result
+   * immediately after would see only `project.baseDir`, not the real content roots. Passing
+   * already-resolved [roots] avoids that.
+   */
+  fun addContentRoots(project: Project, roots: Set<VirtualFile>? = null) {
     if (disposed || project.isDisposed) return
     if (!ensureLanguageServerInitialized()) {
       SnykBalloonNotificationHelper.showWarn(
@@ -1047,7 +1081,9 @@ class LanguageServerWrapper(private val project: Project) : Disposable {
     }
     ensureLanguageServerProtocolVersion(project)
     updateConfiguration(false)
-    val added = getWorkspaceFoldersFromRoots(project)
+    val added =
+      roots?.let { workspaceFoldersFrom(normalizeContentRoots(it)) }
+        ?: getWorkspaceFoldersFromRoots(project)
     updateWorkspaceFolders(added, emptySet())
   }
 

--- a/src/test/kotlin/snyk/common/lsp/LanguageServerWrapperTest.kt
+++ b/src/test/kotlin/snyk/common/lsp/LanguageServerWrapperTest.kt
@@ -15,6 +15,7 @@ import io.mockk.unmockkAll
 import io.mockk.verify
 import io.snyk.plugin.getCliFile
 import io.snyk.plugin.getContentRootVirtualFiles
+import io.snyk.plugin.getSnykTaskQueueService
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.services.SnykApplicationSettingsStateService
 import io.snyk.plugin.ui.toolwindow.SnykPluginDisposable
@@ -599,6 +600,142 @@ class LanguageServerWrapperTest {
     } finally {
       java.nio.file.Files.deleteIfExists(tempDir)
     }
+  }
+
+  @Test
+  fun `addContentRoots uses precomputed roots instead of recomputing content roots`() {
+    // getContentRootVirtualFiles() resolves via DumbService.runWhenSmart, which only runs
+    // synchronously when already on the EDT in smart mode. Called off the EDT (as addContentRoots
+    // now is, via sendScanCommand's runInBackground), it would defer to a later EDT tick and this
+    // stub would never actually be consulted for the folders sent below — so this assertion catches
+    // a regression where addContentRoots silently starts recomputing roots again instead of using
+    // the ones already resolved on the EDT by its caller.
+    simulateRunningLS()
+    justRun { lsMock.workspaceService.didChangeConfiguration(any<DidChangeConfigurationParams>()) }
+    justRun { lsMock.workspaceService.didChangeWorkspaceFolders(any()) }
+    every { getSnykTaskQueueService(projectMock) } returns null
+
+    val virtualFile = mockk<VirtualFile>()
+    every { virtualFile.path } returns "/tmp/snyk-test-precomputed-root"
+    every { virtualFile.name } returns "snyk-test-precomputed-root"
+    every { virtualFile.toNioPath() } returns Paths.get("/tmp/snyk-test-precomputed-root")
+
+    cut.addContentRoots(projectMock, setOf(virtualFile))
+
+    verify(exactly = 0) { projectMock.getContentRootVirtualFiles() }
+    verify { lsMock.workspaceService.didChangeWorkspaceFolders(any()) }
+    assertTrue(cut.configuredWorkspaceFolders.any { it.uri.contains("snyk-test-precomputed-root") })
+  }
+
+  @Test
+  fun `sendScanCommand resolves roots on the EDT and reuses them in the backgrounded addContentRoots call`() {
+    // sendScanCommand's runWhenSmart callback and the runInBackground block inside it are never
+    // actually invoked by the other sendScanCommand tests (they stub runWhenSmart as a no-op), so
+    // this is the only test that exercises the real wiring end-to-end: it proves getContentRoots()
+    // is resolved exactly once (on the "EDT" leg, before backgrounding) and that addContentRoots
+    // reuses that same result rather than recomputing it from inside the backgrounded block.
+    simulateRunningLS()
+    justRun { lsMock.workspaceService.didChangeConfiguration(any<DidChangeConfigurationParams>()) }
+    justRun { lsMock.workspaceService.didChangeWorkspaceFolders(any()) }
+    every { lsMock.workspaceService.executeCommand(any<ExecuteCommandParams>()) } returns
+      CompletableFuture.completedFuture(null)
+    every { getSnykTaskQueueService(projectMock) } returns null
+    every { dumbServiceMock.isDumb } returns false
+
+    val virtualFile = mockk<VirtualFile>()
+    every { virtualFile.path } returns "/tmp/snyk-test-scan-root"
+    every { virtualFile.name } returns "snyk-test-scan-root"
+    every { virtualFile.toNioPath() } returns Paths.get("/tmp/snyk-test-scan-root")
+    every { projectMock.getContentRootVirtualFiles() } returns setOf(virtualFile)
+
+    // The outer runWhenSmart in sendScanCommand is only ever entered when already EDT+smart, so it
+    // runs its callback synchronously in real usage — match that here.
+    every { dumbServiceMock.runWhenSmart(any()) } answers { firstArg<Runnable>().run() }
+
+    // runInBackground is `inline`, so it is NOT interceptable via mockkStatic(UtilsKt) — the real
+    // call compiles straight to ProgressManager.getInstance().run(Task.Backgroundable).
+    // ProgressManager.getInstance() caches its resolved instance in a static field on first call,
+    // bypassing ApplicationManager.getApplication() on every later call in this JVM fork — so
+    // stubbing applicationMock.getService(...) only works for whichever test happens to run first.
+    // mockkStatic on the class itself intercepts the getInstance() call directly instead, which is
+    // unaffected by that internal caching.
+    mockkStatic(com.intellij.openapi.progress.ProgressManager::class)
+    val progressManagerMock = mockk<com.intellij.openapi.progress.ProgressManager>()
+    every { com.intellij.openapi.progress.ProgressManager.getInstance() } returns
+      progressManagerMock
+    val indicatorMock = mockk<com.intellij.openapi.progress.ProgressIndicator>(relaxed = true)
+    every { progressManagerMock.run(any<com.intellij.openapi.progress.Task>()) } answers
+      {
+        (firstArg<com.intellij.openapi.progress.Task>()
+            as com.intellij.openapi.progress.Task.Backgroundable)
+          .run(indicatorMock)
+      }
+
+    cut.sendScanCommand()
+
+    // Exactly once: the EDT-side getContentRoots() call in sendScanCommand. If addContentRoots
+    // recomputed roots itself instead of reusing the ones resolved on the EDT, this would be
+    // invoked a second time.
+    verify(exactly = 1) { projectMock.getContentRootVirtualFiles() }
+    verify { lsMock.workspaceService.didChangeWorkspaceFolders(any()) }
+    assertTrue(cut.configuredWorkspaceFolders.any { it.uri.contains("snyk-test-scan-root") })
+  }
+
+  @Test
+  fun `sendScanCommand does nothing in the backgrounded block once the project is disposed`() {
+    // Backgrounding this block means the project can be disposed between the EDT-side root
+    // resolution and the background task actually running (e.g. the IDE window closing while the
+    // task is queued) — a sequence that was impossible when this all ran synchronously on the EDT.
+    simulateRunningLS()
+    every { getSnykTaskQueueService(projectMock) } returns null
+    every { dumbServiceMock.isDumb } returns false
+
+    val virtualFile = mockk<VirtualFile>()
+    every { virtualFile.path } returns "/tmp/snyk-test-disposed-root"
+    every { virtualFile.name } returns "snyk-test-disposed-root"
+    every { virtualFile.toNioPath() } returns Paths.get("/tmp/snyk-test-disposed-root")
+    every { projectMock.getContentRootVirtualFiles() } returns setOf(virtualFile)
+
+    // sendFolderScanCommand only calls executeCommand for a folder already present in
+    // configuredWorkspaceFolders, and has no disposal check of its own — so without seeding this,
+    // the executeCommand assertion below would pass vacuously (blocked by that unrelated,
+    // pre-existing membership check) regardless of whether the disposal guard under test exists.
+    cut.configuredWorkspaceFolders.add(
+      WorkspaceFolder(
+        Paths.get("/tmp/snyk-test-disposed-root").toUri().toASCIIString(),
+        "snyk-test-disposed-root",
+      )
+    )
+
+    every { dumbServiceMock.runWhenSmart(any()) } answers { firstArg<Runnable>().run() }
+
+    // ProgressManager.getInstance() caches its resolved instance in a static field, so it must be
+    // intercepted via mockkStatic rather than via applicationMock.getService(...), or this test's
+    // stub is silently ignored whenever it doesn't happen to run first in the JVM fork.
+    mockkStatic(com.intellij.openapi.progress.ProgressManager::class)
+    val progressManagerMock = mockk<com.intellij.openapi.progress.ProgressManager>()
+    every { com.intellij.openapi.progress.ProgressManager.getInstance() } returns
+      progressManagerMock
+    val indicatorMock = mockk<com.intellij.openapi.progress.ProgressIndicator>(relaxed = true)
+    every { progressManagerMock.run(any<com.intellij.openapi.progress.Task>()) } answers
+      {
+        // Simulate disposal happening after roots were resolved on the EDT but before the
+        // background task body runs.
+        every { projectMock.isDisposed } returns true
+        (firstArg<com.intellij.openapi.progress.Task>()
+            as com.intellij.openapi.progress.Task.Backgroundable)
+          .run(indicatorMock)
+      }
+
+    cut.sendScanCommand()
+
+    // The real discriminator: sendFolderScanCommand has no disposal check of its own, so with the
+    // pre-seeded folder above it would call executeCommand unconditionally unless the disposal
+    // guard under test short-circuits the whole locked block first.
+    verify(exactly = 0) { lsMock.workspaceService.executeCommand(any<ExecuteCommandParams>()) }
+    // Secondary/defense-in-depth: also covered independently by addContentRoots's own
+    // disposed-check, so this alone wouldn't catch a regression in the new guard.
+    verify(exactly = 0) { lsMock.workspaceService.didChangeWorkspaceFolders(any()) }
   }
 
   @Test


### PR DESCRIPTION
### Description

Fixes IDE-2478 — the Snyk IntelliJ plugin freezing the whole IDE for 5-10s at a time on workspaces with many content roots.

Root cause: `sendScanCommand()` ran a chain of blocking LSP calls (`addContentRoots` → `ensureLanguageServerInitialized` (untimed lock + blocking network/CLI init) → `updateWorkspaceFolders` → synchronous LSP calls) inside `DumbService.runWhenSmart{}`, which executes on the EDT.

**Fix:** wrap the update in `runInBackground`, mirroring the existing `restart()` pattern.

Two follow-on issues surfaced during review and are fixed in the same commit:
- Moving `addContentRoots` off-EDT would make its internal content-root lookup race (only resolves synchronously when called from the EDT) and silently collapse to just `project.baseDir`. Fixed by threading the already EDT-resolved roots through a new `addContentRoots(project, roots)` overload, normalized the same way the original recompute path was.
- Backgrounding removed the EDT's implicit serialization between concurrent `sendScanCommand()` calls, and its "can't run mid-project-close" safety. Fixed with a dedicated lock and a disposal guard.

Known, deliberately out-of-scope limitations (documented in code comments): `restart()` and `SnykTaskQueueService.connectProjectToLanguageServer` retain the identical pre-existing off-EDT recompute race on much rarer paths than `sendScanCommand`; `sendScanCommand`'s pre-existing `notAuthenticated()` guard can still block the EDT if invoked while the LS isn't yet initialized (e.g. via `PreCommitHookHandler`) — unchanged by this diff, needs separate investigation.

### Checklist

- [x] Read and understood the [Code of Conduct](https://github.com/snyk/snyk-intellij-plugin/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/snyk-intellij-plugin/blob/master/CONTRIBUTING.md).
- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing (not user-facing)

### Screenshots / GIFs

N/A — internal threading fix, no UI change.