### PR TITLE
fix: move sendScanCommand LSP calls off the EDT [IDE-2478]

### DIFF
--- a/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
@@ -40,6 +40,7 @@ import java.util.concurrent.TimeoutException
 import java.util.concurrent.locks.ReentrantLock
 import java.util.logging.Level
 import java.util.logging.Logger.getLogger
+import kotlin.concurrent.withLock
 import org.apache.commons.lang3.SystemUtils
 import org.eclipse.lsp4j.ClientCapabilities
 import org.eclipse.lsp4j.ClientInfo
@@ -134,6 +135,10 @@ class LanguageServerWrapper(private val project: Project) : Disposable {
   // internal for test set up
   internal val configuredWorkspaceFolders: MutableSet<WorkspaceFolder> =
     ConcurrentHashMap.newKeySet()
+  // sendScanCommand()'s backgrounded workspace-folder update (see below) reads this from a
+  // background-pool thread after dispose() may have set it from a different thread (e.g. the EDT
+  // on plugin unload), so it needs the same cross-thread visibility guarantee as isInitialized.
+  @Volatile
   private var disposed = false
     get() {
       return ApplicationManager.getApplication().isDisposed || field
@@ -159,6 +164,13 @@ class LanguageServerWrapper(private val project: Project) : Disposable {
   lateinit var process: Process
 
   var isInitializing: ReentrantLock = ReentrantLock()
+
+  // sendScanCommand() used to run entirely inside DumbService.runWhenSmart, which always executes
+  // on the single-threaded EDT, so overlapping sendScanCommand() calls (e.g. a token refresh and a
+  // user-triggered scan landing close together) were naturally serialized. Now that the
+  // workspace-folder update runs in the background (see sendScanCommand()), this lock restores
+  // that serialization.
+  private val workspaceFolderUpdateLock = ReentrantLock()
 
   // Written by initialize() / the LS-termination listener on background threads and read
   // cross-thread (e.g. the settings panel poll and the non-forcing getConfigHtml check) outside the
@@ -418,9 +430,11 @@ class LanguageServerWrapper(private val project: Project) : Disposable {
 
   fun getWorkspaceFoldersFromRoots(project: Project): Set<WorkspaceFolder> {
     if (disposed || project.isDisposed) return emptySet()
-    val normalizedRoots = getContentRoots(project)
-    return normalizedRoots.map { WorkspaceFolder(it.toLanguageServerURI(), it.name) }.toSet()
+    return workspaceFoldersFrom(getContentRoots(project))
   }
+
+  private fun workspaceFoldersFrom(roots: Set<VirtualFile>): Set<WorkspaceFolder> =
+    roots.map { WorkspaceFolder(it.toLanguageServerURI(), it.name) }.toSet()
 
   private fun getContentRoots(project: Project): MutableSet<VirtualFile> {
     val contentRoots = project.getContentRootVirtualFiles()
@@ -561,9 +575,24 @@ class LanguageServerWrapper(private val project: Project) : Disposable {
   fun sendScanCommand() {
     if (notAuthenticated()) return
     DumbService.getInstance(project).runWhenSmart {
+      // Resolve roots here, on the EDT: getContentRoots() -> getContentRootVirtualFiles() goes
+      // through DumbService.runWhenSmart itself, which only resolves synchronously when already
+      // called from the EDT in smart mode. Off the EDT it would defer to a later EDT tick, so
+      // addContentRoots() below reuses this result instead of recomputing it.
       val roots = getContentRoots(project)
-      if (roots.isNotEmpty()) addContentRoots(project)
-      roots.forEach { sendFolderScanCommand(it.path, project) }
+      // The didChangeWorkspaceFolders/executeCommand calls below can block for seconds against a
+      // slow or hung language server (see IDE-2478); run them off the EDT so a stuck LS no longer
+      // freezes the whole IDE.
+      runInBackground("Snyk: syncing workspace folders and starting scan") {
+        workspaceFolderUpdateLock.withLock {
+          // The project can be disposed between the EDT-side root resolution above and this
+          // background block running (e.g. the IDE window closing while the task is queued) — a
+          // sequence that was impossible when this all ran synchronously on the EDT.
+          if (disposed || project.isDisposed) return@withLock
+          if (roots.isNotEmpty()) addContentRoots(project, roots)
+          roots.forEach { sendFolderScanCommand(it.path, project) }
+        }
+      }
     }
   }
 
@@ -1036,7 +1065,14 @@ class LanguageServerWrapper(private val project: Project) : Disposable {
     }
   }
 
-  fun addContentRoots(project: Project) {
+  /**
+   * [roots], when provided, is used as-is instead of recomputing content roots via
+   * [getWorkspaceFoldersFromRoots]/[getContentRootVirtualFiles]. That recompute only resolves
+   * synchronously when called from the EDT in smart mode; off the EDT it defers to a later EDT
+   * tick, silently collapsing to just `project.baseDir`. Callers running off the EDT (e.g.
+   * [sendScanCommand]'s backgrounded update) must pass already-resolved, normalized roots.
+   */
+  fun addContentRoots(project: Project, roots: Set<VirtualFile>? = null) {
     if (disposed || project.isDisposed) return
     if (!ensureLanguageServerInitialized()) {
       SnykBalloonNotificationHelper.showWarn(
@@ -1047,7 +1083,7 @@ class LanguageServerWrapper(private val project: Project) : Disposable {
     }
     ensureLanguageServerProtocolVersion(project)
     updateConfiguration(false)
-    val added = getWorkspaceFoldersFromRoots(project)
+    val added = roots?.let { workspaceFoldersFrom(it) } ?: getWorkspaceFoldersFromRoots(project)
     updateWorkspaceFolders(added, emptySet())
   }
 

--- a/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
+++ b/src/main/kotlin/snyk/common/lsp/LanguageServerWrapper.kt
@@ -135,9 +135,6 @@ class LanguageServerWrapper(private val project: Project) : Disposable {
   // internal for test set up
   internal val configuredWorkspaceFolders: MutableSet<WorkspaceFolder> =
     ConcurrentHashMap.newKeySet()
-  // sendScanCommand()'s backgrounded workspace-folder update (see below) reads this from a
-  // background-pool thread after dispose() may have set it from a different thread (e.g. the EDT
-  // on plugin unload), so it needs the same cross-thread visibility guarantee as isInitialized.
   @Volatile
   private var disposed = false
     get() {
@@ -165,11 +162,6 @@ class LanguageServerWrapper(private val project: Project) : Disposable {
 
   var isInitializing: ReentrantLock = ReentrantLock()
 
-  // sendScanCommand() used to run entirely inside DumbService.runWhenSmart, which always executes
-  // on the single-threaded EDT, so overlapping sendScanCommand() calls (e.g. a token refresh and a
-  // user-triggered scan landing close together) were naturally serialized. Now that the
-  // workspace-folder update runs in the background (see sendScanCommand()), this lock restores
-  // that serialization.
   private val workspaceFolderUpdateLock = ReentrantLock()
 
   // Written by initialize() / the LS-termination listener on background threads and read
@@ -575,19 +567,9 @@ class LanguageServerWrapper(private val project: Project) : Disposable {
   fun sendScanCommand() {
     if (notAuthenticated()) return
     DumbService.getInstance(project).runWhenSmart {
-      // Resolve roots here, on the EDT: getContentRoots() -> getContentRootVirtualFiles() goes
-      // through DumbService.runWhenSmart itself, which only resolves synchronously when already
-      // called from the EDT in smart mode. Off the EDT it would defer to a later EDT tick, so
-      // addContentRoots() below reuses this result instead of recomputing it.
       val roots = getContentRoots(project)
-      // The didChangeWorkspaceFolders/executeCommand calls below can block for seconds against a
-      // slow or hung language server (see IDE-2478); run them off the EDT so a stuck LS no longer
-      // freezes the whole IDE.
       runInBackground("Snyk: syncing workspace folders and starting scan") {
         workspaceFolderUpdateLock.withLock {
-          // The project can be disposed between the EDT-side root resolution above and this
-          // background block running (e.g. the IDE window closing while the task is queued) — a
-          // sequence that was impossible when this all ran synchronously on the EDT.
           if (disposed || project.isDisposed) return@withLock
           if (roots.isNotEmpty()) addContentRoots(project, roots)
           roots.forEach { sendFolderScanCommand(it.path, project) }
@@ -1066,11 +1048,8 @@ class LanguageServerWrapper(private val project: Project) : Disposable {
   }
 
   /**
-   * [roots], when provided, is used as-is instead of recomputing content roots via
-   * [getWorkspaceFoldersFromRoots]/[getContentRootVirtualFiles]. That recompute only resolves
-   * synchronously when called from the EDT in smart mode; off the EDT it defers to a later EDT
-   * tick, silently collapsing to just `project.baseDir`. Callers running off the EDT (e.g.
-   * [sendScanCommand]'s backgrounded update) must pass already-resolved, normalized roots.
+   * Pass [roots] when calling this off the EDT: recomputing them via [getWorkspaceFoldersFromRoots]
+   * only resolves synchronously on the EDT and otherwise silently collapses to `project.baseDir`.
    */
   fun addContentRoots(project: Project, roots: Set<VirtualFile>? = null) {
     if (disposed || project.isDisposed) return

--- a/src/test/kotlin/snyk/common/lsp/LanguageServerWrapperTest.kt
+++ b/src/test/kotlin/snyk/common/lsp/LanguageServerWrapperTest.kt
@@ -238,11 +238,6 @@ class LanguageServerWrapperTest {
 
   @Test
   fun `addContentRoots reuses precomputed roots instead of recomputing content roots`() {
-    // getContentRootVirtualFiles() resolves via DumbService.runWhenSmart, which only runs
-    // synchronously when already called from the EDT in smart mode. sendScanCommand now calls
-    // addContentRoots from a background thread, so it must pass the roots it already resolved on
-    // the EDT rather than letting addContentRoots recompute them off-EDT (which would silently
-    // collapse to just project.baseDir).
     simulateRunningLS()
     justRun { lsMock.workspaceService.didChangeConfiguration(any<DidChangeConfigurationParams>()) }
     justRun { lsMock.workspaceService.didChangeWorkspaceFolders(any()) }
@@ -275,15 +270,11 @@ class LanguageServerWrapperTest {
     every { virtualFile.toNioPath() } returns Paths.get("/tmp/snyk-test-scan-root")
     every { projectMock.getContentRootVirtualFiles() } returns setOf(virtualFile)
 
-    // runWhenSmart is only ever entered when already EDT+smart, so it runs its callback
-    // synchronously in real usage — match that here.
     every { dumbServiceMock.runWhenSmart(any()) } answers { firstArg<Runnable>().run() }
     stubRunInBackgroundToRunSynchronously()
 
     cut.sendScanCommand()
 
-    // Exactly once: the EDT-side getContentRoots() call. If the backgrounded block recomputed
-    // roots itself instead of reusing what was resolved on the EDT, this would be invoked twice.
     verify(exactly = 1) { projectMock.getContentRootVirtualFiles() }
     verify { lsMock.workspaceService.didChangeWorkspaceFolders(any()) }
     verify { lsMock.workspaceService.executeCommand(any<ExecuteCommandParams>()) }
@@ -292,10 +283,6 @@ class LanguageServerWrapperTest {
 
   @Test
   fun `sendScanCommand does not update workspace folders once the project is disposed before the background task runs`() {
-    // Backgrounding sendScanCommand's workspace-folder update means the project can be disposed
-    // between the EDT-side root resolution and the background task actually running (e.g. the IDE
-    // window closing while the task is queued) — impossible when this all ran synchronously on the
-    // EDT.
     simulateRunningLS()
     every { getSnykTaskQueueService(projectMock) } returns null
 
@@ -1672,13 +1659,10 @@ class LanguageServerWrapperTest {
     every { processMock.isAlive } returns true
   }
 
-  // runInBackground is `inline`, so it can't be intercepted via mockkStatic on its containing
-  // file (the call is compiled straight into the caller) — it has to be caught one level down, at
-  // the real ProgressManager.getInstance().run(Task.Backgroundable) call it compiles to.
-  // ProgressManager.getInstance() also caches its resolved instance in a static field on first
-  // call, so it must be stubbed via mockkStatic on the class itself rather than through
-  // applicationMock.getService(...), or the stub only takes effect for whichever test happens to
-  // run first in this JVM fork.
+  // runInBackground is inline, so it must be stubbed one level down, at the
+  // ProgressManager.getInstance().run(Task.Backgroundable) call it compiles to. getInstance()
+  // caches its result in a static field, so mockkStatic(ProgressManager::class) is required here
+  // instead of the applicationMock.getService(...) pattern used elsewhere in this file.
   private fun stubRunInBackgroundToRunSynchronously(beforeRun: () -> Unit = {}) {
     mockkStatic(ProgressManager::class)
     val progressManagerMock = mockk<ProgressManager>()

--- a/src/test/kotlin/snyk/common/lsp/LanguageServerWrapperTest.kt
+++ b/src/test/kotlin/snyk/common/lsp/LanguageServerWrapperTest.kt
@@ -2,6 +2,9 @@ package snyk.common.lsp
 
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
@@ -15,6 +18,7 @@ import io.mockk.unmockkAll
 import io.mockk.verify
 import io.snyk.plugin.getCliFile
 import io.snyk.plugin.getContentRootVirtualFiles
+import io.snyk.plugin.getSnykTaskQueueService
 import io.snyk.plugin.pluginSettings
 import io.snyk.plugin.services.SnykApplicationSettingsStateService
 import io.snyk.plugin.ui.toolwindow.SnykPluginDisposable
@@ -230,6 +234,91 @@ class LanguageServerWrapperTest {
     cut.sendScanCommand()
 
     verify(exactly = 0) { dumbServiceMock.runWhenSmart(any()) }
+  }
+
+  @Test
+  fun `addContentRoots reuses precomputed roots instead of recomputing content roots`() {
+    // getContentRootVirtualFiles() resolves via DumbService.runWhenSmart, which only runs
+    // synchronously when already called from the EDT in smart mode. sendScanCommand now calls
+    // addContentRoots from a background thread, so it must pass the roots it already resolved on
+    // the EDT rather than letting addContentRoots recompute them off-EDT (which would silently
+    // collapse to just project.baseDir).
+    simulateRunningLS()
+    justRun { lsMock.workspaceService.didChangeConfiguration(any<DidChangeConfigurationParams>()) }
+    justRun { lsMock.workspaceService.didChangeWorkspaceFolders(any()) }
+    every { getSnykTaskQueueService(projectMock) } returns null
+
+    val virtualFile = mockk<VirtualFile>()
+    every { virtualFile.path } returns "/tmp/snyk-test-precomputed-root"
+    every { virtualFile.name } returns "snyk-test-precomputed-root"
+    every { virtualFile.toNioPath() } returns Paths.get("/tmp/snyk-test-precomputed-root")
+
+    cut.addContentRoots(projectMock, setOf(virtualFile))
+
+    verify(exactly = 0) { projectMock.getContentRootVirtualFiles() }
+    verify { lsMock.workspaceService.didChangeWorkspaceFolders(any()) }
+    assertTrue(cut.configuredWorkspaceFolders.any { it.uri.contains("snyk-test-precomputed-root") })
+  }
+
+  @Test
+  fun `sendScanCommand resolves roots on the EDT and runs the workspace-folder update off the EDT`() {
+    simulateRunningLS()
+    justRun { lsMock.workspaceService.didChangeConfiguration(any<DidChangeConfigurationParams>()) }
+    justRun { lsMock.workspaceService.didChangeWorkspaceFolders(any()) }
+    every { lsMock.workspaceService.executeCommand(any<ExecuteCommandParams>()) } returns
+      CompletableFuture.completedFuture(null)
+    every { getSnykTaskQueueService(projectMock) } returns null
+
+    val virtualFile = mockk<VirtualFile>()
+    every { virtualFile.path } returns "/tmp/snyk-test-scan-root"
+    every { virtualFile.name } returns "snyk-test-scan-root"
+    every { virtualFile.toNioPath() } returns Paths.get("/tmp/snyk-test-scan-root")
+    every { projectMock.getContentRootVirtualFiles() } returns setOf(virtualFile)
+
+    // runWhenSmart is only ever entered when already EDT+smart, so it runs its callback
+    // synchronously in real usage — match that here.
+    every { dumbServiceMock.runWhenSmart(any()) } answers { firstArg<Runnable>().run() }
+    stubRunInBackgroundToRunSynchronously()
+
+    cut.sendScanCommand()
+
+    // Exactly once: the EDT-side getContentRoots() call. If the backgrounded block recomputed
+    // roots itself instead of reusing what was resolved on the EDT, this would be invoked twice.
+    verify(exactly = 1) { projectMock.getContentRootVirtualFiles() }
+    verify { lsMock.workspaceService.didChangeWorkspaceFolders(any()) }
+    verify { lsMock.workspaceService.executeCommand(any<ExecuteCommandParams>()) }
+    assertTrue(cut.configuredWorkspaceFolders.any { it.uri.contains("snyk-test-scan-root") })
+  }
+
+  @Test
+  fun `sendScanCommand does not update workspace folders once the project is disposed before the background task runs`() {
+    // Backgrounding sendScanCommand's workspace-folder update means the project can be disposed
+    // between the EDT-side root resolution and the background task actually running (e.g. the IDE
+    // window closing while the task is queued) — impossible when this all ran synchronously on the
+    // EDT.
+    simulateRunningLS()
+    every { getSnykTaskQueueService(projectMock) } returns null
+
+    val virtualFile = mockk<VirtualFile>()
+    every { virtualFile.path } returns "/tmp/snyk-test-disposed-root"
+    every { virtualFile.name } returns "snyk-test-disposed-root"
+    every { virtualFile.toNioPath() } returns Paths.get("/tmp/snyk-test-disposed-root")
+    every { projectMock.getContentRootVirtualFiles() } returns setOf(virtualFile)
+
+    cut.configuredWorkspaceFolders.add(
+      WorkspaceFolder(
+        Paths.get("/tmp/snyk-test-disposed-root").toUri().toASCIIString(),
+        "snyk-test-disposed-root",
+      )
+    )
+
+    every { dumbServiceMock.runWhenSmart(any()) } answers { firstArg<Runnable>().run() }
+    stubRunInBackgroundToRunSynchronously { every { projectMock.isDisposed } returns true }
+
+    cut.sendScanCommand()
+
+    verify(exactly = 0) { lsMock.workspaceService.executeCommand(any<ExecuteCommandParams>()) }
+    verify(exactly = 0) { lsMock.workspaceService.didChangeWorkspaceFolders(any()) }
   }
 
   @Test
@@ -1581,5 +1670,24 @@ class LanguageServerWrapperTest {
     cut.process = processMock
     every { processMock.info().startInstant().isPresent } returns true
     every { processMock.isAlive } returns true
+  }
+
+  // runInBackground is `inline`, so it can't be intercepted via mockkStatic on its containing
+  // file (the call is compiled straight into the caller) — it has to be caught one level down, at
+  // the real ProgressManager.getInstance().run(Task.Backgroundable) call it compiles to.
+  // ProgressManager.getInstance() also caches its resolved instance in a static field on first
+  // call, so it must be stubbed via mockkStatic on the class itself rather than through
+  // applicationMock.getService(...), or the stub only takes effect for whichever test happens to
+  // run first in this JVM fork.
+  private fun stubRunInBackgroundToRunSynchronously(beforeRun: () -> Unit = {}) {
+    mockkStatic(ProgressManager::class)
+    val progressManagerMock = mockk<ProgressManager>()
+    every { ProgressManager.getInstance() } returns progressManagerMock
+    val indicatorMock = mockk<ProgressIndicator>(relaxed = true)
+    every { progressManagerMock.run(any<Task>()) } answers
+      {
+        beforeRun()
+        (firstArg<Task>() as Task.Backgroundable).run(indicatorMock)
+      }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Fixes [IDE-2478](https://snyksec.atlassian.net/browse/IDE-2478) — the Snyk IntelliJ plugin freezing the whole IDE for 5-10s at a time, repeatedly, on workspaces with many content roots (customer reported 24).

Root cause: `sendScanCommand()` ran entirely inside `DumbService.runWhenSmart { ... }`, which IntelliJ always executes on the EDT. The `didChangeWorkspaceFolders`/`executeCommand` calls it makes to the language server can block for seconds against a slow or hung LS — exactly what the customer's own thread-dump analysis found.

**Fix:** resolve content roots on the EDT (unchanged), then run the actual workspace-folder update and scan dispatch via `runInBackground`, mirroring the existing `restart()` pattern, so a stuck LS no longer freezes the IDE.

Two follow-on issues are addressed in the same commit, because they're needed for the background move to be correct rather than just relocating the bug:
- `addContentRoots(project)` recomputes content roots via `getContentRootVirtualFiles()`, which itself uses `DumbService.runWhenSmart` and only resolves synchronously when called from the EDT. Off the EDT it defers to a later tick, silently collapsing to just `project.baseDir`. Fixed by adding `addContentRoots(project, roots)` so `sendScanCommand` passes through the roots it already resolved on the EDT.
- Backgrounding removed the EDT's implicit serialization between overlapping `sendScanCommand()` calls and its atomicity with respect to project disposal. Fixed with a dedicated `workspaceFolderUpdateLock` and a `disposed || project.isDisposed` guard inside the backgrounded block. The existing `disposed` field is now marked `@Volatile` (matching `isInitialized`'s existing pattern) since it's read from a genuinely concurrent background thread for the first time.

**Deliberately out of scope** (kept this fix minimal — see [PR #887](https://github.com/snyk/snyk-intellij-plugin/pull/887) for a larger attempt at the same ticket with more defensive changes, e.g. root-normalization on the new overload and broader test infra): `restart()` and `SnykTaskQueueService.connectProjectToLanguageServer` still call `addContentRoots(project)` with `roots=null`, so they retain the pre-existing off-EDT recompute race — but on much rarer paths than `sendScanCommand`, which is what fires once per content root on every workspace-folder registration.

Comments in the diff are kept to the minimum that isn't recoverable by reading the surrounding code: `addContentRoots`'s KDoc documents the `roots` parameter's precondition (a public API contract), and the test helper notes a genuine mocking gotcha (inline functions + `ProgressManager` static caching).

### Checklist

- [x] Read and understood the [Code of Conduct](https://github.com/snyk/snyk-intellij-plugin/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/snyk-intellij-plugin/blob/master/CONTRIBUTING.md).
- [x] Tests added and all succeed (`./gradlew test`, 88/88 green in `LanguageServerWrapperTest`, full suite green)
- [x] Linted (`./gradlew spotlessCheck ktlintCheck`)
- [ ] README.md updated, if user-facing (not user-facing)

### Screenshots / GIFs

N/A — internal threading fix, no UI change.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1825db35-c6ec-4ac4-b2b3-5e0d1297739f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1825db35-c6ec-4ac4-b2b3-5e0d1297739f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[IDE-2478]: https://snyksec.atlassian.net/browse/IDE-2478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ