### PR TITLE
docs: note Gradle test task caching in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ Tests use JUnit4 with IntelliJ's `BasePlatformTestCase`/testFramework fixtures a
 - Use MockK for mocking and reuse existing mocks.
 - This is not a library: delete unused files instead of deprecating them.
 - After changing `.kt`/`.java` files, run `./gradlew spotlessCheck ktlintCheck`; run the full test suite (`./gradlew test`) and check coverage (`./gradlew koverXmlReport`, target 80%+ on changed code) before committing.
+- Gradle will report `UP-TO-DATE` and exit 0 without running anything if the test task is cached, which is indistinguishable from a genuine pass. Use `./gradlew test --rerun-tasks` when you need to confirm a real, non-cached green.
 - Run Snyk SCA/Code scans against the project's absolute path before committing and after `build.gradle.kts` changes; fix real findings, don't touch test fixtures.
 - Before pushing, run `./gradlew verifyPlugin`.
 - Before each commit, check for and address feedback from the PR review bot (snyk-pr-review-bot) on any open PR.


### PR DESCRIPTION
### Description

Adds a note to AGENTS.md's Development Workflow section: `./gradlew test` can report `UP-TO-DATE` and exit 0 without running anything when the test task is cached, which looks identical to a genuine pass. Use `./gradlew test --rerun-tasks` to confirm a real, non-cached green.

This consolidates guidance that was previously documented only on a shared cross-repo Confluence setup-instructions page. It's specific to this repo's own Gradle/IntelliJ build, so it belongs here instead.

### Checklist

- [x] Read and understood the [Code of Conduct](https://github.com/snyk/snyk-intellij-plugin/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/snyk-intellij-plugin/blob/master/CONTRIBUTING.md).
- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing

N/A: docs-only change (one line in AGENTS.md), no code/tests affected.

### Screenshots / GIFs

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to AGENTS.md; no code, build, or runtime behavior affected.
> 
> **Overview**
> **Adds one workflow bullet to `AGENTS.md`** so agents and contributors know that `./gradlew test` can finish with `UP-TO-DATE` and exit 0 when Gradle’s test task is cached—same as a real green run.
> 
> The new guidance says to use **`./gradlew test --rerun-tasks`** when you need to force tests to run and confirm a non-cached pass. This moves repo-specific Gradle/IntelliJ advice from shared Confluence setup docs into the in-repo agent workflow section, next to the existing “run tests before commit” step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cee9f8284953319c9db02bd0ff8a837a05be4bd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->