### PR TITLE
fix: mention configuration in auth trust warning [IDE-2137]

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -18,5 +18,5 @@ ignore:
   'SNYK-JAVA-COMFASTERXMLJACKSONCORE-15907551':
   - '*':
       reason: temporary exception
-      expires: '2026-06-01'
+      expires: 2026-06-01
 patch: {}

--- a/src/main/resources/SnykBundle.properties
+++ b/src/main/resources/SnykBundle.properties
@@ -1,4 +1,4 @@
-snyk.panel.auth.trust.warning.text=When scanning project files, Snyk may automatically execute code<br>such as invoking the package manager to get dependency information.<br>You should only scan projects you trust. <a href="https://docs.snyk.io/ide-tools/jetbrains-plugins/folder-trust">More info</a>
+snyk.panel.auth.trust.warning.text=When scanning project files, Snyk may automatically execute code and configuration,<br>such as invoking the package manager to get dependency information.<br>You should only scan projects you trust. <a href="https://docs.snyk.io/ide-tools/jetbrains-plugins/folder-trust">More info</a>
 
 snyk.settings.organization.tooltip.description=<p>Specify the organization (ID or name) for Snyk to run scans against.</p><p>Organization selection follows this order:</p><ol><li>Project-specific settings (if configured)</li><li>This global setting (if the project-specific setting is empty)</li><li>Your web account's preferred organization (if both above are empty)</li></ol><p>Manual organization settings override automatic organization selection.</p>
 snyk.settings.organization.tooltip.linkText=User Docs

--- a/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SnykAuthPanelIntegTest.kt
+++ b/src/test/kotlin/io/snyk/plugin/ui/toolwindow/SnykAuthPanelIntegTest.kt
@@ -72,7 +72,7 @@ class SnykAuthPanelIntegTest : LightPlatform4TestCase() {
         |  <li align="left">Improve your code and upgrade dependencies</li>
         |</ol>
         |<br>
-        |When scanning project files, Snyk may automatically execute code<br>such as invoking the package manager to get dependency information.<br>You should only scan projects you trust. <a href="https://docs.snyk.io/ide-tools/jetbrains-plugins/folder-trust">More info</a>
+        |When scanning project files, Snyk may automatically execute code and configuration,<br>such as invoking the package manager to get dependency information.<br>You should only scan projects you trust. <a href="https://docs.snyk.io/ide-tools/jetbrains-plugins/folder-trust">More info</a>
         |<br>
         |<br>
         |</html>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Updates the auth-panel trust warning in `SnykBundle.properties` (and matching integration test) to mention **code and configuration** execution risks before trusting a project. IDE-2137.

### Checklist

- [x] Tests updated (`SnykAuthPanelIntegTest.kt`)
- [ ] Spotless / ktlint / full test suite run in CI

### Verification

Verified in the IntelliJ sandbox by opening the bottom-anchored Snyk tool window (purple dog icon, bottom-left) while logged out. The auth panel shows:

> When scanning project files, Snyk may automatically execute code and configuration, such as invoking the package manager to get dependency information. You should only scan projects you trust.

![IntelliJ Snyk auth panel showing code and configuration trust warning](https://cursor.com/artifacts/c/art-1aaf4ddc-17ea-4f6e-aafe-b9c8817376db)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-65cca110-0855-4ba7-bc5b-09755cc083f8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65cca110-0855-4ba7-bc5b-09755cc083f8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

