### PR TITLE
chore(ci): flip Remy to PR against master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ jobs:
       - prodsec/security_scans:
           mode: auto
           open-source-agentic-fix-enabled: true
+          open-source-agentic-fix-base-branch: master
           open-source-additional-arguments: --exclude=test
           release-branch: master
           iac-scan: disabled


### PR DESCRIPTION
### Description

Adds `open-source-agentic-fix-base-branch: master` to `.circleci/config.yml`'s `prodsec/security_scans` step (prodsec-orb v1.2.32), so the agentic-fix bot targets `master` instead of whatever feature branch it happens to scan. Same fix as snyk/snyk-ls#1432, opened here as a test to see if it would actually cause a fix PR to land against `master`.

**Result: inconclusive, not a failure.** Checked the CircleCI `security-scans` job for this PR's commit (pipeline #2165, job 4261). The Open Source scan step ran, but the `Agentic fix for blocking Open Source vulnerabilities` step logged:

```
[agentic fix] Skipped: the Open Source scan found no vulnerabilities at or above high.
```

There's currently no High-or-above OSS vulnerability on this branch, so the agentic-fix path never engaged — the new `open-source-agentic-fix-base-branch` parameter was never exercised, in either direction. This isn't evidence the config change doesn't work; there was simply nothing for it to fix. (The "Configured mode=auto ... Changing to mode=gate" log line is a separate, unrelated mechanism — it governs whether the *scan itself* blocks the build on this non-release branch, not whether the agentic-fix step runs.)

To actually validate this, we'd need either a real High+ vulnerability present when the job runs, or to wait for the next scan that finds one on a branch with this config.

### Checklist

- [ ] Read and understood the [Code of Conduct](https://github.com/snyk/snyk-intellij-plugin/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/snyk-intellij-plugin/blob/master/CONTRIBUTING.md).
- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CircleCI orb parameter for where automated fix PRs are opened; no application or security logic changes.
> 
> **Overview**
> Configures the prodsec `security_scans` job so **Remy/agentic-fix** open-source remediation PRs use **`master`** as the base branch instead of the scanned feature branch.
> 
> Adds `open-source-agentic-fix-base-branch: master` alongside the existing `open-source-agentic-fix-enabled: true` setting in `.circleci/config.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0f307ebb3bcfbc0d5317524db65bea2e815aa30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->